### PR TITLE
Docs: Update dispose ad documentation and example app

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Google Mobile Ads SDK for Flutter currently supports loading and displaying 
 
 Note: This plugin also contains support for **[Google Ad Manager](https://admanager.google.com/home/)**. If you are interested in creating and loading an Ad with Ad Manager, you may follow the same prerequisites, platform setup, mobile ads SDK initialization steps outlined in this doc, and then see [creating and loading an ad with Ad Manager](https://github.com/googleads/googleads-mobile-flutter#creating-and-loading-an-ad-with-ad-manager) for further instructions.
 
-See also the [codelab for inline ads in Flutter](https://codelabs.developers.google.com/codelabs/admob-inline-ads-in-flutter#0) for a detailed guide on setting 
+See also the [codelab for inline ads in Flutter](https://codelabs.developers.google.com/codelabs/admob-inline-ads-in-flutter#0) for a detailed guide on setting
 inline banner and native ads.
 
 ## Prerequisites
@@ -248,6 +248,7 @@ final AdListener listener = AdListener(
  onAdLoaded: (Ad ad) => print('Ad loaded.'),
  // Called when an ad request failed.
  onAdFailedToLoad: (Ad ad, LoadAdError error) {
+   ad.dispose();
    print('Ad failed to load: $error');
  },
  // Called when an ad opens an overlay that covers the screen.
@@ -339,12 +340,16 @@ final AdListener listener = AdListener(
  onAdLoaded: (Ad ad) => print('Ad loaded.'),
  // Called when an ad request failed.
  onAdFailedToLoad: (Ad ad, LoadAdError error) {
+   ad.dispose();
    print('Ad failed to load: $error');
  },
  // Called when an ad opens an overlay that covers the screen.
  onAdOpened: (Ad ad) => print('Ad opened.'),
  // Called when an ad removes an overlay that covers the screen.
- onAdClosed: (Ad ad) => print('Ad closed.'),
+ onAdClosed: (Ad ad) {
+   ad.dispose();
+   print('Ad closed.');
+ },
  // Called when an ad is in the process of leaving the application.
  onApplicationExit: (Ad ad) => print('Left application.'),
 );
@@ -634,11 +639,12 @@ The `factoryId` will need to match the one used to add the factory to `GoogleMob
 Through the use of `AdListener`, you can listen for lifecycle events, such as when an ad is closed or the user leaves the app. This example implements each method and logs a message to the console:
 
 ```dart
-AdListener(
+final AdListener listener = AdListener(
  // Called when an ad is successfully received.
  onAdLoaded: (Ad ad) => print('Ad loaded.'),
  // Called when an ad request failed.
  onAdFailedToLoad: (Ad ad, LoadAdError error) {
+   ad.dispose();
    print('Ad failed to load: $error');
  },
  // Called when an ad opens an overlay that covers the screen.
@@ -738,17 +744,21 @@ Through the use of `AdListener`, you can listen for lifecycle events, such as wh
 
 
 ```dart
-AdListener(
+final AdListener listener = AdListener(
  // Called when an ad is successfully received.
  onAdLoaded: (Ad ad) => print('Ad loaded.'),
  // Called when an ad request failed.
  onAdFailedToLoad: (Ad ad, LoadAdError error) {
+   ad.dispose();
    print('Ad failed to load: $error');
  },
  // Called when an ad opens an overlay that covers the screen.
  onAdOpened: (Ad ad) => print('Ad opened.'),
  // Called when an ad removes an overlay that covers the screen.
- onAdClosed: (Ad ad) => print('Ad closed.'),
+ onAdClosed: (Ad ad) {
+   ad.dispose();
+   print('Ad closed.');
+ },
  // Called when an ad is in the process of leaving the application.
  onApplicationExit: (Ad ad) => print('Left application.'),
  // Called when a RewardedAd triggers a reward.
@@ -788,7 +798,7 @@ That's it! Your app is now ready to display rewarded ads.
 
 ## Creating and Loading an Ad with Ad Manager
 
-This section shows how to create and load ads with [Google Ad Manager](https://admanager.google.com/home/). 
+This section shows how to create and load ads with [Google Ad Manager](https://admanager.google.com/home/).
 
 ## Select an Ad Format
 
@@ -805,7 +815,7 @@ This section shows how to create and load ads with [Google Ad Manager](https://a
 
 For Ad Manager you will be using `PublisherAdRequest` instead of `AdRequest`.
 `PublisherAdRequest` is similar to `AdRequest` but has two additional properties: `customTargeting` and `customTargetingLists`,
-which are used to support [custom targeting](https://support.google.com/admanager/answer/188092?hl=en). 
+which are used to support [custom targeting](https://support.google.com/admanager/answer/188092?hl=en).
 
 ```
 final PublisherAdRequest request = PublisherAdRequest(
@@ -814,7 +824,7 @@ final PublisherAdRequest request = PublisherAdRequest(
   customTargeting: <String, String>{'some', 'targeting'},
   customTargetingLists: <String, List<String>>{'favoriteColors': <String>['red', 'yellow']},
 );
-```    
+```
 
 ## Ad Manager Banner Ads
 
@@ -934,6 +944,7 @@ final AdListener listener = AdListener(
  onAdLoaded: (Ad ad) => print('Ad loaded.'),
  // Called when an ad request failed.
  onAdFailedToLoad: (Ad ad, LoadAdError error) {
+   ad.dispose();
    print('Ad failed to load: $error');
  },
  // Called when an ad opens an overlay that covers the screen.
@@ -1025,12 +1036,16 @@ final AdListener listener = AdListener(
  onAdLoaded: (Ad ad) => print('Ad loaded.'),
  // Called when an ad request failed.
  onAdFailedToLoad: (Ad ad, LoadAdError error) {
+   ad.dispose();
    print('Ad failed to load: $error');
  },
  // Called when an ad opens an overlay that covers the screen.
  onAdOpened: (Ad ad) => print('Ad opened.'),
  // Called when an ad removes an overlay that covers the screen.
- onAdClosed: (Ad ad) => print('Ad closed.'),
+ onAdClosed: (Ad ad) {
+   ad.dispose();
+   print('Ad closed.');
+ },
  // Called when an ad is in the process of leaving the application.
  onApplicationExit: (Ad ad) => print('Left application.'),
 );
@@ -1319,11 +1334,12 @@ The `factoryId` will need to match the one used to add the factory to `GoogleMob
 Through the use of `AdListener`, you can listen for lifecycle events, such as when an ad is closed or the user leaves the app. This example implements each method and logs a message to the console:
 
 ```dart
-AdListener(
+final AdListener listener = AdListener(
  // Called when an ad is successfully received.
  onAdLoaded: (Ad ad) => print('Ad loaded.'),
  // Called when an ad request failed.
  onAdFailedToLoad: (Ad ad, LoadAdError error) {
+   ad.dispose();
    print('Ad failed to load: $error');
  },
  // Called when an ad opens an overlay that covers the screen.
@@ -1422,17 +1438,21 @@ Through the use of `AdListener`, you can listen for lifecycle events, such as wh
 
 
 ```dart
-AdListener(
+final AdListener listener = AdListener(
  // Called when an ad is successfully received.
  onAdLoaded: (Ad ad) => print('Ad loaded.'),
  // Called when an ad request failed.
  onAdFailedToLoad: (Ad ad, LoadAdError error) {
+   ad.dispose();
    print('Ad failed to load: $error');
  },
  // Called when an ad opens an overlay that covers the screen.
  onAdOpened: (Ad ad) => print('Ad opened.'),
  // Called when an ad removes an overlay that covers the screen.
- onAdClosed: (Ad ad) => print('Ad closed.'),
+ onAdClosed: (Ad ad) {
+   ad.dispose();
+   print('Ad closed.');
+ },
  // Called when an ad is in the process of leaving the application.
  onApplicationExit: (Ad ad) => print('Left application.'),
  // Called when a RewardedAd triggers a reward.

--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.11.0+4
 
 * Fixes a [bug](https://github.com/googleads/googleads-mobile-flutter/issues/47) where state is not properly cleaned up on hot restart.
+* Update README and example app to appropriately dispose ads.
 
 ## 0.11.0+3
 

--- a/packages/google_mobile_ads/README.md
+++ b/packages/google_mobile_ads/README.md
@@ -8,7 +8,7 @@ The Google Mobile Ads SDK for Flutter currently supports loading and displaying 
 
 Note: This plugin also contains support for **[Google Ad Manager](https://admanager.google.com/home/)**. If you are interested in creating and loading an Ad with Ad Manager, you may follow the same prerequisites, platform setup, mobile ads SDK initialization steps outlined in this doc, and then see [creating and loading an ad with Ad Manager](https://github.com/googleads/googleads-mobile-flutter#creating-and-loading-an-ad-with-ad-manager) for further instructions.
 
-See also the [codelab for inline ads in Flutter](https://codelabs.developers.google.com/codelabs/admob-inline-ads-in-flutter#0) for a detailed guide on setting 
+See also the [codelab for inline ads in Flutter](https://codelabs.developers.google.com/codelabs/admob-inline-ads-in-flutter#0) for a detailed guide on setting
 inline banner and native ads.
 
 ## Prerequisites
@@ -248,6 +248,7 @@ final AdListener listener = AdListener(
  onAdLoaded: (Ad ad) => print('Ad loaded.'),
  // Called when an ad request failed.
  onAdFailedToLoad: (Ad ad, LoadAdError error) {
+   ad.dispose();
    print('Ad failed to load: $error');
  },
  // Called when an ad opens an overlay that covers the screen.
@@ -339,12 +340,16 @@ final AdListener listener = AdListener(
  onAdLoaded: (Ad ad) => print('Ad loaded.'),
  // Called when an ad request failed.
  onAdFailedToLoad: (Ad ad, LoadAdError error) {
+   ad.dispose();
    print('Ad failed to load: $error');
  },
  // Called when an ad opens an overlay that covers the screen.
  onAdOpened: (Ad ad) => print('Ad opened.'),
  // Called when an ad removes an overlay that covers the screen.
- onAdClosed: (Ad ad) => print('Ad closed.'),
+ onAdClosed: (Ad ad) {
+   ad.dispose();
+   print('Ad closed.');
+ },
  // Called when an ad is in the process of leaving the application.
  onApplicationExit: (Ad ad) => print('Left application.'),
 );
@@ -634,11 +639,12 @@ The `factoryId` will need to match the one used to add the factory to `GoogleMob
 Through the use of `AdListener`, you can listen for lifecycle events, such as when an ad is closed or the user leaves the app. This example implements each method and logs a message to the console:
 
 ```dart
-AdListener(
+final AdListener listener = AdListener(
  // Called when an ad is successfully received.
  onAdLoaded: (Ad ad) => print('Ad loaded.'),
  // Called when an ad request failed.
  onAdFailedToLoad: (Ad ad, LoadAdError error) {
+   ad.dispose();
    print('Ad failed to load: $error');
  },
  // Called when an ad opens an overlay that covers the screen.
@@ -738,17 +744,21 @@ Through the use of `AdListener`, you can listen for lifecycle events, such as wh
 
 
 ```dart
-AdListener(
+final AdListener listener = AdListener(
  // Called when an ad is successfully received.
  onAdLoaded: (Ad ad) => print('Ad loaded.'),
  // Called when an ad request failed.
  onAdFailedToLoad: (Ad ad, LoadAdError error) {
+   ad.dispose();
    print('Ad failed to load: $error');
  },
  // Called when an ad opens an overlay that covers the screen.
  onAdOpened: (Ad ad) => print('Ad opened.'),
  // Called when an ad removes an overlay that covers the screen.
- onAdClosed: (Ad ad) => print('Ad closed.'),
+ onAdClosed: (Ad ad) {
+   ad.dispose();
+   print('Ad closed.');
+ },
  // Called when an ad is in the process of leaving the application.
  onApplicationExit: (Ad ad) => print('Left application.'),
  // Called when a RewardedAd triggers a reward.
@@ -788,7 +798,7 @@ That's it! Your app is now ready to display rewarded ads.
 
 ## Creating and Loading an Ad with Ad Manager
 
-This section shows how to create and load ads with [Google Ad Manager](https://admanager.google.com/home/). 
+This section shows how to create and load ads with [Google Ad Manager](https://admanager.google.com/home/).
 
 ## Select an Ad Format
 
@@ -805,7 +815,7 @@ This section shows how to create and load ads with [Google Ad Manager](https://a
 
 For Ad Manager you will be using `PublisherAdRequest` instead of `AdRequest`.
 `PublisherAdRequest` is similar to `AdRequest` but has two additional properties: `customTargeting` and `customTargetingLists`,
-which are used to support [custom targeting](https://support.google.com/admanager/answer/188092?hl=en). 
+which are used to support [custom targeting](https://support.google.com/admanager/answer/188092?hl=en).
 
 ```
 final PublisherAdRequest request = PublisherAdRequest(
@@ -814,7 +824,7 @@ final PublisherAdRequest request = PublisherAdRequest(
   customTargeting: <String, String>{'some', 'targeting'},
   customTargetingLists: <String, List<String>>{'favoriteColors': <String>['red', 'yellow']},
 );
-```    
+```
 
 ## Ad Manager Banner Ads
 
@@ -934,6 +944,7 @@ final AdListener listener = AdListener(
  onAdLoaded: (Ad ad) => print('Ad loaded.'),
  // Called when an ad request failed.
  onAdFailedToLoad: (Ad ad, LoadAdError error) {
+   ad.dispose();
    print('Ad failed to load: $error');
  },
  // Called when an ad opens an overlay that covers the screen.
@@ -1025,12 +1036,16 @@ final AdListener listener = AdListener(
  onAdLoaded: (Ad ad) => print('Ad loaded.'),
  // Called when an ad request failed.
  onAdFailedToLoad: (Ad ad, LoadAdError error) {
+   ad.dispose();
    print('Ad failed to load: $error');
  },
  // Called when an ad opens an overlay that covers the screen.
  onAdOpened: (Ad ad) => print('Ad opened.'),
  // Called when an ad removes an overlay that covers the screen.
- onAdClosed: (Ad ad) => print('Ad closed.'),
+ onAdClosed: (Ad ad) {
+   ad.dispose();
+   print('Ad closed.');
+ },
  // Called when an ad is in the process of leaving the application.
  onApplicationExit: (Ad ad) => print('Left application.'),
 );
@@ -1319,11 +1334,12 @@ The `factoryId` will need to match the one used to add the factory to `GoogleMob
 Through the use of `AdListener`, you can listen for lifecycle events, such as when an ad is closed or the user leaves the app. This example implements each method and logs a message to the console:
 
 ```dart
-AdListener(
+final AdListener listener = AdListener(
  // Called when an ad is successfully received.
  onAdLoaded: (Ad ad) => print('Ad loaded.'),
  // Called when an ad request failed.
  onAdFailedToLoad: (Ad ad, LoadAdError error) {
+   ad.dispose();
    print('Ad failed to load: $error');
  },
  // Called when an ad opens an overlay that covers the screen.
@@ -1422,17 +1438,21 @@ Through the use of `AdListener`, you can listen for lifecycle events, such as wh
 
 
 ```dart
-AdListener(
+final AdListener listener = AdListener(
  // Called when an ad is successfully received.
  onAdLoaded: (Ad ad) => print('Ad loaded.'),
  // Called when an ad request failed.
  onAdFailedToLoad: (Ad ad, LoadAdError error) {
+   ad.dispose();
    print('Ad failed to load: $error');
  },
  // Called when an ad opens an overlay that covers the screen.
  onAdOpened: (Ad ad) => print('Ad opened.'),
  // Called when an ad removes an overlay that covers the screen.
- onAdClosed: (Ad ad) => print('Ad closed.'),
+ onAdClosed: (Ad ad) {
+   ad.dispose();
+   print('Ad closed.');
+ },
  // Called when an ad is in the process of leaving the application.
  onApplicationExit: (Ad ad) => print('Left application.'),
  // Called when a RewardedAd triggers a reward.

--- a/packages/google_mobile_ads/example/lib/main.dart
+++ b/packages/google_mobile_ads/example/lib/main.dart
@@ -240,6 +240,7 @@ class BannerAdState extends State<BannerAdWidget> {
           bannerCompleter.complete(ad as BannerAd);
         },
         onAdFailedToLoad: (Ad ad, LoadAdError error) {
+          ad.dispose();
           print('$BannerAd failedToLoad: $error');
           bannerCompleter.completeError(null);
         },
@@ -317,6 +318,7 @@ class PublisherBannerAdState extends State<PublisherBannerAdWidget> {
           bannerCompleter.complete(ad as PublisherBannerAd);
         },
         onAdFailedToLoad: (Ad ad, LoadAdError error) {
+          ad.dispose();
           print('$PublisherBannerAd failedToLoad: $error');
           bannerCompleter.completeError(null);
         },
@@ -391,6 +393,7 @@ class NativeAdState extends State<NativeAdWidget> {
           nativeAdCompleter.complete(ad as NativeAd);
         },
         onAdFailedToLoad: (Ad ad, LoadAdError error) {
+          ad.dispose();
           print('$NativeAd failedToLoad: $error');
           nativeAdCompleter.completeError(null);
         },

--- a/packages/google_mobile_ads/example/lib/reusable_inline_example.dart
+++ b/packages/google_mobile_ads/example/lib/reusable_inline_example.dart
@@ -13,6 +13,7 @@ class ReusableInlineExample extends StatefulWidget {
 }
 
 class _ReusableInlineExampleState extends State<ReusableInlineExample> {
+
   BannerAd _bannerAd;
   bool _bannerAdIsLoaded = false;
 
@@ -21,6 +22,7 @@ class _ReusableInlineExampleState extends State<ReusableInlineExample> {
 
   NativeAd _nativeAd;
   bool _nativeAdIsLoaded = false;
+
 
   @override
   Widget build(BuildContext context) => Scaffold(
@@ -86,6 +88,7 @@ class _ReusableInlineExampleState extends State<ReusableInlineExample> {
           },
           onAdFailedToLoad: (Ad ad, LoadAdError error) {
             print('$BannerAd failedToLoad: $error');
+            ad.dispose();
           },
           onAdOpened: (Ad ad) => print('$BannerAd onAdOpened.'),
           onAdClosed: (Ad ad) => print('$BannerAd onAdClosed.'),
@@ -108,7 +111,8 @@ class _ReusableInlineExampleState extends State<ReusableInlineExample> {
           });
         },
         onAdFailedToLoad: (Ad ad, LoadAdError error) {
-          print('$NativeAd failedToLoad: $error');
+          print('$NativeAd failedToLoad: ${error}');
+          ad.dispose();
         },
         onAdOpened: (Ad ad) => print('$NativeAd onAdOpened.'),
         onAdClosed: (Ad ad) => print('$NativeAd onAdClosed.'),
@@ -129,6 +133,7 @@ class _ReusableInlineExampleState extends State<ReusableInlineExample> {
         },
         onAdFailedToLoad: (Ad ad, LoadAdError error) {
           print('$PublisherBannerAd failedToLoad: $error');
+          ad.dispose();
         },
         onAdOpened: (Ad ad) => print('$PublisherBannerAd onAdOpened.'),
         onAdClosed: (Ad ad) => print('$PublisherBannerAd onAdClosed.'),

--- a/packages/google_mobile_ads/example/lib/reusable_inline_example.dart
+++ b/packages/google_mobile_ads/example/lib/reusable_inline_example.dart
@@ -13,7 +13,6 @@ class ReusableInlineExample extends StatefulWidget {
 }
 
 class _ReusableInlineExampleState extends State<ReusableInlineExample> {
-
   BannerAd _bannerAd;
   bool _bannerAdIsLoaded = false;
 
@@ -22,7 +21,6 @@ class _ReusableInlineExampleState extends State<ReusableInlineExample> {
 
   NativeAd _nativeAd;
   bool _nativeAdIsLoaded = false;
-
 
   @override
   Widget build(BuildContext context) => Scaffold(


### PR DESCRIPTION
## Description

- Update example app to properly dispose of ad objects in `onAdFailedToLoad` and `onAdClosed` callbacks
- Update readme examples

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.