### PR TITLE
Bug fix - Ios memory leaks

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.11.0+3
 
-* Fixes an [Android crash](https://github.com/googleads/googleads-mobile-flutter/issues/46) when reusing Native and Banner Ad objects
+* Fixes an [Android crash](https://github.com/googleads/googleads-mobile-flutter/issues/46) when reusing Native and Banner Ad objects.
+* Fixes [iOS memory leaks](https://github.com/googleads/googleads-mobile-flutter/issues/69).
 
 ## 0.11.0+2
 

--- a/packages/google_mobile_ads/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/google_mobile_ads/example/ios/Runner.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		9EA7213725BB6517008D57E3 /* GoogleMobileAds.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EA7213525BB6464008D57E3 /* GoogleMobileAds.xcframework */; };
 		9EA7213825BB6530008D57E3 /* GoogleMobileAds.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EA7213525BB6464008D57E3 /* GoogleMobileAds.xcframework */; };
+		9EF1F00025F8351A0017A440 /* FLTGoogleMobileAdsPluginMethodCallsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF1EFFF25F8351A0017A440 /* FLTGoogleMobileAdsPluginMethodCallsTest.m */; };
 		FBE669D215209F1F44CEEB21 /* libPods-Runner.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F369F228D3A43519CEE308 /* libPods-Runner.a */; };
 /* End PBXBuildFile section */
 
