### PR TITLE
Destroy ads on PlatformView.dispose

### DIFF
--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterBannerAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterBannerAd.java
@@ -99,6 +99,7 @@ class FlutterBannerAd extends FlutterAd implements PlatformView {
   public void dispose() {
     if (view != null) {
       view.destroy();
+      view = null;
     }
   }
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterNativeAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterNativeAd.java
@@ -143,6 +143,7 @@ class FlutterNativeAd extends FlutterAd implements PlatformView {
   public void dispose() {
     if (ad != null) {
       ad.destroy();
+      ad = null;
     }
   }
 

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterPublisherBannerAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterPublisherBannerAd.java
@@ -126,6 +126,10 @@ class FlutterPublisherBannerAd extends FlutterAd implements PlatformView {
 
   @Override
   public void dispose() {
+    if (view != null) {
+      view.destroy();
+      view = null;
+    }
     // Do nothing.
   }
 }


### PR DESCRIPTION
Destroy banner and native ads when `PlatformView.dispose()` is called.
This is only necessary for Android banner and native ads.