### PR TITLE
Show warning when ad object is reused

### DIFF
--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -107,6 +107,17 @@ class AdInstanceManager {
   /// Returns null if an invalid [Ad] was passed in.
   int adIdFor(Ad ad) => _loadedAds.inverse[ad];
 
+  Set<int> _mountedWidgetAdIds = <int>{};
+
+  /// Returns true if the [adId] is already mounted in a [WidgetAd].
+  bool isWidgetAdIdMounted(int adId) => _mountedWidgetAdIds.contains(adId);
+
+  /// Indicates that [adId] is mounted in widget tree.
+  void mountWidgetAdId(int adId) => _mountedWidgetAdIds.add(adId);
+
+  /// Indicates that [adId] is unmounted from the widget tree.
+  void unmountWidgetAdId(int adId) => _mountedWidgetAdIds.add(adId);
+
   /// Starts loading the ad if not previously loaded.
   ///
   /// Loading also terminates if ad is already in the process of loading.
@@ -276,7 +287,8 @@ class AdInstanceManager {
       'MobileAds#updateRequestConfiguration',
       <dynamic, dynamic>{
         'maxAdContentRating': requestConfiguration.maxAdContentRating,
-        'tagForChildDirectedTreatment': requestConfiguration.tagForChildDirectedTreatment,
+        'tagForChildDirectedTreatment':
+            requestConfiguration.tagForChildDirectedTreatment,
         'testDeviceIds': requestConfiguration.testDeviceIds,
         'tagForUnderAgeOfConsent': requestConfiguration.tagForUnderAgeOfConsent,
       },


### PR DESCRIPTION
## Description

Currently, we don't show any warnings when an ad object is reused, or an `AdWidget` is mounted twice.  

This causes an exception in the Flutter engine as creating the same platform view twice is a violation. The platform view should be disposed always before being created again as far as the engine is concerned.

## Related Issues

Fixes https://github.com/flutter/flutterfire_temporary/issues/185
Fixes https://github.com/flutter/flutter/issues/76728

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
