### PR TITLE
Fix bug with disposing on iOS

### DIFF
--- a/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.h
@@ -28,7 +28,7 @@
 - (id<FLTAd> _Nullable)adFor:(NSNumber *_Nonnull)adId;
 - (NSNumber *_Nullable)adIdFor:(id<FLTAd> _Nonnull)ad;
 - (void)loadAd:(id<FLTAd> _Nonnull)ad adId:(NSNumber *_Nonnull)adId;
-- (void)dispose:(id<FLTAd> _Nonnull)ad;
+- (void)dispose:(NSNumber *_Nonnull)adId;
 - (void)showAdWithID:(NSNumber *_Nonnull)adId;
 - (void)onAdLoaded:(id<FLTAd> _Nonnull)ad;
 - (void)onAdFailedToLoad:(id<FLTAd> _Nonnull)ad error:(FLTLoadAdError *_Nonnull)error;

--- a/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.m
@@ -58,8 +58,8 @@
   [ad load];
 }
 
-- (void)dispose:(id<FLTAd> _Nonnull)ad {
-  [_ads removeObjectForKey:[self adIdFor:ad]];
+- (void)dispose:(NSNumber *_Nonnull)adId; {
+  [_ads removeObjectForKey:adId];
 }
 
 - (void)showAdWithID:(NSNumber *_Nonnull)adId {

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.h
@@ -23,6 +23,8 @@
 #define FLTLogWarning(format, ...) \
   NSLog((@"GoogleMobileAdsPlugin <warning> " format), ##__VA_ARGS__)
 
+@class FLTAdInstanceManager;
+
 /**
  * Creates a `GADUnifiedNativeAdView` to be shown in a Flutter app.
  *
@@ -48,6 +50,7 @@
  * Flutter plugin providing access to the Google Mobile Ads API.
  */
 @interface FLTGoogleMobileAdsPlugin : NSObject <FlutterPlugin>
+- (instancetype _Nonnull)initWithManager:(FLTAdInstanceManager *_Nonnull)manager;
 /**
  * Adds a `FLTNativeAdFactory` used to create a `GADUnifiedNativeAdView`s from a Native Ad created
  * in Dart.

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
@@ -25,8 +25,8 @@
 }
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
-  FLTGoogleMobileAdsPlugin *instance =
-      [[FLTGoogleMobileAdsPlugin alloc] initWithBinaryMessenger:registrar.messenger];
+  FLTAdInstanceManager *instanceManager = [[FLTAdInstanceManager alloc] initWithBinaryMessenger:registrar.messenger];
+  FLTGoogleMobileAdsPlugin *instance = [[FLTGoogleMobileAdsPlugin alloc] initWithManager:instanceManager];
   [registrar publish:instance];
 
   FLTGoogleMobileAdsReaderWriter *readerWriter = [[FLTGoogleMobileAdsReaderWriter alloc] init];
@@ -45,16 +45,11 @@
                           withId:@"plugins.flutter.io/google_mobile_ads/ad_widget"];
 }
 
-- (instancetype)init {
-  self = [super init];
-  return self;
-}
-
-- (instancetype)initWithBinaryMessenger:(id<FlutterBinaryMessenger>)binaryMessenger {
+- (instancetype)initWithManager:(FLTAdInstanceManager *)manager {
   self = [self init];
   if (self) {
     _nativeAdFactories = [NSMutableDictionary dictionary];
-    _manager = [[FLTAdInstanceManager alloc] initWithBinaryMessenger:binaryMessenger];
+    _manager = manager;
   }
 
   return self;

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsTest.m
@@ -260,7 +260,10 @@
   OCMStub([mockBannerAd load]);
 
   [_manager loadAd:bannerAd adId:@(1)];
-  [_manager dispose:bannerAd];
+  
+  FLTGoogleMobileAdsPlugin *plugin = [[FLTGoogleMobileAdsPlugin alloc] initWithManager:_manager];
+  FlutterMethodCall *methodCall = [FlutterMethodCall methodCallWithMethodName:@"disposeAd" arguments:@{@"adId": @(1)}];
+  [plugin handleMethodCall:methodCall result:^(id  _Nullable result) {}];
 
   XCTAssertNil([_manager adFor:@(1)]);
   XCTAssertNil([_manager adIdFor:bannerAd]);


### PR DESCRIPTION
## Description

The `MethodCall` received from `disposeAd` would incorrectly pass an `adId` instead of an `FLTAd`. `FLTAdInstanceManager dispose` was changed to receive an adID.

## Related Issues

Fixes https://github.com/googleads/googleads-mobile-flutter/issues/69

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
