### PR TITLE
Bug fix - Fix crash reusing banner and native ad objects on Android

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.11.0+3
 
-* Fixes a [crash](https://github.com/googleads/googleads-mobile-flutter/issues/46) when reusing Native and Banner Ad objects
+* Fixes an [Android crash](https://github.com/googleads/googleads-mobile-flutter/issues/46) when reusing Native and Banner Ad objects
 
 ## 0.11.0+2
 

--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.0+3
+
+* Fixes a [crash](https://github.com/googleads/googleads-mobile-flutter/issues/46) when reusing Native and Banner Ad objects
+
 ## 0.11.0+2
 
 * Set min Android version to `19`.

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdInstanceManager.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdInstanceManager.java
@@ -69,6 +69,13 @@ class AdInstanceManager {
   }
 
   void disposeAd(int adId) {
+    if (!ads.containsKey(adId)) {
+      return;
+    }
+    Object adObject = ads.get(adId);
+    if (adObject instanceof FlutterDestroyableAd) {
+      ((FlutterDestroyableAd) adObject).destroy();
+    }
     ads.remove(adId);
   }
 

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
@@ -17,5 +17,5 @@ package io.flutter.plugins.googlemobileads;
 /** Constants used in the plugin. */
 public class Constants {
   /** Version request agent. Should be bumped alongside plugin versions. */
-  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-0.11.0+2";
+  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-0.11.0+3";
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterBannerAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterBannerAd.java
@@ -20,7 +20,7 @@ import androidx.annotation.Nullable;
 import com.google.android.gms.ads.AdView;
 import io.flutter.plugin.platform.PlatformView;
 
-class FlutterBannerAd extends FlutterAd implements PlatformView {
+class FlutterBannerAd extends FlutterAd implements PlatformView, FlutterDestroyableAd {
   @NonNull private final AdInstanceManager manager;
   @NonNull private final String adUnitId;
   @NonNull private final FlutterAdSize size;
@@ -97,6 +97,12 @@ class FlutterBannerAd extends FlutterAd implements PlatformView {
 
   @Override
   public void dispose() {
+    // Do nothing. This is because banner ads can be displayed again after being removed from
+    // the view hierarchy. For example, if in a scrolling list view.
+  }
+
+  @Override
+  public void destroy() {
     if (view != null) {
       view.destroy();
       view = null;

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterBannerAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterBannerAd.java
@@ -97,8 +97,9 @@ class FlutterBannerAd extends FlutterAd implements PlatformView, FlutterDestroya
 
   @Override
   public void dispose() {
-    // Do nothing. This is because banner ads can be displayed again after being removed from
-    // the view hierarchy. For example, if in a scrolling list view.
+    // Do nothing. Cleanup is handled in destroy() below, which is triggered from dispose() being
+    // called on the flutter ad object. This is allows for reuse of the  ad view, for example
+    // in a scrolling list view.
   }
 
   @Override

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterDestroyableAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterDestroyableAd.java
@@ -1,0 +1,8 @@
+package io.flutter.plugins.googlemobileads;
+
+/** Interface for a destroyable ad. */
+public interface FlutterDestroyableAd {
+
+  /** Destroy any ads and free up references. */
+  void destroy();
+}

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterNativeAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterNativeAd.java
@@ -27,7 +27,7 @@ import io.flutter.plugin.platform.PlatformView;
 import io.flutter.plugins.googlemobileads.GoogleMobileAdsPlugin.NativeAdFactory;
 import java.util.Map;
 
-class FlutterNativeAd extends FlutterAd implements PlatformView {
+class FlutterNativeAd extends FlutterAd implements PlatformView, FlutterDestroyableAd {
   private static final String TAG = "FlutterNativeAd";
 
   @NonNull private final AdInstanceManager manager;
@@ -141,6 +141,12 @@ class FlutterNativeAd extends FlutterAd implements PlatformView {
 
   @Override
   public void dispose() {
+    // Do nothing. This is because banner ads can be displayed again after being removed from
+    // the view hierarchy. For example, if in a scrolling list view.
+  }
+
+  @Override
+  public void destroy() {
     if (ad != null) {
       ad.destroy();
       ad = null;

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterNativeAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterNativeAd.java
@@ -141,8 +141,9 @@ class FlutterNativeAd extends FlutterAd implements PlatformView, FlutterDestroya
 
   @Override
   public void dispose() {
-    // Do nothing. This is because banner ads can be displayed again after being removed from
-    // the view hierarchy. For example, if in a scrolling list view.
+    // Do nothing. Cleanup is handled in destroy() below, which is triggered from dispose() being
+    // called on the flutter ad object. This is allows for reuse of the ad view, for example
+    // in a scrolling list view.
   }
 
   @Override

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterPublisherBannerAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterPublisherBannerAd.java
@@ -126,8 +126,9 @@ class FlutterPublisherBannerAd extends FlutterAd implements PlatformView, Flutte
 
   @Override
   public void dispose() {
-    // Do nothing. This is because banner ads can be displayed again after being removed from
-    // the view hierarchy. For example, if in a scrolling list view.
+    // Do nothing. Cleanup is handled in destroy() below, which is triggered from dispose() being
+    // called on the flutter ad object. This is allows for reuse of the ad view, for example
+    // in a scrolling list view.
   }
 
   @Override

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterPublisherBannerAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterPublisherBannerAd.java
@@ -27,7 +27,7 @@ import java.util.List;
  * Wrapper around {@link com.google.android.gms.ads.doubleclick.PublisherAdView} for the Google
  * Mobile Ads Plugin.
  */
-class FlutterPublisherBannerAd extends FlutterAd implements PlatformView {
+class FlutterPublisherBannerAd extends FlutterAd implements PlatformView, FlutterDestroyableAd {
   @NonNull private final AdInstanceManager manager;
   @NonNull private final String adUnitId;
   @NonNull private final List<FlutterAdSize> sizes;
@@ -126,10 +126,15 @@ class FlutterPublisherBannerAd extends FlutterAd implements PlatformView {
 
   @Override
   public void dispose() {
+    // Do nothing. This is because banner ads can be displayed again after being removed from
+    // the view hierarchy. For example, if in a scrolling list view.
+  }
+
+  @Override
+  public void destroy() {
     if (view != null) {
       view.destroy();
       view = null;
     }
-    // Do nothing.
   }
 }

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
@@ -46,6 +46,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
 
 public class GoogleMobileAdsTest {
   private AdInstanceManager testManager;
@@ -229,20 +230,57 @@ public class GoogleMobileAdsTest {
   }
 
   @Test
-  public void disposeAd() {
-    final FlutterBannerAd bannerAd =
-        new FlutterBannerAd.Builder()
-            .setManager(testManager)
-            .setAdUnitId("testId")
-            .setSize(new FlutterAdSize(1, 2))
-            .setRequest(request)
-            .build();
+  public void disposeAd_banner() {
+    FlutterBannerAd bannerAd = Mockito.mock(FlutterBannerAd.class);
     testManager.trackAd(bannerAd, 2);
     assertNotNull(testManager.adForId(2));
     assertNotNull(testManager.adIdFor(bannerAd));
     testManager.disposeAd(2);
+    verify(bannerAd).destroy();
     assertNull(testManager.adForId(2));
     assertNull(testManager.adIdFor(bannerAd));
+
+    FlutterPublisherBannerAd publisherBannerAd = Mockito.mock(FlutterPublisherBannerAd.class);
+    testManager.trackAd(publisherBannerAd, 2);
+    assertNotNull(testManager.adForId(2));
+    assertNotNull(testManager.adIdFor(publisherBannerAd));
+    testManager.disposeAd(2);
+    verify(publisherBannerAd).destroy();
+    assertNull(testManager.adForId(2));
+    assertNull(testManager.adIdFor(publisherBannerAd));
+
+    FlutterNativeAd flutterNativeAd = Mockito.mock(FlutterNativeAd.class);
+    testManager.trackAd(flutterNativeAd, 2);
+    assertNotNull(testManager.adForId(2));
+    assertNotNull(testManager.adIdFor(flutterNativeAd));
+    testManager.disposeAd(2);
+    verify(flutterNativeAd).destroy();
+    assertNull(testManager.adForId(2));
+    assertNull(testManager.adIdFor(flutterNativeAd));
+  }
+
+  @Test
+  public void disposeAd_publisherBanner() {
+    FlutterPublisherBannerAd publisherBannerAd = Mockito.mock(FlutterPublisherBannerAd.class);
+    testManager.trackAd(publisherBannerAd, 2);
+    assertNotNull(testManager.adForId(2));
+    assertNotNull(testManager.adIdFor(publisherBannerAd));
+    testManager.disposeAd(2);
+    verify(publisherBannerAd).destroy();
+    assertNull(testManager.adForId(2));
+    assertNull(testManager.adIdFor(publisherBannerAd));
+  }
+
+  @Test
+  public void disposeAd_native() {
+    FlutterNativeAd flutterNativeAd = Mockito.mock(FlutterNativeAd.class);
+    testManager.trackAd(flutterNativeAd, 2);
+    assertNotNull(testManager.adForId(2));
+    assertNotNull(testManager.adIdFor(flutterNativeAd));
+    testManager.disposeAd(2);
+    verify(flutterNativeAd).destroy();
+    assertNull(testManager.adForId(2));
+    assertNull(testManager.adIdFor(flutterNativeAd));
   }
 
   @Test

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
@@ -239,24 +239,6 @@ public class GoogleMobileAdsTest {
     verify(bannerAd).destroy();
     assertNull(testManager.adForId(2));
     assertNull(testManager.adIdFor(bannerAd));
-
-    FlutterPublisherBannerAd publisherBannerAd = Mockito.mock(FlutterPublisherBannerAd.class);
-    testManager.trackAd(publisherBannerAd, 2);
-    assertNotNull(testManager.adForId(2));
-    assertNotNull(testManager.adIdFor(publisherBannerAd));
-    testManager.disposeAd(2);
-    verify(publisherBannerAd).destroy();
-    assertNull(testManager.adForId(2));
-    assertNull(testManager.adIdFor(publisherBannerAd));
-
-    FlutterNativeAd flutterNativeAd = Mockito.mock(FlutterNativeAd.class);
-    testManager.trackAd(flutterNativeAd, 2);
-    assertNotNull(testManager.adForId(2));
-    assertNotNull(testManager.adIdFor(flutterNativeAd));
-    testManager.disposeAd(2);
-    verify(flutterNativeAd).destroy();
-    assertNull(testManager.adForId(2));
-    assertNull(testManager.adIdFor(flutterNativeAd));
   }
 
   @Test

--- a/packages/google_mobile_ads/example/lib/constants.dart
+++ b/packages/google_mobile_ads/example/lib/constants.dart
@@ -1,0 +1,25 @@
+/// Constants used in the example app.
+class Constants {
+  /// List of strings that can be used as filler text.
+  static const List<String> article = <String>[
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod'
+        ' tempor incididunt ut labore et dolore magna aliqua. Faucibus purus in'
+        ' massa tempor. Quis enim lobortis scelerisque fermentum dui faucibus'
+        ' in. Nibh praesent tristique magna sit amet purus gravida quis.'
+        ' Magna sit amet purus gravida quis blandit turpis cursus in. Sed'
+        ' adipiscing diam donec adipiscing tristique. Urna porttitor rhoncus'
+        ' dolor purus non enim praesent. Pellentesque habitant morbi tristique'
+        ' senectus et netus. Risus ultricies tristique nulla aliquet enim tortor'
+        ' at.',
+    'Eget dolor morbi non arcu. Nec sagittis aliquam malesuada bibendum. Nec'
+        ' feugiat nisl pretium fusce id velit ut. Volutpat commodo sed egestas'
+        ' egestas. Ultrices neque ornare aenean euismod elementum. Consequat'
+        ' semper viverra nam libero justo laoreet sit amet cursus. Fusce ut'
+        ' placerat orci nulla pellentesque dignissim. Justo donec enim diam'
+        ' vulputate ut pharetra sit amet.',
+    'Et malesuada fames ac turpis egestas maecenas. Augue ut lectus arcu'
+        ' bibendum at varius. Mauris rhoncus aenean vel elit scelerisque mauris'
+        ' pellentesque pulvinar. Faucibus a pellentesque sit amet porttitor'
+        ' eget dolor.'
+  ];
+}

--- a/packages/google_mobile_ads/example/lib/constants.dart
+++ b/packages/google_mobile_ads/example/lib/constants.dart
@@ -1,25 +1,14 @@
 /// Constants used in the example app.
 class Constants {
-  /// List of strings that can be used as filler text.
-  static const List<String> article = <String>[
-    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod'
-        ' tempor incididunt ut labore et dolore magna aliqua. Faucibus purus in'
-        ' massa tempor. Quis enim lobortis scelerisque fermentum dui faucibus'
-        ' in. Nibh praesent tristique magna sit amet purus gravida quis.'
-        ' Magna sit amet purus gravida quis blandit turpis cursus in. Sed'
-        ' adipiscing diam donec adipiscing tristique. Urna porttitor rhoncus'
-        ' dolor purus non enim praesent. Pellentesque habitant morbi tristique'
-        ' senectus et netus. Risus ultricies tristique nulla aliquet enim tortor'
-        ' at.',
-    'Eget dolor morbi non arcu. Nec sagittis aliquam malesuada bibendum. Nec'
-        ' feugiat nisl pretium fusce id velit ut. Volutpat commodo sed egestas'
-        ' egestas. Ultrices neque ornare aenean euismod elementum. Consequat'
-        ' semper viverra nam libero justo laoreet sit amet cursus. Fusce ut'
-        ' placerat orci nulla pellentesque dignissim. Justo donec enim diam'
-        ' vulputate ut pharetra sit amet.',
-    'Et malesuada fames ac turpis egestas maecenas. Augue ut lectus arcu'
-        ' bibendum at varius. Mauris rhoncus aenean vel elit scelerisque mauris'
-        ' pellentesque pulvinar. Faucibus a pellentesque sit amet porttitor'
-        ' eget dolor.'
-  ];
+  /// Placeholder text.
+  static const String placeholderText =
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod'
+      ' tempor incididunt ut labore et dolore magna aliqua. Faucibus purus in'
+      ' massa tempor. Quis enim lobortis scelerisque fermentum dui faucibus'
+      ' in. Nibh praesent tristique magna sit amet purus gravida quis.'
+      ' Magna sit amet purus gravida quis blandit turpis cursus in. Sed'
+      ' adipiscing diam donec adipiscing tristique. Urna porttitor rhoncus'
+      ' dolor purus non enim praesent. Pellentesque habitant morbi tristique'
+      ' senectus et netus. Risus ultricies tristique nulla aliquet enim tortor'
+      ' at.';
 }

--- a/packages/google_mobile_ads/example/lib/main.dart
+++ b/packages/google_mobile_ads/example/lib/main.dart
@@ -18,10 +18,9 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
-import 'package:google_mobile_ads_example/reusable_banner_example.dart';
 
 import 'constants.dart';
-import 'reusable_banner_example.dart';
+import 'reusable_inline_example.dart';
 
 // You can also test with your own ad unit IDs by registering your device as a
 // test device. Check the logs for your device's ID value.
@@ -150,11 +149,11 @@ class _MyAppState extends State<MyApp> {
                       _rewardedReady = false;
                       _rewardedAd = null;
                       break;
-                    case 'ReusableBannerExample':
+                    case 'ReusableInlineExample':
                       Navigator.push(
                         context,
                         MaterialPageRoute(
-                            builder: (context) => ReusableBannerExample()),
+                            builder: (context) => ReusableInlineExample()),
                       );
                       break;
                     default:
@@ -171,8 +170,8 @@ class _MyAppState extends State<MyApp> {
                     value: '$RewardedAd',
                   ),
                   PopupMenuItem<String>(
-                    child: Text('Reusable Banner Example'),
-                    value: 'ReusableBannerExample',
+                    child: Text('Reusable Inline Ads Object Example'),
+                    value: 'ReusableInlineExample',
                   ),
                 ],
               ),

--- a/packages/google_mobile_ads/example/lib/main.dart
+++ b/packages/google_mobile_ads/example/lib/main.dart
@@ -18,6 +18,10 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
+import 'package:google_mobile_ads_example/reusable_banner_example.dart';
+
+import 'constants.dart';
+import 'reusable_banner_example.dart';
 
 // You can also test with your own ad unit IDs by registering your device as a
 // test device. Check the logs for your device's ID value.
@@ -35,28 +39,6 @@ class _MyAppState extends State<MyApp> {
     contentUrl: 'http://foo.com/bar.html',
     nonPersonalizedAds: true,
   );
-
-  final List<String> _article = <String>[
-    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod'
-        ' tempor incididunt ut labore et dolore magna aliqua. Faucibus purus in'
-        ' massa tempor. Quis enim lobortis scelerisque fermentum dui faucibus'
-        ' in. Nibh praesent tristique magna sit amet purus gravida quis.'
-        ' Magna sit amet purus gravida quis blandit turpis cursus in. Sed'
-        ' adipiscing diam donec adipiscing tristique. Urna porttitor rhoncus'
-        ' dolor purus non enim praesent. Pellentesque habitant morbi tristique'
-        ' senectus et netus. Risus ultricies tristique nulla aliquet enim tortor'
-        ' at.',
-    'Eget dolor morbi non arcu. Nec sagittis aliquam malesuada bibendum. Nec'
-        ' feugiat nisl pretium fusce id velit ut. Volutpat commodo sed egestas'
-        ' egestas. Ultrices neque ornare aenean euismod elementum. Consequat'
-        ' semper viverra nam libero justo laoreet sit amet cursus. Fusce ut'
-        ' placerat orci nulla pellentesque dignissim. Justo donec enim diam'
-        ' vulputate ut pharetra sit amet.',
-    'Et malesuada fames ac turpis egestas maecenas. Augue ut lectus arcu'
-        ' bibendum at varius. Mauris rhoncus aenean vel elit scelerisque mauris'
-        ' pellentesque pulvinar. Faucibus a pellentesque sit amet porttitor'
-        ' eget dolor.'
-  ];
 
   InterstitialAd _interstitialAd;
   bool _interstitialReady = false;
@@ -148,69 +130,84 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      home: Scaffold(
-        appBar: AppBar(
-          title: const Text('AdMob Plugin example app'),
-          actions: <Widget>[
-            PopupMenuButton<String>(
-              onSelected: (String result) {
-                assert(result == 'InterstitialAd' || result == 'RewardedAd');
-                switch (result) {
-                  case 'InterstitialAd':
-                    if (!_interstitialReady) return;
-                    _interstitialAd.show();
-                    _interstitialReady = false;
-                    _interstitialAd = null;
-                    break;
-                  case 'RewardedAd':
-                    if (!_rewardedReady) return;
-                    _rewardedAd.show();
-                    _rewardedReady = false;
-                    _rewardedAd = null;
-                }
-              },
-              itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
-                PopupMenuItem<String>(
-                  child: Text('$InterstitialAd'),
-                  value: '$InterstitialAd',
-                ),
-                PopupMenuItem<String>(
-                  child: Text('$RewardedAd'),
-                  value: '$RewardedAd',
-                ),
-              ],
-            ),
-          ],
-        ),
-        body: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16.0),
-          child: ListView.separated(
-            cacheExtent: 500,
-            itemCount: 100,
-            separatorBuilder: (BuildContext context, int index) {
-              return Container(
-                height: 40,
-              );
-            },
-            itemBuilder: (BuildContext context, int index) {
-              if (index % 2 == 0) {
-                return Text(
-                  _article[(index / 2).ceil() % 3],
-                  style: TextStyle(fontSize: 24),
+      home: Builder(
+        builder: (context) => Scaffold(
+          appBar: AppBar(
+            title: const Text('AdMob Plugin example app'),
+            actions: <Widget>[
+              PopupMenuButton<String>(
+                onSelected: (String result) {
+                  switch (result) {
+                    case 'InterstitialAd':
+                      if (!_interstitialReady) return;
+                      _interstitialAd.show();
+                      _interstitialReady = false;
+                      _interstitialAd = null;
+                      break;
+                    case 'RewardedAd':
+                      if (!_rewardedReady) return;
+                      _rewardedAd.show();
+                      _rewardedReady = false;
+                      _rewardedAd = null;
+                      break;
+                    case 'ReusableBannerExample':
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                            builder: (context) => ReusableBannerExample()),
+                      );
+                      break;
+                    default:
+                      throw AssertionError('unexpected button: ${result}');
+                  }
+                },
+                itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
+                  PopupMenuItem<String>(
+                    child: Text('$InterstitialAd'),
+                    value: '$InterstitialAd',
+                  ),
+                  PopupMenuItem<String>(
+                    child: Text('$RewardedAd'),
+                    value: '$RewardedAd',
+                  ),
+                  PopupMenuItem<String>(
+                    child: Text('Reusable Banner Example'),
+                    value: 'ReusableBannerExample',
+                  ),
+                ],
+              ),
+            ],
+          ),
+          body: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16.0),
+            child: ListView.separated(
+              cacheExtent: 500,
+              itemCount: 100,
+              separatorBuilder: (BuildContext context, int index) {
+                return Container(
+                  height: 40,
                 );
-              }
+              },
+              itemBuilder: (BuildContext context, int index) {
+                if (index % 2 == 0) {
+                  return Text(
+                    Constants.article[(index / 2).ceil() % 3],
+                    style: TextStyle(fontSize: 24),
+                  );
+                }
 
-              final int adIndex = (index / 2).floor();
-              Widget adWidget;
-              if (adIndex % 3 == 0) {
-                adWidget = BannerAdWidget(AdSize.banner);
-              } else if (adIndex % 3 == 1) {
-                adWidget = PublisherBannerAdWidget(AdSize.largeBanner);
-              } else {
-                adWidget = NativeAdWidget();
-              }
-              return Center(child: adWidget);
-            },
+                final int adIndex = (index / 2).floor();
+                Widget adWidget;
+                if (adIndex % 3 == 0) {
+                  adWidget = BannerAdWidget(AdSize.banner);
+                } else if (adIndex % 3 == 1) {
+                  adWidget = PublisherBannerAdWidget(AdSize.largeBanner);
+                } else {
+                  adWidget = NativeAdWidget();
+                }
+                return Center(child: adWidget);
+              },
+            ),
           ),
         ),
       ),

--- a/packages/google_mobile_ads/example/lib/main.dart
+++ b/packages/google_mobile_ads/example/lib/main.dart
@@ -190,7 +190,7 @@ class _MyAppState extends State<MyApp> {
               itemBuilder: (BuildContext context, int index) {
                 if (index % 2 == 0) {
                   return Text(
-                    Constants.article[(index / 2).ceil() % 3],
+                    Constants.placeholderText,
                     style: TextStyle(fontSize: 24),
                   );
                 }

--- a/packages/google_mobile_ads/example/lib/reusable_banner_example.dart
+++ b/packages/google_mobile_ads/example/lib/reusable_banner_example.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:google_mobile_ads/google_mobile_ads.dart';
+import 'constants.dart';
+import 'dart:io' show Platform;
+
+/// This example displays a banner ad in a list view where the banner ad
+/// is reused.
+class ReusableBannerExample extends StatefulWidget {
+  @override
+  _ReusableBannerExampleState createState() => _ReusableBannerExampleState();
+}
+
+class _ReusableBannerExampleState extends State<ReusableBannerExample> {
+  BannerAd _bannerAd;
+  bool _bannerAdIsLoaded = false;
+
+  PublisherBannerAd _publisherBannerAd;
+  bool _publisherBannerAdIsLoaded = false;
+
+  NativeAd _nativeAd;
+  bool _nativeAdIsLoaded = false;
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+        appBar: AppBar(
+          title: Text('Reusable Banner Ad Example'),
+        ),
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16.0),
+            child: ListView.separated(
+              cacheExtent: 500,
+              itemCount: 20,
+              separatorBuilder: (BuildContext context, int index) {
+                return Container(
+                  height: 40,
+                );
+              },
+              itemBuilder: (BuildContext context, int index) {
+                if (index == 5 && _bannerAdIsLoaded && _bannerAd != null) {
+                  return Container(
+                      height: _bannerAd.size.height.toDouble(),
+                      width: _bannerAd.size.width.toDouble(),
+                      child: AdWidget(ad: _bannerAd));
+                }
+                if (index == 10 &&
+                    _publisherBannerAdIsLoaded &&
+                    _publisherBannerAd != null) {
+                  return Container(
+                      height: _publisherBannerAd.sizes[0].height.toDouble(),
+                      width: _publisherBannerAd.sizes[0].width.toDouble(),
+                      child: AdWidget(ad: _publisherBannerAd));
+                }
+                if (index == 15 && _nativeAdIsLoaded && _nativeAd != null) {
+                  return Container(
+                      width: 250, height: 350, child: AdWidget(ad: _nativeAd));
+                }
+
+                return Text(
+                  Constants.article[(index / 2).ceil() % 3],
+                  style: TextStyle(fontSize: 24),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _bannerAd = BannerAd(
+        size: AdSize.banner,
+        adUnitId: Platform.isAndroid
+            ? 'ca-app-pub-3940256099942544/6300978111'
+            : 'ca-app-pub-3940256099942544/2934735716',
+        listener: AdListener(
+          onAdLoaded: (Ad ad) {
+            print('$BannerAd loaded.');
+            setState(() {
+              this._bannerAdIsLoaded = true;
+            });
+          },
+          onAdFailedToLoad: (Ad ad, LoadAdError error) {
+            print('$BannerAd failedToLoad: $error');
+          },
+          onAdOpened: (Ad ad) => print('$BannerAd onAdOpened.'),
+          onAdClosed: (Ad ad) => print('$BannerAd onAdClosed.'),
+          onApplicationExit: (Ad ad) => print('$BannerAd onApplicationExit.'),
+        ),
+        request: AdRequest())
+      ..load();
+
+    _nativeAd = NativeAd(
+      adUnitId: Platform.isAndroid
+          ? 'ca-app-pub-3940256099942544/2247696110'
+          : 'ca-app-pub-3940256099942544/3986624511',
+      request: AdRequest(),
+      factoryId: 'adFactoryExample',
+      listener: AdListener(
+        onAdLoaded: (Ad ad) {
+          print('$NativeAd loaded.');
+          setState(() {
+            this._nativeAdIsLoaded = true;
+          });
+        },
+        onAdFailedToLoad: (Ad ad, LoadAdError error) {
+          print('$NativeAd failedToLoad: $error');
+        },
+        onAdOpened: (Ad ad) => print('$NativeAd onAdOpened.'),
+        onAdClosed: (Ad ad) => print('$NativeAd onAdClosed.'),
+        onApplicationExit: (Ad ad) => print('$NativeAd onApplicationExit.'),
+      ),
+    )..load();
+
+    _publisherBannerAd = PublisherBannerAd(
+      adUnitId: '/6499/example/banner',
+      request: PublisherAdRequest(nonPersonalizedAds: true),
+      sizes: [AdSize.largeBanner],
+      listener: AdListener(
+        onAdLoaded: (Ad ad) {
+          print('$PublisherBannerAd loaded.');
+          setState(() {
+            this._publisherBannerAdIsLoaded = true;
+          });
+        },
+        onAdFailedToLoad: (Ad ad, LoadAdError error) {
+          print('$PublisherBannerAd failedToLoad: $error');
+        },
+        onAdOpened: (Ad ad) => print('$PublisherBannerAd onAdOpened.'),
+        onAdClosed: (Ad ad) => print('$PublisherBannerAd onAdClosed.'),
+        onApplicationExit: (Ad ad) =>
+            print('$PublisherBannerAd onApplicationExit.'),
+      ),
+    )..load();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _bannerAd?.dispose();
+    _bannerAd = null;
+    _publisherBannerAd?.dispose();
+    _publisherBannerAd = null;
+    _nativeAd?.dispose();
+    _nativeAd = null;
+  }
+}

--- a/packages/google_mobile_ads/example/lib/reusable_inline_example.dart
+++ b/packages/google_mobile_ads/example/lib/reusable_inline_example.dart
@@ -59,7 +59,7 @@ class _ReusableInlineExampleState extends State<ReusableInlineExample> {
                 }
 
                 return Text(
-                  Constants.article[(index / 2).ceil() % 3],
+                  Constants.placeholderText,
                   style: TextStyle(fontSize: 24),
                 );
               },

--- a/packages/google_mobile_ads/example/lib/reusable_inline_example.dart
+++ b/packages/google_mobile_ads/example/lib/reusable_inline_example.dart
@@ -3,14 +3,16 @@ import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'constants.dart';
 import 'dart:io' show Platform;
 
-/// This example displays a banner ad in a list view where the banner ad
-/// is reused.
-class ReusableBannerExample extends StatefulWidget {
+/// This example demonstrates inline ads in a list view, where the ad objects
+/// live for the lifetime of this widget. This differs from the example in
+/// [main.dart], which creates a new ad object whenever an ad is to be displayed
+/// in the ListView.
+class ReusableInlineExample extends StatefulWidget {
   @override
-  _ReusableBannerExampleState createState() => _ReusableBannerExampleState();
+  _ReusableInlineExampleState createState() => _ReusableInlineExampleState();
 }
 
-class _ReusableBannerExampleState extends State<ReusableBannerExample> {
+class _ReusableInlineExampleState extends State<ReusableInlineExample> {
   BannerAd _bannerAd;
   bool _bannerAdIsLoaded = false;
 
@@ -23,7 +25,7 @@ class _ReusableBannerExampleState extends State<ReusableBannerExample> {
   @override
   Widget build(BuildContext context) => Scaffold(
         appBar: AppBar(
-          title: Text('Reusable Banner Ad Example'),
+          title: Text('Reusable Inline Ad Example'),
         ),
         body: Center(
           child: Padding(
@@ -69,6 +71,7 @@ class _ReusableBannerExampleState extends State<ReusableBannerExample> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    // Create the ad objects and load ads.
     _bannerAd = BannerAd(
         size: AdSize.banner,
         adUnitId: Platform.isAndroid

--- a/packages/google_mobile_ads/ios/Classes/FLTConstants.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTConstants.h
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /** Versioned request agent string. */
-#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-0.11.0+2"
+#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-0.11.0+3"

--- a/packages/google_mobile_ads/pubspec.yaml
+++ b/packages/google_mobile_ads/pubspec.yaml
@@ -16,7 +16,7 @@ name: google_mobile_ads
 description: Flutter plugin for Google Mobile Ads, supporting
   banner, interstitial (full-screen),  rewarded and native ads
 homepage: https://github.com/googleads/googleads-mobile-flutter/tree/master/packages/google_mobile_ads
-version: 0.11.0+2
+version: 0.11.0+3
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

This changes Android banner and native ads so that destruction of the ad view occurs when `dispose()` is invoked on the corresponding Flutter ad object (e.g.`FlutterBannerAd.dispose()`.

Also adds a new page to the example app that demonstrates this behavior. 

This lets you reuse banner and native ad objects, so the same ad view can be shown again after it's been removed from the view hierarchy. This can happen if the ad is in a list view and you want to show the same ad if you scroll past an ad and then back up to it.

## Related Issues

https://github.com/googleads/googleads-mobile-flutter/issues/46
https://github.com/googleads/googleads-mobile-flutter/issues/36
