### PR TITLE
Rename step as iOS (instead of Apple)

### DIFF
--- a/.github/workflows/google_mobile_ads.yaml
+++ b/.github/workflows/google_mobile_ads.yaml
@@ -47,7 +47,7 @@ jobs:
           cd packages/google_mobile_ads/example/android
           ./gradlew test
 
-  apple:
+  iOS:
     runs-on: macos-latest
     timeout-minutes: 40
     steps:


### PR DESCRIPTION
## Description

This is to make it consistent with the Android step.