@@ -72,6 +73,7 @@
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9EA7213525BB6464008D57E3 /* GoogleMobileAds.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GoogleMobileAds.xcframework; path = "Pods/Google-Mobile-Ads-SDK/Frameworks/GoogleMobileAdsFramework-Current/GoogleMobileAds.xcframework"; sourceTree = "<group>"; };
+		9EF1EFFF25F8351A0017A440 /* FLTGoogleMobileAdsPluginMethodCallsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FLTGoogleMobileAdsPluginMethodCallsTest.m; path = ../../../ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m; sourceTree = "<group>"; };
 		CE82265EF05E2A9632B25E60 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		F1C099CEFFFD5550FC343D00 /* libPods-google_mobile_ads_exampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-google_mobile_ads_exampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F74051031B69F8124E38352E /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
@@ -123,6 +125,7 @@
 		8FB13CD3248F07B80011A72F /* google_mobile_ads_exampleTests */ = {
 			isa = PBXGroup;
 			children = (
+				9EF1EFFF25F8351A0017A440 /* FLTGoogleMobileAdsPluginMethodCallsTest.m */,
 				8FB13CE12498136E0011A72F /* FLTGoogleMobileAdsReaderWriterTest.m */,
 				8FB13CDC248F07D90011A72F /* FLTGoogleMobileAdsTest.m */,
 				8FB13CD6248F07B80011A72F /* Info.plist */,
@@ -391,6 +394,7 @@
 			files = (
 				8FB13CDD248F07D90011A72F /* FLTGoogleMobileAdsTest.m in Sources */,
 				8FB13CE22498136E0011A72F /* FLTGoogleMobileAdsReaderWriterTest.m in Sources */,
+				9EF1F00025F8351A0017A440 /* FLTGoogleMobileAdsPluginMethodCallsTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.h
@@ -28,7 +28,7 @@
 - (id<FLTAd> _Nullable)adFor:(NSNumber *_Nonnull)adId;
 - (NSNumber *_Nullable)adIdFor:(id<FLTAd> _Nonnull)ad;
 - (void)loadAd:(id<FLTAd> _Nonnull)ad adId:(NSNumber *_Nonnull)adId;
-- (void)dispose:(id<FLTAd> _Nonnull)ad;
+- (void)dispose:(NSNumber *_Nonnull)adId;
 - (void)showAdWithID:(NSNumber *_Nonnull)adId;
 - (void)onAdLoaded:(id<FLTAd> _Nonnull)ad;
 - (void)onAdFailedToLoad:(id<FLTAd> _Nonnull)ad error:(FLTLoadAdError *_Nonnull)error;

--- a/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.m
@@ -58,8 +58,8 @@
   [ad load];
 }
 
-- (void)dispose:(id<FLTAd> _Nonnull)ad {
-  [_ads removeObjectForKey:[self adIdFor:ad]];
+- (void)dispose:(NSNumber *_Nonnull)adId {
+  [_ads removeObjectForKey:adId];
 }
 
 - (void)showAdWithID:(NSNumber *_Nonnull)adId {

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
@@ -1,0 +1,52 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+#import "../Classes/FLTAdInstanceManager_Internal.h"
+#import "../Classes/FLTGoogleMobileAdsPlugin.h"
+
+@interface FLTGoogleMobileAdsPluginMethodCallsTest : XCTestCase
+@end
+
+@implementation FLTGoogleMobileAdsPluginMethodCallsTest {
+  FLTGoogleMobileAdsPlugin *_fltGoogleMobileAdsPlugin;
+  NSObject<FlutterBinaryMessenger> *_mockMessenger;
+  FLTAdInstanceManager *_mockAdInstanceMessenger;
+}
+
+- (void)setUp {
+  _mockAdInstanceMessenger = OCMClassMock([FLTAdInstanceManager class]);
+  _fltGoogleMobileAdsPlugin = [[FLTGoogleMobileAdsPlugin alloc] init];
+  [_fltGoogleMobileAdsPlugin setValue:_mockAdInstanceMessenger forKey:@"_manager"];
+}
+
+- (void)testEncodeDecodeAdSize {
+  FlutterMethodCall *methodCall = [FlutterMethodCall methodCallWithMethodName:@"disposeAd"
+                                                                    arguments:@{@"adId" : @1}];
+  __block bool resultInvoked = false;
+  __block id _Nullable returnedResult;
+  FlutterResult result = ^(id _Nullable result) {
+    resultInvoked = true;
+    returnedResult = result;
+  };
+
+  [_fltGoogleMobileAdsPlugin handleMethodCall:methodCall result:result];
+
+  XCTAssertTrue(resultInvoked);
+  XCTAssertNil(returnedResult);
+  OCMVerify([_mockAdInstanceMessenger dispose:@1]);
+}
+@end

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
@@ -23,14 +23,13 @@
 
 @implementation FLTGoogleMobileAdsPluginMethodCallsTest {
   FLTGoogleMobileAdsPlugin *_fltGoogleMobileAdsPlugin;
-  NSObject<FlutterBinaryMessenger> *_mockMessenger;
-  FLTAdInstanceManager *_mockAdInstanceMessenger;
+  FLTAdInstanceManager *_mockAdInstanceManager;
 }
 
 - (void)setUp {
-  _mockAdInstanceMessenger = OCMClassMock([FLTAdInstanceManager class]);
+  _mockAdInstanceManager = OCMClassMock([FLTAdInstanceManager class]);
   _fltGoogleMobileAdsPlugin = [[FLTGoogleMobileAdsPlugin alloc] init];
-  [_fltGoogleMobileAdsPlugin setValue:_mockAdInstanceMessenger forKey:@"_manager"];
+  [_fltGoogleMobileAdsPlugin setValue:_mockAdInstanceManager forKey:@"_manager"];
 }
 
 - (void)testDisposeAd {
@@ -47,6 +46,6 @@
 
   XCTAssertTrue(resultInvoked);
   XCTAssertNil(returnedResult);
-  OCMVerify([_mockAdInstanceMessenger dispose:@1]);
+  OCMVerify([_mockAdInstanceManager dispose:@1]);
 }
 @end

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
@@ -33,7 +33,7 @@
   [_fltGoogleMobileAdsPlugin setValue:_mockAdInstanceMessenger forKey:@"_manager"];
 }
 
-- (void)testEncodeDecodeAdSize {
+- (void)testDisposeAd {
   FlutterMethodCall *methodCall = [FlutterMethodCall methodCallWithMethodName:@"disposeAd"
                                                                     arguments:@{@"adId" : @1}];
   __block bool resultInvoked = false;

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsTest.m
@@ -260,7 +260,7 @@
   OCMStub([mockBannerAd load]);
 
   [_manager loadAd:bannerAd adId:@(1)];
-  [_manager dispose:bannerAd];
+  [_manager dispose:@(1)];
 
   XCTAssertNil([_manager adFor:@(1)]);
   XCTAssertNil([_manager adIdFor:bannerAd]);


### PR DESCRIPTION
## Description

Fixes a bug in iOS that caused the native objects to get retained for all disposed ads.

## Related Issues
https://github.com/googleads/googleads-mobile-flutter/issues/69
