### PR TITLE
Clean up ad state in hot restart.

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.0+4
+
+* Fixes a [bug](https://github.com/googleads/googleads-mobile-flutter/issues/47) where state is not properly cleaned up on hot restart.
+
 ## 0.11.0+3
 
 * Fixes an [Android crash](https://github.com/googleads/googleads-mobile-flutter/issues/46) when reusing Native and Banner Ad objects.

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdInstanceManager.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdInstanceManager.java
@@ -16,6 +16,7 @@ package io.flutter.plugins.googlemobileads;
 
 import android.app.Activity;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.StandardMethodCodec;
@@ -47,10 +48,12 @@ class AdInstanceManager {
     this.activity = activity;
   }
 
+  @Nullable
   FlutterAd adForId(int id) {
     return ads.get(id);
   }
 
+  @Nullable
   Integer adIdFor(@NonNull FlutterAd ad) {
     for (Integer adId : ads.keySet()) {
       if (ads.get(adId) == ad) {
@@ -77,6 +80,16 @@ class AdInstanceManager {
       ((FlutterDestroyableAd) adObject).destroy();
     }
     ads.remove(adId);
+  }
+
+  void disposeAllAds() {
+    for (Map.Entry<Integer, FlutterAd> entry : ads.entrySet()) {
+      if (entry.getValue() != null && entry.getValue() instanceof FlutterDestroyableAd) {
+        FlutterDestroyableAd destroyableAd = (FlutterDestroyableAd) entry.getValue();
+        destroyableAd.destroy();
+      }
+    }
+    ads.clear();
   }
 
   void onAdLoaded(@NonNull FlutterAd ad) {

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
@@ -17,5 +17,5 @@ package io.flutter.plugins.googlemobileads;
 /** Constants used in the plugin. */
 public class Constants {
   /** Version request agent. Should be bumped alongside plugin versions. */
-  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-0.11.0+3";
+  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-0.11.0+4";
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -18,6 +18,7 @@ import android.app.Activity;
 import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.ads.RequestConfiguration;
 import com.google.android.gms.ads.formats.UnifiedNativeAd;
@@ -57,6 +58,14 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
   @Nullable private FlutterPluginBinding pluginBinding;
   @Nullable private AdInstanceManager instanceManager;
   private final Map<String, NativeAdFactory> nativeAdFactories = new HashMap<>();
+
+  /** Constructor for testing. */
+  @VisibleForTesting
+  protected GoogleMobileAdsPlugin(
+      @Nullable FlutterPluginBinding pluginBinding, @Nullable AdInstanceManager instanceManager) {
+    this.pluginBinding = pluginBinding;
+    this.instanceManager = instanceManager;
+  }
 
   /**
    * Interface used to display a {@link com.google.android.gms.ads.formats.UnifiedNativeAd}.
@@ -202,6 +211,12 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
   @Override
   public void onMethodCall(@NonNull MethodCall call, @NonNull final Result result) {
     switch (call.method) {
+      case "_init":
+        // Internal init. This is necessary to cleanup state on hot restart.
+        instanceManager.disposeAllAds();
+        result.success(null);
+        break;
+
       case "MobileAds#initialize":
         MobileAds.initialize(
             instanceManager.activity,

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -60,8 +60,8 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
   private final Map<String, NativeAdFactory> nativeAdFactories = new HashMap<>();
 
   /**
-   * Public constructor for the plugin.
-   * Dependency initialization is handled in lifecycle methods below.
+   * Public constructor for the plugin. Dependency initialization is handled in lifecycle methods
+   * below.
    */
   public GoogleMobileAdsPlugin() {}
 

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -59,6 +59,12 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
   @Nullable private AdInstanceManager instanceManager;
   private final Map<String, NativeAdFactory> nativeAdFactories = new HashMap<>();
 
+  /**
+   * Public constructor for the plugin.
+   * Dependency initialization is handled in lifecycle methods below.
+   */
+  public GoogleMobileAdsPlugin() {}
+
   /** Constructor for testing. */
   @VisibleForTesting
   protected GoogleMobileAdsPlugin(

--- a/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.h
@@ -42,6 +42,7 @@
 - (void)onAdClosed:(id<FLTAd> _Nonnull)ad;
 - (void)onRewardedAdUserEarnedReward:(FLTRewardedAd *_Nonnull)ad
                               reward:(FLTRewardItem *_Nonnull)reward;
+- (void)disposeAllAds;
 @end
 
 @interface FLTNewGoogleMobileAdsViewFactory : NSObject <FlutterPlatformViewFactory>

--- a/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.m
@@ -62,6 +62,10 @@
   [_ads removeObjectForKey:adId];
 }
 
+- (void)disposeAllAds {
+  [_ads removeAllObjects];
+}
+
 - (void)showAdWithID:(NSNumber *_Nonnull)adId {
   id<FLTAdWithoutView> ad = (id<FLTAdWithoutView>)[self adFor:adId];
 

--- a/packages/google_mobile_ads/ios/Classes/FLTConstants.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTConstants.h
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /** Versioned request agent string. */
-#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-0.11.0+3"
+#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-0.11.0+4"

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsCollection_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsCollection_Internal.h
@@ -24,4 +24,5 @@
 - (void)removeObjectForKey:(KeyType _Nonnull)key;
 - (id _Nullable)objectForKey:(KeyType _Nonnull)key;
 - (NSArray<KeyType> *_Nonnull)allKeysForObject:(ObjectType _Nonnull)object;
+- (void)removeAllObjects;
 @end

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsCollection_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsCollection_Internal.m
@@ -59,4 +59,11 @@
   });
   return keys;
 }
+
+- (void)removeAllObjects {
+  dispatch_async(_lockQueue, ^{
+    [self->_dictionary removeAllObjects];
+  });
+}
+
 @end

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
@@ -101,6 +101,9 @@
         startWithCompletionHandler:^(GADInitializationStatus *_Nonnull status) {
           result([[FLTInitializationStatus alloc] initWithStatus:status]);
         }];
+  } else if ([call.method isEqualToString:@"_init"]) {
+    [_manager disposeAllAds];
+    result(nil);
   } else if ([call.method isEqualToString:@"MobileAds#updateRequestConfiguration"]) {
     NSString *maxAdContentRating = call.arguments[@"maxAdContentRating"];
     NSNumber *tagForChildDirectedTreatment = call.arguments[@"tagForChildDirectedTreatment"];

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
@@ -48,4 +48,23 @@
   XCTAssertNil(returnedResult);
   OCMVerify([_mockAdInstanceManager dispose:@1]);
 }
+
+- (void)testInternalInit {
+  FlutterMethodCall *methodCall = [FlutterMethodCall methodCallWithMethodName:@"_init"
+                                                                    arguments:@{}];
+
+  __block bool resultInvoked = false;
+  __block id _Nullable returnedResult;
+  FlutterResult result = ^(id _Nullable result) {
+    resultInvoked = true;
+    returnedResult = result;
+  };
+
+  [_fltGoogleMobileAdsPlugin handleMethodCall:methodCall result:result];
+
+  XCTAssertTrue(resultInvoked);
+  XCTAssertNil(returnedResult);
+  OCMVerify([_mockAdInstanceManager disposeAllAds]);
+}
+
 @end

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsTest.m
@@ -266,6 +266,34 @@
   XCTAssertNil([_manager adIdFor:bannerAd]);
 }
 
+- (void)testDisposeAllAds {
+  FLTAdSize *size = [[FLTAdSize alloc] initWithWidth:@(1) height:@(2)];
+  FLTBannerAd *bannerAd1 =
+      [[FLTBannerAd alloc] initWithAdUnitId:@"testId"
+                                       size:size
+                                    request:[[FLTAdRequest alloc] init]
+                         rootViewController:OCMClassMock([UIViewController class])];
+  FLTBannerAd *mockBannerAd1 = OCMPartialMock(bannerAd1);
+  OCMStub([mockBannerAd1 load]);
+
+  FLTBannerAd *bannerAd2 =
+      [[FLTBannerAd alloc] initWithAdUnitId:@"testId"
+                                       size:size
+                                    request:[[FLTAdRequest alloc] init]
+                         rootViewController:OCMClassMock([UIViewController class])];
+  FLTBannerAd *mockBannerAd2 = OCMPartialMock(bannerAd2);
+  OCMStub([mockBannerAd2 load]);
+
+  [_manager loadAd:bannerAd1 adId:@(1)];
+  [_manager loadAd:bannerAd2 adId:@(2)];
+  [_manager disposeAllAds];
+
+  XCTAssertNil([_manager adFor:@(1)]);
+  XCTAssertNil([_manager adIdFor:bannerAd1]);
+  XCTAssertNil([_manager adFor:@(2)]);
+  XCTAssertNil([_manager adIdFor:bannerAd2]);
+}
+
 - (void)testOnAdLoaded {
   FLTNativeAd *ad =
       [[FLTNativeAd alloc] initWithAdUnitId:@"testAdUnitId"

--- a/packages/google_mobile_ads/lib/src/mobile_ads.dart
+++ b/packages/google_mobile_ads/lib/src/mobile_ads.dart
@@ -32,7 +32,7 @@ enum AdapterInitializationState {
 class MobileAds {
   MobileAds._();
 
-  static final MobileAds _instance = MobileAds._();
+  static final MobileAds _instance = MobileAds._().._init();
 
   /// Shared instance to initialize the AdMob SDK.
   static MobileAds get instance => _instance;
@@ -54,6 +54,11 @@ class MobileAds {
   Future<void> updateRequestConfiguration(
       RequestConfiguration requestConfiguration) {
     return instanceManager.updateRequestConfiguration(requestConfiguration);
+  }
+
+  /// Internal init to cleanup state for hot restart.
+  void _init() {
+    instanceManager.channel.invokeMethod("_init");
   }
 }
 

--- a/packages/google_mobile_ads/lib/src/mobile_ads.dart
+++ b/packages/google_mobile_ads/lib/src/mobile_ads.dart
@@ -57,6 +57,7 @@ class MobileAds {
   }
 
   /// Internal init to cleanup state for hot restart.
+  /// This is a workaround for https://github.com/flutter/flutter/issues/7160.
   void _init() {
     instanceManager.channel.invokeMethod("_init");
   }

--- a/packages/google_mobile_ads/pubspec.yaml
+++ b/packages/google_mobile_ads/pubspec.yaml
@@ -16,7 +16,7 @@ name: google_mobile_ads
 description: Flutter plugin for Google Mobile Ads, supporting
   banner, interstitial (full-screen),  rewarded and native ads
 homepage: https://github.com/googleads/googleads-mobile-flutter/tree/master/packages/google_mobile_ads
-version: 0.11.0+3
+version: 0.11.0+4
 
 flutter:
   plugin:

--- a/packages/google_mobile_ads/test/mobile_ads_test.dart
+++ b/packages/google_mobile_ads/test/mobile_ads_test.dart
@@ -118,10 +118,10 @@ void main() {
     test('$MobileAds.initialize', () async {
       final InitializationStatus result = await MobileAds.instance.initialize();
 
-      expect(log,
-          <Matcher>[
-            isMethodCall("_init", arguments: null),
-            isMethodCall("MobileAds#initialize", arguments: null)]);
+      expect(log, <Matcher>[
+        isMethodCall("_init", arguments: null),
+        isMethodCall("MobileAds#initialize", arguments: null)
+      ]);
 
       expect(result.adapterStatuses, hasLength(1));
       final AdapterStatus status = result.adapterStatuses['aName'];

--- a/packages/google_mobile_ads/test/mobile_ads_test.dart
+++ b/packages/google_mobile_ads/test/mobile_ads_test.dart
@@ -45,6 +45,8 @@ void main() {
                 null,
               ),
             });
+          case '_init':
+            return null;
           default:
             assert(false);
             return null;
@@ -117,7 +119,9 @@ void main() {
       final InitializationStatus result = await MobileAds.instance.initialize();
 
       expect(log,
-          <Matcher>[isMethodCall("MobileAds#initialize", arguments: null)]);
+          <Matcher>[
+            isMethodCall("_init", arguments: null),
+            isMethodCall("MobileAds#initialize", arguments: null)]);
 
       expect(result.adapterStatuses, hasLength(1));
       final AdapterStatus status = result.adapterStatuses['aName'];


### PR DESCRIPTION
## Description

This adds logic to the static initialization of `MobileAds.instance`, which cleans up any stored ad objects on the platform side. 

## Related Issues

https://github.com/googleads/googleads-mobile-flutter/issues/47

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
