### PR TITLE
Rewarded server side verification options

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.12.0+1
+## 0.12.1
 
 * Rewarded ads now take an optional `ServerSideVerification`, to support [custom data in rewarded ads](https://developers.google.com/admob/ios/rewarded-video-ssv#custom_data).
 

--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.0+1
+
+* Rewarded ads now take an optional `ServerSideVerification`, to support [custom data in rewarded ads](https://developers.google.com/admob/ios/rewarded-video-ssv#custom_data).
+
 ## 0.12.0
 
 * Migrated to null safety. Minimum Dart SDK version is bumped to 2.12.0.

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
@@ -35,6 +35,7 @@ final class AdMessageCodec extends StandardMessageCodec {
   private static final byte VALUE_INITIALIZATION_STATE = (byte) 135;
   private static final byte VALUE_ADAPTER_STATUS = (byte) 136;
   private static final byte VALUE_INITIALIZATION_STATUS = (byte) 137;
+  private static final byte VALUE_SERVER_SIDE_VERIFICATION_OPTIONS = (byte) 138;
 
   @Override
   protected void writeValue(ByteArrayOutputStream stream, Object value) {
@@ -150,6 +151,10 @@ final class AdMessageCodec extends StandardMessageCodec {
       case VALUE_INITIALIZATION_STATUS:
         return new FlutterInitializationStatus(
             (Map<String, FlutterAdapterStatus>) readValueOfType(buffer.get(), buffer));
+      case VALUE_SERVER_SIDE_VERIFICATION_OPTIONS:
+        return new FlutterServerSideVerificationOptions(
+          (String) readValueOfType(buffer.get(), buffer),
+          (String) readValueOfType(buffer.get(), buffer));
       default:
         return super.readValueOfType(type, buffer);
     }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
@@ -153,8 +153,8 @@ final class AdMessageCodec extends StandardMessageCodec {
             (Map<String, FlutterAdapterStatus>) readValueOfType(buffer.get(), buffer));
       case VALUE_SERVER_SIDE_VERIFICATION_OPTIONS:
         return new FlutterServerSideVerificationOptions(
-          (String) readValueOfType(buffer.get(), buffer),
-          (String) readValueOfType(buffer.get(), buffer));
+            (String) readValueOfType(buffer.get(), buffer),
+            (String) readValueOfType(buffer.get(), buffer));
       default:
         return super.readValueOfType(type, buffer);
     }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
@@ -94,6 +94,11 @@ final class AdMessageCodec extends StandardMessageCodec {
       stream.write(VALUE_INITIALIZATION_STATUS);
       final FlutterInitializationStatus status = (FlutterInitializationStatus) value;
       writeValue(stream, status.adapterStatuses);
+    } else if (value instanceof FlutterServerSideVerificationOptions) {
+      stream.write(VALUE_SERVER_SIDE_VERIFICATION_OPTIONS);
+      FlutterServerSideVerificationOptions options = (FlutterServerSideVerificationOptions) value;
+      writeValue(stream, options.getUserId());
+      writeValue(stream, options.getCustomData());
     } else {
       super.writeValue(stream, value);
     }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
@@ -17,5 +17,5 @@ package io.flutter.plugins.googlemobileads;
 /** Constants used in the plugin. */
 public class Constants {
   /** Version request agent. Should be bumped alongside plugin versions. */
-  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-0.12.0";
+  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-0.12.0+1";
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
@@ -17,5 +17,5 @@ package io.flutter.plugins.googlemobileads;
 /** Constants used in the plugin. */
 public class Constants {
   /** Version request agent. Should be bumped alongside plugin versions. */
-  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-0.12.0+1";
+  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-0.12.1";
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedAd.java
@@ -82,7 +82,7 @@ class FlutterRewardedAd extends FlutterAd.FlutterOverlayAd {
       @NonNull AdInstanceManager manager,
       @NonNull String adUnitId,
       @NonNull FlutterPublisherAdRequest publisherRequest,
-    @Nullable FlutterServerSideVerificationOptions serverSideVerificationOptions) {
+      @Nullable FlutterServerSideVerificationOptions serverSideVerificationOptions) {
     this.manager = manager;
     this.adUnitId = adUnitId;
     this.publisherRequest = publisherRequest;
@@ -149,8 +149,8 @@ class FlutterRewardedAd extends FlutterAd.FlutterOverlayAd {
   RewardedAd createRewardedAd() {
     RewardedAd rewardedAd = new RewardedAd(manager.activity, adUnitId);
     if (serverSideVerificationOptions != null) {
-      rewardedAd.setServerSideVerificationOptions
-        (serverSideVerificationOptions.asServerSideVerificationOptions());
+      rewardedAd.setServerSideVerificationOptions(
+          serverSideVerificationOptions.asServerSideVerificationOptions());
     }
     return rewardedAd;
   }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedAd.java
@@ -31,6 +31,7 @@ class FlutterRewardedAd extends FlutterAd.FlutterOverlayAd {
   @NonNull private final String adUnitId;
   @Nullable private final FlutterAdRequest request;
   @Nullable private final FlutterPublisherAdRequest publisherRequest;
+  @Nullable private final FlutterServerSideVerificationOptions serverSideVerificationOptions;
   @Nullable RewardedAd rewardedAd;
 
   static class FlutterRewardItem {
@@ -68,21 +69,25 @@ class FlutterRewardedAd extends FlutterAd.FlutterOverlayAd {
   public FlutterRewardedAd(
       @NonNull AdInstanceManager manager,
       @NonNull String adUnitId,
-      @NonNull FlutterAdRequest request) {
+      @NonNull FlutterAdRequest request,
+      @Nullable FlutterServerSideVerificationOptions serverSideVerificationOptions) {
     this.manager = manager;
     this.adUnitId = adUnitId;
     this.request = request;
     this.publisherRequest = null;
+    this.serverSideVerificationOptions = serverSideVerificationOptions;
   }
 
   public FlutterRewardedAd(
       @NonNull AdInstanceManager manager,
       @NonNull String adUnitId,
-      @NonNull FlutterPublisherAdRequest publisherRequest) {
+      @NonNull FlutterPublisherAdRequest publisherRequest,
+    @Nullable FlutterServerSideVerificationOptions serverSideVerificationOptions) {
     this.manager = manager;
     this.adUnitId = adUnitId;
     this.publisherRequest = publisherRequest;
     this.request = null;
+    this.serverSideVerificationOptions = serverSideVerificationOptions;
   }
 
   @Override
@@ -142,6 +147,11 @@ class FlutterRewardedAd extends FlutterAd.FlutterOverlayAd {
   @NonNull
   @VisibleForTesting
   RewardedAd createRewardedAd() {
-    return new RewardedAd(manager.activity, adUnitId);
+    RewardedAd rewardedAd = new RewardedAd(manager.activity, adUnitId);
+    if (serverSideVerificationOptions != null) {
+      rewardedAd.setServerSideVerificationOptions
+        (serverSideVerificationOptions.asServerSideVerificationOptions());
+    }
+    return rewardedAd;
   }
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedAd.java
@@ -93,6 +93,10 @@ class FlutterRewardedAd extends FlutterAd.FlutterOverlayAd {
   @Override
   void load() {
     rewardedAd = createRewardedAd();
+    if (serverSideVerificationOptions != null) {
+      rewardedAd.setServerSideVerificationOptions(
+        serverSideVerificationOptions.asServerSideVerificationOptions());
+    }
     final RewardedAdLoadCallback adLoadCallback =
         new RewardedAdLoadCallback() {
           @Override
@@ -148,10 +152,6 @@ class FlutterRewardedAd extends FlutterAd.FlutterOverlayAd {
   @VisibleForTesting
   RewardedAd createRewardedAd() {
     RewardedAd rewardedAd = new RewardedAd(manager.activity, adUnitId);
-    if (serverSideVerificationOptions != null) {
-      rewardedAd.setServerSideVerificationOptions(
-          serverSideVerificationOptions.asServerSideVerificationOptions());
-    }
     return rewardedAd;
   }
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedAd.java
@@ -95,7 +95,7 @@ class FlutterRewardedAd extends FlutterAd.FlutterOverlayAd {
     rewardedAd = createRewardedAd();
     if (serverSideVerificationOptions != null) {
       rewardedAd.setServerSideVerificationOptions(
-        serverSideVerificationOptions.asServerSideVerificationOptions());
+          serverSideVerificationOptions.asServerSideVerificationOptions());
     }
     final RewardedAdLoadCallback adLoadCallback =
         new RewardedAdLoadCallback() {

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedAd.java
@@ -151,7 +151,6 @@ class FlutterRewardedAd extends FlutterAd.FlutterOverlayAd {
   @NonNull
   @VisibleForTesting
   RewardedAd createRewardedAd() {
-    RewardedAd rewardedAd = new RewardedAd(manager.activity, adUnitId);
-    return rewardedAd;
+    return new RewardedAd(manager.activity, adUnitId);
   }
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterServerSideVerificationOptions.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterServerSideVerificationOptions.java
@@ -1,0 +1,36 @@
+package io.flutter.plugins.googlemobileads;
+
+import androidx.annotation.Nullable;
+import com.google.android.gms.ads.rewarded.ServerSideVerificationOptions;
+
+class FlutterServerSideVerificationOptions {
+
+  @Nullable private final String userId;
+  @Nullable private final String customData;
+
+  public FlutterServerSideVerificationOptions(
+    @Nullable String userId,
+    @Nullable String customData) {
+    this.userId = userId;
+    this.customData = customData;
+  }
+
+  @Nullable public String getUserId() {
+    return userId;
+  }
+
+  @Nullable public String getCustomData() {
+    return customData;
+  }
+
+  public ServerSideVerificationOptions asServerSideVerificationOptions() {
+    ServerSideVerificationOptions.Builder builder =  new ServerSideVerificationOptions.Builder();
+    if (userId != null) {
+      builder.setUserId(userId);
+    }
+    if (customData != null) {
+      builder.setCustomData(customData);
+    }
+    return builder.build();
+  }
+}

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterServerSideVerificationOptions.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterServerSideVerificationOptions.java
@@ -9,22 +9,23 @@ class FlutterServerSideVerificationOptions {
   @Nullable private final String customData;
 
   public FlutterServerSideVerificationOptions(
-    @Nullable String userId,
-    @Nullable String customData) {
+      @Nullable String userId, @Nullable String customData) {
     this.userId = userId;
     this.customData = customData;
   }
 
-  @Nullable public String getUserId() {
+  @Nullable
+  public String getUserId() {
     return userId;
   }
 
-  @Nullable public String getCustomData() {
+  @Nullable
+  public String getCustomData() {
     return customData;
   }
 
   public ServerSideVerificationOptions asServerSideVerificationOptions() {
-    ServerSideVerificationOptions.Builder builder =  new ServerSideVerificationOptions.Builder();
+    ServerSideVerificationOptions.Builder builder = new ServerSideVerificationOptions.Builder();
     if (userId != null) {
       builder.setUserId(userId);
     }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterServerSideVerificationOptions.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterServerSideVerificationOptions.java
@@ -4,6 +4,7 @@ import androidx.annotation.Nullable;
 import com.google.android.gms.ads.rewarded.ServerSideVerificationOptions;
 import java.util.Objects;
 
+/** A wrapper for {@link ServerSideVerificationOptions}. */
 class FlutterServerSideVerificationOptions {
 
   @Nullable private final String userId;
@@ -25,6 +26,7 @@ class FlutterServerSideVerificationOptions {
     return customData;
   }
 
+  /** Gets an equivalent {@link ServerSideVerificationOptions}. */
   public ServerSideVerificationOptions asServerSideVerificationOptions() {
     ServerSideVerificationOptions.Builder builder = new ServerSideVerificationOptions.Builder();
     if (userId != null) {

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterServerSideVerificationOptions.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterServerSideVerificationOptions.java
@@ -2,6 +2,7 @@ package io.flutter.plugins.googlemobileads;
 
 import androidx.annotation.Nullable;
 import com.google.android.gms.ads.rewarded.ServerSideVerificationOptions;
+import java.util.Objects;
 
 class FlutterServerSideVerificationOptions {
 
@@ -33,5 +34,14 @@ class FlutterServerSideVerificationOptions {
       builder.setCustomData(customData);
     }
     return builder.build();
+  }
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    if (!(obj instanceof FlutterServerSideVerificationOptions)) {
+      return false;
+    }
+    FlutterServerSideVerificationOptions other = (FlutterServerSideVerificationOptions) obj;
+    return Objects.equals(other.userId, userId) && Objects.equals(other.customData, customData);
   }
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterServerSideVerificationOptions.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterServerSideVerificationOptions.java
@@ -40,10 +40,18 @@ class FlutterServerSideVerificationOptions {
 
   @Override
   public boolean equals(@Nullable Object obj) {
+    if (this == obj) {
+      return true;
+    }
     if (!(obj instanceof FlutterServerSideVerificationOptions)) {
       return false;
     }
     FlutterServerSideVerificationOptions other = (FlutterServerSideVerificationOptions) obj;
     return Objects.equals(other.userId, userId) && Objects.equals(other.customData, customData);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(userId, customData);
   }
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -303,13 +303,22 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
         final String adUnitId = requireNonNull(call.<String>argument("adUnitId"));
         final FlutterAdRequest request = call.argument("request");
         final FlutterPublisherAdRequest publisherRequest = call.argument("publisherRequest");
+        final FlutterServerSideVerificationOptions serverSideVerificationOptions =
+          call.argument("serverSideVerificationOptions");
 
         final FlutterRewardedAd rewardedAd;
         if (request != null) {
-          rewardedAd = new FlutterRewardedAd(requireNonNull(instanceManager), adUnitId, request);
+          rewardedAd = new FlutterRewardedAd(
+            requireNonNull(instanceManager),
+            adUnitId,
+            request,
+            serverSideVerificationOptions);
         } else if (publisherRequest != null) {
-          rewardedAd =
-              new FlutterRewardedAd(requireNonNull(instanceManager), adUnitId, publisherRequest);
+          rewardedAd = new FlutterRewardedAd(
+            requireNonNull(instanceManager),
+            adUnitId,
+            publisherRequest,
+            serverSideVerificationOptions);
         } else {
           result.error("InvalidRequest", "A null or invalid ad request was provided.", null);
           break;
@@ -346,7 +355,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
         instanceManager.disposeAd(call.<Integer>argument("adId"));
         result.success(null);
         break;
-      case "showAdWithoutView":
+      case "":
         final boolean adShown = instanceManager.showAdWithId(call.<Integer>argument("adId"));
         if (!adShown) {
           result.error("AdShowError", "Ad failed to show.", null);

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -304,21 +304,23 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
         final FlutterAdRequest request = call.argument("request");
         final FlutterPublisherAdRequest publisherRequest = call.argument("publisherRequest");
         final FlutterServerSideVerificationOptions serverSideVerificationOptions =
-          call.argument("serverSideVerificationOptions");
+            call.argument("serverSideVerificationOptions");
 
         final FlutterRewardedAd rewardedAd;
         if (request != null) {
-          rewardedAd = new FlutterRewardedAd(
-            requireNonNull(instanceManager),
-            adUnitId,
-            request,
-            serverSideVerificationOptions);
+          rewardedAd =
+              new FlutterRewardedAd(
+                  requireNonNull(instanceManager),
+                  adUnitId,
+                  request,
+                  serverSideVerificationOptions);
         } else if (publisherRequest != null) {
-          rewardedAd = new FlutterRewardedAd(
-            requireNonNull(instanceManager),
-            adUnitId,
-            publisherRequest,
-            serverSideVerificationOptions);
+          rewardedAd =
+              new FlutterRewardedAd(
+                  requireNonNull(instanceManager),
+                  adUnitId,
+                  publisherRequest,
+                  serverSideVerificationOptions);
         } else {
           result.error("InvalidRequest", "A null or invalid ad request was provided.", null);
           break;

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -357,7 +357,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
         instanceManager.disposeAd(call.<Integer>argument("adId"));
         result.success(null);
         break;
-      case "":
+      case "showAdWithoutView":
         final boolean adShown = instanceManager.showAdWithId(call.<Integer>argument("adId"));
         if (!adShown) {
           result.error("AdShowError", "Ad failed to show.", null);

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
@@ -16,6 +16,7 @@ package io.flutter.plugins.googlemobileads;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.android.gms.ads.rewarded.ServerSideVerificationOptions;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -102,5 +103,18 @@ public class AdMessageCodecTest {
     FlutterPublisherAdRequest decodedPublisherAdRequest =
         (FlutterPublisherAdRequest) codec.decodeMessage((ByteBuffer) message.position(0));
     assertEquals(decodedPublisherAdRequest, flutterPublisherAdRequest);
+  }
+
+  @Test
+  public void adMessageCodec_decodeServerSideVerificationOptions() {
+    AdMessageCodec codec = new AdMessageCodec();
+    FlutterServerSideVerificationOptions options = new FlutterServerSideVerificationOptions(
+      "user-id", "custom-data");
+
+    ByteBuffer message = codec.encodeMessage(options);
+
+    FlutterServerSideVerificationOptions decodedOptions = (FlutterServerSideVerificationOptions)
+      codec.decodeMessage((ByteBuffer) message.position(0));
+    assertEquals(decodedOptions, options);
   }
 }

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
@@ -16,7 +16,6 @@ package io.flutter.plugins.googlemobileads;
 
 import static org.junit.Assert.assertEquals;
 
-import com.google.android.gms.ads.rewarded.ServerSideVerificationOptions;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -108,34 +107,38 @@ public class AdMessageCodecTest {
   @Test
   public void adMessageCodec_decodeServerSideVerificationOptions() {
     AdMessageCodec codec = new AdMessageCodec();
-    FlutterServerSideVerificationOptions options = new FlutterServerSideVerificationOptions(
-      "user-id", "custom-data");
+    FlutterServerSideVerificationOptions options =
+        new FlutterServerSideVerificationOptions("user-id", "custom-data");
 
     ByteBuffer message = codec.encodeMessage(options);
 
-    FlutterServerSideVerificationOptions decodedOptions = (FlutterServerSideVerificationOptions)
-    codec.decodeMessage((ByteBuffer) message.position(0));
+    FlutterServerSideVerificationOptions decodedOptions =
+        (FlutterServerSideVerificationOptions)
+            codec.decodeMessage((ByteBuffer) message.position(0));
     assertEquals(decodedOptions, options);
 
     // WIth userId = null.
     options = new FlutterServerSideVerificationOptions(null, "custom-data");
     message = codec.encodeMessage(options);
-    decodedOptions = (FlutterServerSideVerificationOptions)
-    codec.decodeMessage((ByteBuffer) message.position(0));
+    decodedOptions =
+        (FlutterServerSideVerificationOptions)
+            codec.decodeMessage((ByteBuffer) message.position(0));
     assertEquals(decodedOptions, options);
 
     // WIth customData = null.
     options = new FlutterServerSideVerificationOptions("user-Id", null);
     message = codec.encodeMessage(options);
-    decodedOptions = (FlutterServerSideVerificationOptions)
-    codec.decodeMessage((ByteBuffer) message.position(0));
+    decodedOptions =
+        (FlutterServerSideVerificationOptions)
+            codec.decodeMessage((ByteBuffer) message.position(0));
     assertEquals(decodedOptions, options);
 
     // WIth userId and customData = null.
     options = new FlutterServerSideVerificationOptions(null, null);
     message = codec.encodeMessage(options);
-    decodedOptions = (FlutterServerSideVerificationOptions)
-    codec.decodeMessage((ByteBuffer) message.position(0));
+    decodedOptions =
+        (FlutterServerSideVerificationOptions)
+            codec.decodeMessage((ByteBuffer) message.position(0));
     assertEquals(decodedOptions, options);
   }
 }

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
@@ -114,7 +114,28 @@ public class AdMessageCodecTest {
     ByteBuffer message = codec.encodeMessage(options);
 
     FlutterServerSideVerificationOptions decodedOptions = (FlutterServerSideVerificationOptions)
-      codec.decodeMessage((ByteBuffer) message.position(0));
+    codec.decodeMessage((ByteBuffer) message.position(0));
+    assertEquals(decodedOptions, options);
+
+    // WIth userId = null.
+    options = new FlutterServerSideVerificationOptions(null, "custom-data");
+    message = codec.encodeMessage(options);
+    decodedOptions = (FlutterServerSideVerificationOptions)
+    codec.decodeMessage((ByteBuffer) message.position(0));
+    assertEquals(decodedOptions, options);
+
+    // WIth customData = null.
+    options = new FlutterServerSideVerificationOptions("user-Id", null);
+    message = codec.encodeMessage(options);
+    decodedOptions = (FlutterServerSideVerificationOptions)
+    codec.decodeMessage((ByteBuffer) message.position(0));
+    assertEquals(decodedOptions, options);
+
+    // WIth userId and customData = null.
+    options = new FlutterServerSideVerificationOptions(null, null);
+    message = codec.encodeMessage(options);
+    decodedOptions = (FlutterServerSideVerificationOptions)
+    codec.decodeMessage((ByteBuffer) message.position(0));
     assertEquals(decodedOptions, options);
   }
 }

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
@@ -117,7 +117,7 @@ public class AdMessageCodecTest {
             codec.decodeMessage((ByteBuffer) message.position(0));
     assertEquals(decodedOptions, options);
 
-    // WIth userId = null.
+    // With userId = null.
     options = new FlutterServerSideVerificationOptions(null, "custom-data");
     message = codec.encodeMessage(options);
     decodedOptions =
@@ -125,7 +125,7 @@ public class AdMessageCodecTest {
             codec.decodeMessage((ByteBuffer) message.position(0));
     assertEquals(decodedOptions, options);
 
-    // WIth customData = null.
+    // With customData = null.
     options = new FlutterServerSideVerificationOptions("user-Id", null);
     message = codec.encodeMessage(options);
     decodedOptions =
@@ -133,7 +133,7 @@ public class AdMessageCodecTest {
             codec.decodeMessage((ByteBuffer) message.position(0));
     assertEquals(decodedOptions, options);
 
-    // WIth userId and customData = null.
+    // With userId and customData = null.
     options = new FlutterServerSideVerificationOptions(null, null);
     message = codec.encodeMessage(options);
     decodedOptions =

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
@@ -229,6 +229,39 @@ public class GoogleMobileAdsTest {
   }
 
   @Test
+  public void loadRewardedAdWithPublisherRequest_nullServerSideOptions() {
+    final FlutterPublisherAdRequest mockFlutterRequest = mock(FlutterPublisherAdRequest.class);
+    final PublisherAdRequest mockRequest = mock(PublisherAdRequest.class);
+    when(mockFlutterRequest.asPublisherAdRequest()).thenReturn(mockRequest);
+
+    final FlutterServerSideVerificationOptions options =
+        new FlutterServerSideVerificationOptions(null, null);
+    final FlutterRewardedAd rewardedAd =
+        new FlutterRewardedAd(testManager, "testId", mockFlutterRequest, options);
+
+    final FlutterRewardedAd mockFlutterAd = spy(rewardedAd);
+    final RewardedAd mockPublisherAd = mock(RewardedAd.class);
+    doReturn(mockPublisherAd).when(mockFlutterAd).createRewardedAd();
+    mockFlutterAd.load();
+
+    final ArgumentCaptor<PublisherAdRequest> captor =
+        ArgumentCaptor.forClass(PublisherAdRequest.class);
+    verify(mockPublisherAd)
+        .loadAd(captor.capture(), ArgumentMatchers.any(RewardedAdLoadCallback.class));
+    ArgumentMatcher<ServerSideVerificationOptions> serverSideVerificationOptionsArgumentMatcher =
+        new ArgumentMatcher<ServerSideVerificationOptions>() {
+          @Override
+          public boolean matches(ServerSideVerificationOptions argument) {
+            return argument.getCustomData().isEmpty() && argument.getUserId().isEmpty();
+          }
+        };
+    verify(mockPublisherAd)
+        .setServerSideVerificationOptions(
+            ArgumentMatchers.argThat(serverSideVerificationOptionsArgumentMatcher));
+    assertEquals(captor.getValue(), mockRequest);
+  }
+
+  @Test
   public void showRewardedAd() {
     final FlutterAdRequest mockFlutterRequest = mock(FlutterAdRequest.class);
 

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
@@ -34,6 +34,7 @@ import com.google.android.gms.ads.formats.UnifiedNativeAdView;
 import com.google.android.gms.ads.rewarded.RewardedAd;
 import com.google.android.gms.ads.rewarded.RewardedAdCallback;
 import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback;
+import com.google.android.gms.ads.rewarded.ServerSideVerificationOptions;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel.Result;
@@ -46,6 +47,7 @@ import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
@@ -198,8 +200,10 @@ public class GoogleMobileAdsTest {
     final PublisherAdRequest mockRequest = mock(PublisherAdRequest.class);
     when(mockFlutterRequest.asPublisherAdRequest()).thenReturn(mockRequest);
 
+    final FlutterServerSideVerificationOptions options =
+      new FlutterServerSideVerificationOptions("userId", "customData");
     final FlutterRewardedAd rewardedAd =
-        new FlutterRewardedAd(testManager, "testId", mockFlutterRequest);
+        new FlutterRewardedAd(testManager, "testId", mockFlutterRequest, options);
 
     final FlutterRewardedAd mockFlutterAd = spy(rewardedAd);
     final RewardedAd mockPublisherAd = mock(RewardedAd.class);
@@ -210,6 +214,17 @@ public class GoogleMobileAdsTest {
         ArgumentCaptor.forClass(PublisherAdRequest.class);
     verify(mockPublisherAd)
         .loadAd(captor.capture(), ArgumentMatchers.any(RewardedAdLoadCallback.class));
+    ArgumentMatcher<ServerSideVerificationOptions> serverSideVerificationOptionsArgumentMatcher =
+      new ArgumentMatcher<ServerSideVerificationOptions>() {
+        @Override
+        public boolean matches(ServerSideVerificationOptions argument) {
+          return argument.getCustomData().equals(options.getCustomData())
+            && argument.getUserId().equals(options.getUserId());
+        }
+      };
+    verify(mockPublisherAd)
+      .setServerSideVerificationOptions(ArgumentMatchers
+        .argThat(serverSideVerificationOptionsArgumentMatcher));
     assertEquals(captor.getValue(), mockRequest);
   }
 
@@ -218,7 +233,7 @@ public class GoogleMobileAdsTest {
     final FlutterAdRequest mockFlutterRequest = mock(FlutterAdRequest.class);
 
     final FlutterRewardedAd rewardedAd =
-        new FlutterRewardedAd(testManager, "testId", mockFlutterRequest);
+        new FlutterRewardedAd(testManager, "testId", mockFlutterRequest, null);
 
     final FlutterRewardedAd mockFlutterAd = spy(rewardedAd);
     final RewardedAd mockRewardedAd = mock(RewardedAd.class);
@@ -535,7 +550,7 @@ public class GoogleMobileAdsTest {
 
   @Test
   public void flutterAdListener_onRewardedAdUserEarnedReward() {
-    final FlutterRewardedAd ad = new FlutterRewardedAd(testManager, "testId", request);
+    final FlutterRewardedAd ad = new FlutterRewardedAd(testManager, "testId", request, null);
     testManager.trackAd(ad, 0);
 
     testManager.onRewardedAdUserEarnedReward(

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
@@ -201,7 +201,7 @@ public class GoogleMobileAdsTest {
     when(mockFlutterRequest.asPublisherAdRequest()).thenReturn(mockRequest);
 
     final FlutterServerSideVerificationOptions options =
-      new FlutterServerSideVerificationOptions("userId", "customData");
+        new FlutterServerSideVerificationOptions("userId", "customData");
     final FlutterRewardedAd rewardedAd =
         new FlutterRewardedAd(testManager, "testId", mockFlutterRequest, options);
 
@@ -215,16 +215,16 @@ public class GoogleMobileAdsTest {
     verify(mockPublisherAd)
         .loadAd(captor.capture(), ArgumentMatchers.any(RewardedAdLoadCallback.class));
     ArgumentMatcher<ServerSideVerificationOptions> serverSideVerificationOptionsArgumentMatcher =
-      new ArgumentMatcher<ServerSideVerificationOptions>() {
-        @Override
-        public boolean matches(ServerSideVerificationOptions argument) {
-          return argument.getCustomData().equals(options.getCustomData())
-            && argument.getUserId().equals(options.getUserId());
-        }
-      };
+        new ArgumentMatcher<ServerSideVerificationOptions>() {
+          @Override
+          public boolean matches(ServerSideVerificationOptions argument) {
+            return argument.getCustomData().equals(options.getCustomData())
+                && argument.getUserId().equals(options.getUserId());
+          }
+        };
     verify(mockPublisherAd)
-      .setServerSideVerificationOptions(ArgumentMatchers
-        .argThat(serverSideVerificationOptionsArgumentMatcher));
+        .setServerSideVerificationOptions(
+            ArgumentMatchers.argThat(serverSideVerificationOptionsArgumentMatcher));
     assertEquals(captor.getValue(), mockRequest);
   }
 

--- a/packages/google_mobile_ads/example/lib/main.dart
+++ b/packages/google_mobile_ads/example/lib/main.dart
@@ -117,8 +117,7 @@ class _MyAppState extends State<MyApp> {
             );
           }),
       serverSideVerificationOptions: ServerSideVerificationOptions(
-          userId: 'user1\$!%',
-          customData: 'customdata\$!%'),
+          userId: 'user1\$!%', customData: 'customdata\$!%'),
     )..load();
   }
 

--- a/packages/google_mobile_ads/example/lib/main.dart
+++ b/packages/google_mobile_ads/example/lib/main.dart
@@ -116,8 +116,6 @@ class _MyAppState extends State<MyApp> {
               '$RewardedAd with reward $RewardItem(${reward.amount}, ${reward.type})',
             );
           }),
-      serverSideVerificationOptions: ServerSideVerificationOptions(
-          userId: 'user1\$!%', customData: 'customdata\$!%'),
     )..load();
   }
 

--- a/packages/google_mobile_ads/example/lib/main.dart
+++ b/packages/google_mobile_ads/example/lib/main.dart
@@ -116,6 +116,9 @@ class _MyAppState extends State<MyApp> {
               '$RewardedAd with reward $RewardItem(${reward.amount}, ${reward.type})',
             );
           }),
+      serverSideVerificationOptions: ServerSideVerificationOptions(
+          userId: 'user1\$!%',
+          customData: 'customdata\$!%'),
     )..load();
   }
 

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
@@ -101,7 +101,8 @@
 - (instancetype _Nonnull)initWithAdUnitId:(NSString *_Nonnull)adUnitId
                                   request:(FLTAdRequest *_Nonnull)request
                        rootViewController:(UIViewController *_Nonnull)rootViewController
-                       serverSideVerificationOptions: (FLTServerSideVerificationOptions *_Nullable)serverSideVerificationOptions;
+            serverSideVerificationOptions:
+                (FLTServerSideVerificationOptions *_Nullable)serverSideVerificationOptions;
 - (GADRewardedAd *_Nonnull)rewardedAd;
 @end
 

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
@@ -15,6 +15,7 @@
 #import <GoogleMobileAds/GoogleMobileAds.h>
 #import "FLTAdInstanceManager_Internal.h"
 #import "FLTGoogleMobileAdsPlugin.h"
+#import "FLTMobileAds_Internal.h"
 
 @class FLTAdInstanceManager;
 @protocol FLTNativeAdFactory;
@@ -99,7 +100,8 @@
 @property(weak) FLTAdInstanceManager *_Nullable manager;
 - (instancetype _Nonnull)initWithAdUnitId:(NSString *_Nonnull)adUnitId
                                   request:(FLTAdRequest *_Nonnull)request
-                       rootViewController:(UIViewController *_Nonnull)rootViewController;
+                       rootViewController:(UIViewController *_Nonnull)rootViewController
+                       serverSideVerificationOptions: (FLTServerSideVerificationOptions *_Nullable)serverSideVerificationOptions;
 - (GADRewardedAd *_Nonnull)rewardedAd;
 @end
 

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
@@ -309,16 +309,19 @@
   GADRewardedAd *_rewardedView;
   FLTAdRequest *_adRequest;
   UIViewController *_rootViewController;
+  FLTServerSideVerificationOptions *_serverSideVerificationOptions;
 }
 
 - (instancetype)initWithAdUnitId:(NSString *_Nonnull)adUnitId
                          request:(FLTAdRequest *_Nonnull)request
-              rootViewController:(UIViewController *_Nonnull)rootViewController {
+              rootViewController:(UIViewController *_Nonnull)rootViewController
+              serverSideVerificationOptions: (FLTServerSideVerificationOptions *_Nullable)serverSideVerificationOptions {
   self = [super init];
   if (self) {
     _adRequest = request;
     _rewardedView = [[GADRewardedAd alloc] initWithAdUnitID:adUnitId];
     _rootViewController = rootViewController;
+    _serverSideVerificationOptions = serverSideVerificationOptions;
   }
   return self;
 }
@@ -337,6 +340,9 @@
   } else {
     NSLog(@"A null or invalid ad request was provided.");
     return;
+  }
+  if (_serverSideVerificationOptions != NULL && ![_serverSideVerificationOptions isEqual:[NSNull null]]) {
+    _rewardedView.serverSideVerificationOptions = [_serverSideVerificationOptions asGADServerSideVerificationOptions];
   }
 
   [self.rewardedAd loadRequest:request

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
@@ -313,9 +313,10 @@
 }
 
 - (instancetype)initWithAdUnitId:(NSString *_Nonnull)adUnitId
-                         request:(FLTAdRequest *_Nonnull)request
-              rootViewController:(UIViewController *_Nonnull)rootViewController
-              serverSideVerificationOptions: (FLTServerSideVerificationOptions *_Nullable)serverSideVerificationOptions {
+                          request:(FLTAdRequest *_Nonnull)request
+               rootViewController:(UIViewController *_Nonnull)rootViewController
+    serverSideVerificationOptions:
+        (FLTServerSideVerificationOptions *_Nullable)serverSideVerificationOptions {
   self = [super init];
   if (self) {
     _adRequest = request;
@@ -341,8 +342,10 @@
     NSLog(@"A null or invalid ad request was provided.");
     return;
   }
-  if (_serverSideVerificationOptions != NULL && ![_serverSideVerificationOptions isEqual:[NSNull null]]) {
-    _rewardedView.serverSideVerificationOptions = [_serverSideVerificationOptions asGADServerSideVerificationOptions];
+  if (_serverSideVerificationOptions != NULL &&
+      ![_serverSideVerificationOptions isEqual:[NSNull null]]) {
+    _rewardedView.serverSideVerificationOptions =
+        [_serverSideVerificationOptions asGADServerSideVerificationOptions];
   }
 
   [self.rewardedAd loadRequest:request

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
@@ -344,6 +344,7 @@
   }
   if (_serverSideVerificationOptions != NULL &&
       ![_serverSideVerificationOptions isEqual:[NSNull null]]) {
+    NSLog(@"JJL Rewarded server side verifications found\n");
     _rewardedView.serverSideVerificationOptions =
         [_serverSideVerificationOptions asGADServerSideVerificationOptions];
   }

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
@@ -344,7 +344,6 @@
   }
   if (_serverSideVerificationOptions != NULL &&
       ![_serverSideVerificationOptions isEqual:[NSNull null]]) {
-    NSLog(@"JJL Rewarded server side verifications found\n");
     _rewardedView.serverSideVerificationOptions =
         [_serverSideVerificationOptions asGADServerSideVerificationOptions];
   }

--- a/packages/google_mobile_ads/ios/Classes/FLTConstants.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTConstants.h
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /** Versioned request agent string. */
-#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-0.12.0+1"
+#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-0.12.1"

--- a/packages/google_mobile_ads/ios/Classes/FLTConstants.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTConstants.h
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /** Versioned request agent string. */
-#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-0.12.0"
+#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-0.12.0+1"

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
@@ -217,10 +217,11 @@
       return;
     }
 
-    FLTRewardedAd *ad = [[FLTRewardedAd alloc] initWithAdUnitId:call.arguments[@"adUnitId"]
-                                                        request:request
-                                             rootViewController:rootController
-                                  serverSideVerificationOptions:call.arguments[@"serverSideVerificationOptions"]];
+    FLTRewardedAd *ad =
+        [[FLTRewardedAd alloc] initWithAdUnitId:call.arguments[@"adUnitId"]
+                                        request:request
+                             rootViewController:rootController
+                  serverSideVerificationOptions:call.arguments[@"serverSideVerificationOptions"]];
     [_manager loadAd:ad adId:call.arguments[@"adId"]];
     result(nil);
   } else if ([call.method isEqualToString:@"disposeAd"]) {

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
@@ -219,7 +219,8 @@
 
     FLTRewardedAd *ad = [[FLTRewardedAd alloc] initWithAdUnitId:call.arguments[@"adUnitId"]
                                                         request:request
-                                             rootViewController:rootController];
+                                             rootViewController:rootController
+                                  serverSideVerificationOptions:call.arguments[@"serverSideVerificationOptions"]];
     [_manager loadAd:ad adId:call.arguments[@"adId"]];
     result(nil);
   } else if ([call.method isEqualToString:@"disposeAd"]) {

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
@@ -24,6 +24,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
   FLTAdMobFieldAdapterInitializationState = 135,
   FLTAdMobFieldAdapterStatus = 136,
   FLTAdMobFieldInitializationStatus = 137,
+  FLTAdmobFieldServerSideVerificationOptions = 138,
 };
 
 @interface FLTGoogleMobileAdsReader : FlutterStandardReader
@@ -105,6 +106,12 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
       FLTInitializationStatus *status = [[FLTInitializationStatus alloc] init];
       status.adapterStatuses = [self readValueOfType:[self readByte]];
       return status;
+    }
+    case FLTAdmobFieldServerSideVerificationOptions: {
+      FLTServerSideVerificationOptions *options = [[FLTServerSideVerificationOptions alloc] init];
+      options.userIdentifier = [self readValueOfType:[self readByte]];
+      options.customRewardString = [self readValueOfType:[self readByte]];
+      return options;
     }
   }
   return [super readValueOfType:type];

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
@@ -172,7 +172,12 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     [self writeByte:FLTAdMobFieldInitializationStatus];
     FLTInitializationStatus *status = value;
     [self writeValue:status.adapterStatuses];
-  } else {
+  } else if ([value isKindOfClass:[FLTServerSideVerificationOptions class]]) {
+    [self writeByte:FLTAdmobFieldServerSideVerificationOptions];
+    FLTServerSideVerificationOptions *options = value;
+    [self writeValue:options.userIdentifier];
+    [self writeValue:options.customRewardString];
+  }  else {
     [super writeValue:value];
   }
 }

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
@@ -177,7 +177,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     FLTServerSideVerificationOptions *options = value;
     [self writeValue:options.userIdentifier];
     [self writeValue:options.customRewardString];
-  }  else {
+  } else {
     [super writeValue:value];
   }
 }

--- a/packages/google_mobile_ads/ios/Classes/FLTMobileAds_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTMobileAds_Internal.h
@@ -48,10 +48,9 @@ typedef NS_ENUM(NSUInteger, FLTAdapterInitializationState) {
 - (instancetype)initWithStatus:(GADInitializationStatus *)status;
 @end
 
-
 @interface FLTServerSideVerificationOptions : NSObject
-@property (nonatomic, copy, nullable) NSString *userIdentifier;
-@property (nonatomic, copy, nullable) NSString *customRewardString;
+@property(nonatomic, copy, nullable) NSString *userIdentifier;
+@property(nonatomic, copy, nullable) NSString *customRewardString;
 - (GADServerSideVerificationOptions *_Nonnull)asGADServerSideVerificationOptions;
 @end
 NS_ASSUME_NONNULL_END

--- a/packages/google_mobile_ads/ios/Classes/FLTMobileAds_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTMobileAds_Internal.h
@@ -48,4 +48,10 @@ typedef NS_ENUM(NSUInteger, FLTAdapterInitializationState) {
 - (instancetype)initWithStatus:(GADInitializationStatus *)status;
 @end
 
+
+@interface FLTServerSideVerificationOptions : NSObject
+@property (nonatomic, copy, nullable) NSString *userIdentifier;
+@property (nonatomic, copy, nullable) NSString *customRewardString;
+- (GADServerSideVerificationOptions *_Nonnull)asGADServerSideVerificationOptions;
+@end
 NS_ASSUME_NONNULL_END

--- a/packages/google_mobile_ads/ios/Classes/FLTMobileAds_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTMobileAds_Internal.m
@@ -48,3 +48,12 @@
   return self;
 }
 @end
+
+@implementation FLTServerSideVerificationOptions
+- (GADServerSideVerificationOptions *_Nonnull)asGADServerSideVerificationOptions {
+  GADServerSideVerificationOptions *options = [[GADServerSideVerificationOptions alloc] init];
+  options.userIdentifier = _userIdentifier;
+  options.customRewardString = _customRewardString;
+  return options;
+}
+@end

--- a/packages/google_mobile_ads/ios/Classes/FLTMobileAds_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTMobileAds_Internal.m
@@ -52,6 +52,8 @@
 @implementation FLTServerSideVerificationOptions
 - (GADServerSideVerificationOptions *_Nonnull)asGADServerSideVerificationOptions {
   GADServerSideVerificationOptions *options = [[GADServerSideVerificationOptions alloc] init];
+  NSLog(@"JJL user identifier: %@\n", _userIdentifier);
+  NSLog(@"JJL user custom str: %@\n", _customRewardString);
   options.userIdentifier = _userIdentifier;
   options.customRewardString = _customRewardString;
   return options;

--- a/packages/google_mobile_ads/ios/Classes/FLTMobileAds_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTMobileAds_Internal.m
@@ -52,8 +52,6 @@
 @implementation FLTServerSideVerificationOptions
 - (GADServerSideVerificationOptions *_Nonnull)asGADServerSideVerificationOptions {
   GADServerSideVerificationOptions *options = [[GADServerSideVerificationOptions alloc] init];
-  NSLog(@"JJL user identifier: %@\n", _userIdentifier);
-  NSLog(@"JJL user custom str: %@\n", _customRewardString);
   options.userIdentifier = _userIdentifier;
   options.customRewardString = _customRewardString;
   return options;

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
@@ -54,22 +54,25 @@
 - (void)testLoadRewardedAd {
   FLTAdRequest *request = [[FLTAdRequest alloc] init];
   request.keywords = @[ @"apple" ];
-  FLTServerSideVerificationOptions *serverSideVerificationOptions = [[FLTServerSideVerificationOptions alloc] init];
+  FLTServerSideVerificationOptions *serverSideVerificationOptions =
+      [[FLTServerSideVerificationOptions alloc] init];
   serverSideVerificationOptions.customRewardString = @"reward";
   serverSideVerificationOptions.userIdentifier = @"user-id";
   FLTRewardedAd *ad =
       [[FLTRewardedAd alloc] initWithAdUnitId:@"testId"
                                       request:request
-                           rootViewController:UIApplication.sharedApplication.delegate.window.rootViewController
+                           rootViewController:UIApplication.sharedApplication.delegate.window
+                                                  .rootViewController
                 serverSideVerificationOptions:serverSideVerificationOptions];
 
-  FlutterMethodCall *methodCall = [FlutterMethodCall methodCallWithMethodName:@"loadRewardedAd"
-                                                                    arguments:@{
-                                                                      @"adUnitId" : @"testId",
-                                                                       @"request" : request,
-                                                  @"serverSideVerificationOptions": serverSideVerificationOptions}];
-  
-  
+  FlutterMethodCall *methodCall = [FlutterMethodCall
+      methodCallWithMethodName:@"loadRewardedAd"
+                     arguments:@{
+                       @"adUnitId" : @"testId",
+                       @"request" : request,
+                       @"serverSideVerificationOptions" : serverSideVerificationOptions
+                     }];
+
   __block bool resultInvoked = false;
   __block id _Nullable returnedResult;
   FlutterResult result = ^(id _Nullable result) {
@@ -81,17 +84,17 @@
 
   XCTAssertTrue(resultInvoked);
   XCTAssertNil(returnedResult);
-  BOOL (^verificationBlock)(FLTRewardedAd *) =
-       ^BOOL(FLTRewardedAd *ad) {
-         FLTAdRequest *adRequest = [ad valueForKey: @"_adRequest"];
-         GADRewardedAd *rewardedAd = [ad valueForKey: @"_rewardedView"];
-         FLTServerSideVerificationOptions *options = [ad valueForKey: @"_serverSideVerificationOptions"];
-         XCTAssertEqualObjects(adRequest, request);
-         XCTAssertEqualObjects(rewardedAd.adUnitID, @"testId");
-         XCTAssertEqualObjects(options, serverSideVerificationOptions);
-         return YES;
-       };
-  OCMVerify([_mockAdInstanceManager loadAd:[OCMArg checkWithBlock:verificationBlock] adId:[OCMArg any]]);
+  BOOL (^verificationBlock)(FLTRewardedAd *) = ^BOOL(FLTRewardedAd *ad) {
+    FLTAdRequest *adRequest = [ad valueForKey:@"_adRequest"];
+    GADRewardedAd *rewardedAd = [ad valueForKey:@"_rewardedView"];
+    FLTServerSideVerificationOptions *options = [ad valueForKey:@"_serverSideVerificationOptions"];
+    XCTAssertEqualObjects(adRequest, request);
+    XCTAssertEqualObjects(rewardedAd.adUnitID, @"testId");
+    XCTAssertEqualObjects(options, serverSideVerificationOptions);
+    return YES;
+  };
+  OCMVerify([_mockAdInstanceManager loadAd:[OCMArg checkWithBlock:verificationBlock]
+                                      adId:[OCMArg any]]);
 }
 
 - (void)testInternalInit {

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
@@ -17,6 +17,8 @@
 
 #import "../Classes/FLTAdInstanceManager_Internal.h"
 #import "../Classes/FLTGoogleMobileAdsPlugin.h"
+#import "../Classes/FLTGoogleMobileAdsReaderWriter_Internal.h"
+#import "../Classes/FLTMobileAds_Internal.h"
 
 @interface FLTGoogleMobileAdsPluginMethodCallsTest : XCTestCase
 @end
@@ -47,6 +49,49 @@
   XCTAssertTrue(resultInvoked);
   XCTAssertNil(returnedResult);
   OCMVerify([_mockAdInstanceManager dispose:@1]);
+}
+
+- (void)testLoadRewardedAd {
+  FLTAdRequest *request = [[FLTAdRequest alloc] init];
+  request.keywords = @[ @"apple" ];
+  FLTServerSideVerificationOptions *serverSideVerificationOptions = [[FLTServerSideVerificationOptions alloc] init];
+  serverSideVerificationOptions.customRewardString = @"reward";
+  serverSideVerificationOptions.userIdentifier = @"user-id";
+  FLTRewardedAd *ad =
+      [[FLTRewardedAd alloc] initWithAdUnitId:@"testId"
+                                      request:request
+                           rootViewController:UIApplication.sharedApplication.delegate.window.rootViewController
+                serverSideVerificationOptions:serverSideVerificationOptions];
+
+  FlutterMethodCall *methodCall = [FlutterMethodCall methodCallWithMethodName:@"loadRewardedAd"
+                                                                    arguments:@{
+                                                                      @"adUnitId" : @"testId",
+                                                                       @"request" : request,
+                                                  @"serverSideVerificationOptions": serverSideVerificationOptions}];
+  
+  
+  __block bool resultInvoked = false;
+  __block id _Nullable returnedResult;
+  FlutterResult result = ^(id _Nullable result) {
+    resultInvoked = true;
+    returnedResult = result;
+  };
+
+  [_fltGoogleMobileAdsPlugin handleMethodCall:methodCall result:result];
+
+  XCTAssertTrue(resultInvoked);
+  XCTAssertNil(returnedResult);
+  BOOL (^verificationBlock)(FLTRewardedAd *) =
+       ^BOOL(FLTRewardedAd *ad) {
+         FLTAdRequest *adRequest = [ad valueForKey: @"_adRequest"];
+         GADRewardedAd *rewardedAd = [ad valueForKey: @"_rewardedView"];
+         FLTServerSideVerificationOptions *options = [ad valueForKey: @"_serverSideVerificationOptions"];
+         XCTAssertEqualObjects(adRequest, request);
+         XCTAssertEqualObjects(rewardedAd.adUnitID, @"testId");
+         XCTAssertEqualObjects(options, serverSideVerificationOptions);
+         return YES;
+       };
+  OCMVerify([_mockAdInstanceManager loadAd:[OCMArg checkWithBlock:verificationBlock] adId:[OCMArg any]]);
 }
 
 - (void)testInternalInit {

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
@@ -87,13 +87,15 @@
 }
 
 - (void)testEncodeDecodeServerSideVerification {
-  FLTServerSideVerificationOptions *serverSideVerificationOptions = [[FLTServerSideVerificationOptions alloc] init];
+  FLTServerSideVerificationOptions *serverSideVerificationOptions =
+      [[FLTServerSideVerificationOptions alloc] init];
   serverSideVerificationOptions.customRewardString = @"reward";
   serverSideVerificationOptions.userIdentifier = @"user-id";
   NSData *encodedMessage = [_messageCodec encode:serverSideVerificationOptions];
 
   FLTServerSideVerificationOptions *decoded = [_messageCodec decode:encodedMessage];
-  XCTAssertEqualObjects(decoded.customRewardString, serverSideVerificationOptions.customRewardString);
+  XCTAssertEqualObjects(decoded.customRewardString,
+                        serverSideVerificationOptions.customRewardString);
   XCTAssertEqualObjects(decoded.userIdentifier, serverSideVerificationOptions.userIdentifier);
 
   // With customRewardString not defined.
@@ -101,7 +103,8 @@
   serverSideVerificationOptions.userIdentifier = @"user-id";
   encodedMessage = [_messageCodec encode:serverSideVerificationOptions];
   decoded = [_messageCodec decode:encodedMessage];
-  XCTAssertEqualObjects(decoded.customRewardString, serverSideVerificationOptions.customRewardString);
+  XCTAssertEqualObjects(decoded.customRewardString,
+                        serverSideVerificationOptions.customRewardString);
   XCTAssertEqualObjects(decoded.userIdentifier, serverSideVerificationOptions.userIdentifier);
 
   // With userId not defined.
@@ -109,14 +112,16 @@
   serverSideVerificationOptions.customRewardString = @"reward";
   encodedMessage = [_messageCodec encode:serverSideVerificationOptions];
   decoded = [_messageCodec decode:encodedMessage];
-  XCTAssertEqualObjects(decoded.customRewardString, serverSideVerificationOptions.customRewardString);
+  XCTAssertEqualObjects(decoded.customRewardString,
+                        serverSideVerificationOptions.customRewardString);
   XCTAssertEqualObjects(decoded.userIdentifier, serverSideVerificationOptions.userIdentifier);
 
   // Both undefined.
   serverSideVerificationOptions = [[FLTServerSideVerificationOptions alloc] init];
   encodedMessage = [_messageCodec encode:serverSideVerificationOptions];
   decoded = [_messageCodec decode:encodedMessage];
-  XCTAssertEqualObjects(decoded.customRewardString, serverSideVerificationOptions.customRewardString);
+  XCTAssertEqualObjects(decoded.customRewardString,
+                        serverSideVerificationOptions.customRewardString);
   XCTAssertEqualObjects(decoded.userIdentifier, serverSideVerificationOptions.userIdentifier);
 }
 

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
@@ -91,8 +91,31 @@
   serverSideVerificationOptions.customRewardString = @"reward";
   serverSideVerificationOptions.userIdentifier = @"user-id";
   NSData *encodedMessage = [_messageCodec encode:serverSideVerificationOptions];
-  
+
   FLTServerSideVerificationOptions *decoded = [_messageCodec decode:encodedMessage];
+  XCTAssertEqualObjects(decoded.customRewardString, serverSideVerificationOptions.customRewardString);
+  XCTAssertEqualObjects(decoded.userIdentifier, serverSideVerificationOptions.userIdentifier);
+
+  // With customRewardString not defined.
+  serverSideVerificationOptions = [[FLTServerSideVerificationOptions alloc] init];
+  serverSideVerificationOptions.userIdentifier = @"user-id";
+  encodedMessage = [_messageCodec encode:serverSideVerificationOptions];
+  decoded = [_messageCodec decode:encodedMessage];
+  XCTAssertEqualObjects(decoded.customRewardString, serverSideVerificationOptions.customRewardString);
+  XCTAssertEqualObjects(decoded.userIdentifier, serverSideVerificationOptions.userIdentifier);
+
+  // With userId not defined.
+  serverSideVerificationOptions = [[FLTServerSideVerificationOptions alloc] init];
+  serverSideVerificationOptions.customRewardString = @"reward";
+  encodedMessage = [_messageCodec encode:serverSideVerificationOptions];
+  decoded = [_messageCodec decode:encodedMessage];
+  XCTAssertEqualObjects(decoded.customRewardString, serverSideVerificationOptions.customRewardString);
+  XCTAssertEqualObjects(decoded.userIdentifier, serverSideVerificationOptions.userIdentifier);
+
+  // Both undefined.
+  serverSideVerificationOptions = [[FLTServerSideVerificationOptions alloc] init];
+  encodedMessage = [_messageCodec encode:serverSideVerificationOptions];
+  decoded = [_messageCodec decode:encodedMessage];
   XCTAssertEqualObjects(decoded.customRewardString, serverSideVerificationOptions.customRewardString);
   XCTAssertEqualObjects(decoded.userIdentifier, serverSideVerificationOptions.userIdentifier);
 }

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
@@ -86,6 +86,17 @@
   XCTAssertEqualObjects(decodedItem.type, @"apple");
 }
 
+- (void)testEncodeDecodeServerSideVerification {
+  FLTServerSideVerificationOptions *serverSideVerificationOptions = [[FLTServerSideVerificationOptions alloc] init];
+  serverSideVerificationOptions.customRewardString = @"reward";
+  serverSideVerificationOptions.userIdentifier = @"user-id";
+  NSData *encodedMessage = [_messageCodec encode:serverSideVerificationOptions];
+  
+  FLTServerSideVerificationOptions *decoded = [_messageCodec decode:encodedMessage];
+  XCTAssertEqualObjects(decoded.customRewardString, serverSideVerificationOptions.customRewardString);
+  XCTAssertEqualObjects(decoded.userIdentifier, serverSideVerificationOptions.userIdentifier);
+}
+
 - (void)testEncodeDecodeLoadAdError {
   FLTLoadAdError *error = [[FLTLoadAdError alloc] initWithCode:@(1)
                                                         domain:@"domain"

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsTest.m
@@ -174,14 +174,14 @@
 - (void)testLoadRewardedAd {
   FLTAdRequest *request = [[FLTAdRequest alloc] init];
   request.keywords = @[ @"apple" ];
-  FLTServerSideVerificationOptions *serverSideVerificationOptions = [[FLTServerSideVerificationOptions alloc] init];
+  FLTServerSideVerificationOptions *serverSideVerificationOptions =
+      [[FLTServerSideVerificationOptions alloc] init];
   serverSideVerificationOptions.customRewardString = @"reward";
   serverSideVerificationOptions.userIdentifier = @"user-id";
-  FLTRewardedAd *ad =
-      [[FLTRewardedAd alloc] initWithAdUnitId:@"testId"
-                                      request:request
-                           rootViewController:OCMClassMock([UIViewController class])
-                serverSideVerificationOptions:serverSideVerificationOptions];
+  FLTRewardedAd *ad = [[FLTRewardedAd alloc] initWithAdUnitId:@"testId"
+                                                      request:request
+                                           rootViewController:OCMClassMock([UIViewController class])
+                                serverSideVerificationOptions:serverSideVerificationOptions];
 
   FLTRewardedAd *mockFltAd = OCMPartialMock(ad);
   GADRewardedAd *mockRewardedAd = OCMClassMock([GADRewardedAd class]);
@@ -198,11 +198,10 @@
 - (void)testShowRewardedAd {
   FLTAdRequest *request = [[FLTAdRequest alloc] init];
   request.keywords = @[ @"apple" ];
-  FLTRewardedAd *ad =
-      [[FLTRewardedAd alloc] initWithAdUnitId:@"testId"
-                                      request:request
-                           rootViewController:OCMClassMock([UIViewController class])
-                serverSideVerificationOptions:nil];
+  FLTRewardedAd *ad = [[FLTRewardedAd alloc] initWithAdUnitId:@"testId"
+                                                      request:request
+                                           rootViewController:OCMClassMock([UIViewController class])
+                                serverSideVerificationOptions:nil];
 
   FLTRewardedAd *mockFltAd = OCMPartialMock(ad);
   GADRewardedAd *mockRewardedAd = OCMClassMock([GADRewardedAd class]);
@@ -216,11 +215,10 @@
 - (void)testLoadRewardedAdWithPublisherRequest {
   FLTPublisherAdRequest *request = [[FLTPublisherAdRequest alloc] init];
   request.keywords = @[ @"apple" ];
-  FLTRewardedAd *ad =
-      [[FLTRewardedAd alloc] initWithAdUnitId:@"testId"
-                                      request:request
-                           rootViewController:OCMClassMock([UIViewController class])
-                serverSideVerificationOptions:nil];
+  FLTRewardedAd *ad = [[FLTRewardedAd alloc] initWithAdUnitId:@"testId"
+                                                      request:request
+                                           rootViewController:OCMClassMock([UIViewController class])
+                                serverSideVerificationOptions:nil];
 
   FLTRewardedAd *mockFltAd = OCMPartialMock(ad);
   GADRewardedAd *mockRewardedAd = OCMClassMock([GADRewardedAd class]);
@@ -454,11 +452,10 @@
 }
 
 - (void)testOnRewardedAdUserEarnedReward {
-  FLTRewardedAd *ad =
-      [[FLTRewardedAd alloc] initWithAdUnitId:@"testId"
-                                      request:[[FLTAdRequest alloc] init]
-                           rootViewController:OCMClassMock([UIViewController class])
-                serverSideVerificationOptions:nil];
+  FLTRewardedAd *ad = [[FLTRewardedAd alloc] initWithAdUnitId:@"testId"
+                                                      request:[[FLTAdRequest alloc] init]
+                                           rootViewController:OCMClassMock([UIViewController class])
+                                serverSideVerificationOptions:nil];
   [_manager loadAd:ad adId:@(1)];
 
   [_manager onRewardedAdUserEarnedReward:ad

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsTest.m
@@ -174,10 +174,14 @@
 - (void)testLoadRewardedAd {
   FLTAdRequest *request = [[FLTAdRequest alloc] init];
   request.keywords = @[ @"apple" ];
+  FLTServerSideVerificationOptions *serverSideVerificationOptions = [[FLTServerSideVerificationOptions alloc] init];
+  serverSideVerificationOptions.customRewardString = @"reward";
+  serverSideVerificationOptions.userIdentifier = @"user-id";
   FLTRewardedAd *ad =
       [[FLTRewardedAd alloc] initWithAdUnitId:@"testId"
                                       request:request
-                           rootViewController:OCMClassMock([UIViewController class])];
+                           rootViewController:OCMClassMock([UIViewController class])
+                serverSideVerificationOptions:serverSideVerificationOptions];
 
   FLTRewardedAd *mockFltAd = OCMPartialMock(ad);
   GADRewardedAd *mockRewardedAd = OCMClassMock([GADRewardedAd class]);
@@ -197,7 +201,8 @@
   FLTRewardedAd *ad =
       [[FLTRewardedAd alloc] initWithAdUnitId:@"testId"
                                       request:request
-                           rootViewController:OCMClassMock([UIViewController class])];
+                           rootViewController:OCMClassMock([UIViewController class])
+                serverSideVerificationOptions:nil];
 
   FLTRewardedAd *mockFltAd = OCMPartialMock(ad);
   GADRewardedAd *mockRewardedAd = OCMClassMock([GADRewardedAd class]);
@@ -214,7 +219,8 @@
   FLTRewardedAd *ad =
       [[FLTRewardedAd alloc] initWithAdUnitId:@"testId"
                                       request:request
-                           rootViewController:OCMClassMock([UIViewController class])];
+                           rootViewController:OCMClassMock([UIViewController class])
+                serverSideVerificationOptions:nil];
 
   FLTRewardedAd *mockFltAd = OCMPartialMock(ad);
   GADRewardedAd *mockRewardedAd = OCMClassMock([GADRewardedAd class]);
@@ -451,7 +457,8 @@
   FLTRewardedAd *ad =
       [[FLTRewardedAd alloc] initWithAdUnitId:@"testId"
                                       request:[[FLTAdRequest alloc] init]
-                           rootViewController:OCMClassMock([UIViewController class])];
+                           rootViewController:OCMClassMock([UIViewController class])
+                serverSideVerificationOptions:nil];
   [_manager loadAd:ad adId:@(1)];
 
   [_manager onRewardedAdUserEarnedReward:ad

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -695,10 +695,10 @@ class RewardItem {
 /// https://developers.google.com/admob/android/rewarded-video-ssv for more
 /// information.
 class ServerSideVerificationOptions {
-  /// The user id.
+  /// The user id to be used in server-to-server reward callbacks.
   final String? userId;
 
-  /// Custom data.
+  /// The custom data to be used in server-to-server reward callbacks
   final String? customData;
 
   /// Create [ServerSideVerificationOptions] with the userId or customData.

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -695,12 +695,10 @@ class RewardItem {
 class ServerSideVerificationOptions {
   /// The user id.
   final String userId;
+
   /// Custom data.
   final String customData;
 
   /// Create [ServerSideVerificationOptions] with the userId or customData.
-  ServerSideVerificationOptions({
-    this.userId,
-    this.customData
-  });
+  ServerSideVerificationOptions({this.userId, this.customData});
 }

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -666,7 +666,7 @@ class RewardedAd extends AdWithoutView {
       : 'ca-app-pub-3940256099942544/1712485313';
 
   /// Optional [ServerSideVerificationOptions].
-  final ServerSideVerificationOptions serverSideVerificationOptions;
+  final ServerSideVerificationOptions? serverSideVerificationOptions;
 
   @override
   Future<void> load() async {
@@ -694,11 +694,19 @@ class RewardItem {
 /// information.
 class ServerSideVerificationOptions {
   /// The user id.
-  final String userId;
+  final String? userId;
 
   /// Custom data.
-  final String customData;
+  final String? customData;
 
   /// Create [ServerSideVerificationOptions] with the userId or customData.
   ServerSideVerificationOptions({this.userId, this.customData});
+
+
+  @override
+  bool operator ==(other) {
+    return other is ServerSideVerificationOptions
+      && userId == other.userId
+      && customData == other.customData;
+  }
 }

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -690,6 +690,7 @@ class RewardItem {
 }
 
 /// Options for RewardedAd server-side verification callbacks.
+///
 /// See https://developers.google.com/admob/ios/rewarded-video-ssv and
 /// https://developers.google.com/admob/android/rewarded-video-ssv for more
 /// information.

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -703,11 +703,10 @@ class ServerSideVerificationOptions {
   /// Create [ServerSideVerificationOptions] with the userId or customData.
   ServerSideVerificationOptions({this.userId, this.customData});
 
-
   @override
   bool operator ==(other) {
-    return other is ServerSideVerificationOptions
-      && userId == other.userId
-      && customData == other.customData;
+    return other is ServerSideVerificationOptions &&
+        userId == other.userId &&
+        customData == other.customData;
   }
 }

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -690,7 +690,8 @@ class RewardItem {
 }
 
 /// Options for RewardedAd server-side verification callbacks.
-/// See https://developers.google.com/admob/android/rewarded-video-ssv for more
+/// See https://developers.google.com/admob/ios/rewarded-video-ssv and
+/// https://developers.google.com/admob/android/rewarded-video-ssv for more
 /// information.
 class ServerSideVerificationOptions {
   /// The user id.

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -633,7 +633,8 @@ class RewardedAd extends AdWithoutView {
     required String adUnitId,
     required AdListener listener,
     required this.request,
-  })   : publisherRequest = null,
+    this.serverSideVerificationOptions,
+  })  : publisherRequest = null,
         super(adUnitId: adUnitId, listener: listener);
 
   /// Creates a [RewardedAd] with a [PublisherAdRequest].
@@ -643,7 +644,8 @@ class RewardedAd extends AdWithoutView {
     required String adUnitId,
     required AdListener listener,
     required this.publisherRequest,
-  })   : request = null,
+    this.serverSideVerificationOptions,
+  })  : request = null,
         super(adUnitId: adUnitId, listener: listener);
 
   /// Targeting information used to fetch an [Ad].
@@ -662,6 +664,9 @@ class RewardedAd extends AdWithoutView {
   static final String testAdUnitId = Platform.isAndroid
       ? 'ca-app-pub-3940256099942544/5224354917'
       : 'ca-app-pub-3940256099942544/1712485313';
+
+  /// Optional [ServerSideVerificationOptions].
+  final ServerSideVerificationOptions serverSideVerificationOptions;
 
   @override
   Future<void> load() async {
@@ -682,4 +687,20 @@ class RewardItem {
 
   /// Type of credit rewarded.
   final String type;
+}
+
+/// Options for RewardedAd server-side verification callbacks.
+/// See https://developers.google.com/admob/android/rewarded-video-ssv for more
+/// information.
+class ServerSideVerificationOptions {
+  /// The user id.
+  final String userId;
+  /// Custom data.
+  final String customData;
+
+  /// Create [ServerSideVerificationOptions] with the userId or customData.
+  ServerSideVerificationOptions({
+    this.userId,
+    this.customData
+  });
 }

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -196,7 +196,7 @@ class AdInstanceManager {
         'request': ad.request,
         'publisherRequest': ad.publisherRequest,
         'serverSideVerificationOptions':
-          ad.serverSideVerificationOptions,
+            ad.serverSideVerificationOptions,
       },
     );
   }

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -195,8 +195,7 @@ class AdInstanceManager {
         'adUnitId': ad.adUnitId,
         'request': ad.request,
         'publisherRequest': ad.publisherRequest,
-        'serverSideVerificationOptions':
-            ad.serverSideVerificationOptions,
+        'serverSideVerificationOptions': ad.serverSideVerificationOptions,
       },
     );
   }

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -419,6 +419,10 @@ class AdMessageCodec extends StandardMessageCodec {
           readValueOfType(buffer.getUint8(), buffer)
               .cast<String, AdapterStatus>(),
         );
+      case _valueServerSideVerificationOptions:
+        return ServerSideVerificationOptions(
+            userId: readValueOfType(buffer.getUint8(), buffer),
+            customData: readValueOfType(buffer.getUint8(), buffer));
       default:
         return super.readValueOfType(type, buffer);
     }

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -195,6 +195,8 @@ class AdInstanceManager {
         'adUnitId': ad.adUnitId,
         'request': ad.request,
         'publisherRequest': ad.publisherRequest,
+        'serverSideVerificationOptions':
+          ad.serverSideVerificationOptions,
       },
     );
   }
@@ -303,6 +305,7 @@ class AdMessageCodec extends StandardMessageCodec {
   static const int _valueInitializationState = 135;
   static const int _valueAdapterStatus = 136;
   static const int _valueInitializationStatus = 137;
+  static const int _valueServerSideVerificationOptions = 138;
 
   @override
   void writeValue(WriteBuffer buffer, dynamic value) {
@@ -343,6 +346,10 @@ class AdMessageCodec extends StandardMessageCodec {
     } else if (value is InitializationStatus) {
       buffer.putUint8(_valueInitializationStatus);
       writeValue(buffer, value.adapterStatuses);
+    } else if (value is ServerSideVerificationOptions) {
+      buffer.putUint8(_valueServerSideVerificationOptions);
+      writeValue(buffer, value.userId);
+      writeValue(buffer, value.customData);
     } else {
       super.writeValue(buffer, value);
     }

--- a/packages/google_mobile_ads/pubspec.yaml
+++ b/packages/google_mobile_ads/pubspec.yaml
@@ -16,7 +16,7 @@ name: google_mobile_ads
 description: Flutter plugin for Google Mobile Ads, supporting
   banner, interstitial (full-screen),  rewarded and native ads
 homepage: https://github.com/googleads/googleads-mobile-flutter/tree/master/packages/google_mobile_ads
-version: 0.12.0+1
+version: 0.12.1
 
 flutter:
   plugin:

--- a/packages/google_mobile_ads/pubspec.yaml
+++ b/packages/google_mobile_ads/pubspec.yaml
@@ -16,7 +16,7 @@ name: google_mobile_ads
 description: Flutter plugin for Google Mobile Ads, supporting
   banner, interstitial (full-screen),  rewarded and native ads
 homepage: https://github.com/googleads/googleads-mobile-flutter/tree/master/packages/google_mobile_ads
-version: 0.12.0
+version: 0.12.0+1
 
 flutter:
   plugin:

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -388,14 +388,13 @@ void main() {
 
     test('load rewarded', () async {
       final RewardedAd rewarded = RewardedAd(
-        adUnitId: RewardedAd.testAdUnitId,
-        listener: AdListener(),
-        request: AdRequest(),
-        serverSideVerificationOptions: ServerSideVerificationOptions(
-          userId: 'test-user-id',
-          customData: 'test-custom-data',
-        )
-      );
+          adUnitId: RewardedAd.testAdUnitId,
+          listener: AdListener(),
+          request: AdRequest(),
+          serverSideVerificationOptions: ServerSideVerificationOptions(
+            userId: 'test-user-id',
+            customData: 'test-custom-data',
+          ));
 
       await rewarded.load();
 
@@ -405,7 +404,8 @@ void main() {
           'adUnitId': RewardedAd.testAdUnitId,
           'request': rewarded.request,
           'publisherRequest': null,
-          'serverSideVerificationOptions': rewarded.serverSideVerificationOptions,
+          'serverSideVerificationOptions':
+              rewarded.serverSideVerificationOptions,
         }),
       ]);
 
@@ -431,7 +431,8 @@ void main() {
           'adUnitId': RewardedAd.testAdUnitId,
           'request': null,
           'publisherRequest': rewarded.publisherRequest,
-          'serverSideVerificationOptions': rewarded.serverSideVerificationOptions,
+          'serverSideVerificationOptions':
+              rewarded.serverSideVerificationOptions,
         }),
       ]);
 

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -391,6 +391,10 @@ void main() {
         adUnitId: RewardedAd.testAdUnitId,
         listener: AdListener(),
         request: AdRequest(),
+        serverSideVerificationOptions: ServerSideVerificationOptions(
+          userId: 'test-user-id',
+          customData: 'test-custom-data',
+        )
       );
 
       await rewarded.load();
@@ -401,6 +405,7 @@ void main() {
           'adUnitId': RewardedAd.testAdUnitId,
           'request': rewarded.request,
           'publisherRequest': null,
+          'serverSideVerificationOptions': rewarded.serverSideVerificationOptions,
         }),
       ]);
 
@@ -412,6 +417,10 @@ void main() {
         adUnitId: RewardedAd.testAdUnitId,
         listener: AdListener(),
         publisherRequest: PublisherAdRequest(),
+        serverSideVerificationOptions: ServerSideVerificationOptions(
+          userId: 'test-user-id',
+          customData: 'test-custom-data',
+        ),
       );
 
       await rewarded.load();
@@ -422,6 +431,7 @@ void main() {
           'adUnitId': RewardedAd.testAdUnitId,
           'request': null,
           'publisherRequest': rewarded.publisherRequest,
+          'serverSideVerificationOptions': rewarded.serverSideVerificationOptions,
         }),
       ]);
 


### PR DESCRIPTION
## Description

Adds support for [custom data](https://developers.google.com/admob/ios/rewarded-video-ssv#custom_data) rewarded APIs. 

## Related Issues

https://github.com/googleads/googleads-mobile-flutter/issues/72

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.