### PR TITLE
Remove fixed version number for Google-Mobile-Ads-SDK due incompatibilities with Firebase packages

### DIFF
--- a/packages/google_mobile_ads/ios/google_mobile_ads.podspec
+++ b/packages/google_mobile_ads/ios/google_mobile_ads.podspec
@@ -15,7 +15,7 @@ Google Mobile Ads plugin for Flutter.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'Google-Mobile-Ads-SDK','7.69.0'
+  s.dependency 'Google-Mobile-Ads-SDK'
   s.ios.deployment_target = '9.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS' => 'armv7 arm64 x86_64' }
   s.static_framework = true


### PR DESCRIPTION
## Description

Google Mobile Ads is currently not compatible with packages like `firebase_core` because of different versions of Google-Mobile-Ads-SDK. 

Therefore this pull request removes the fixed version number for Google-Mobile-Ads-SDK in the `google_mobile_ads.podspec` for iOS.

## Related Issues

These are our current incompatible flutter dependencies with firebase and google mobile ads from the `pubspec.yaml`:

```
dependencies:
  firebase_core: ^1.0.3
  firebase_crashlytics: ^2.0.0
  firebase_messaging: ^9.1.1
  google_mobile_ads: ^0.12.1
```

When trying to get the iOS dependencies via `pod install`, an error appears:

```
[!] CocoaPods could not find compatible versions for pod "nanopb":
  In Podfile:
    firebase_core (from `.symlinks/plugins/firebase_core/ios`) was resolved to 1.0.3, which depends on
      Firebase/CoreOnly (= 6.33.0) was resolved to 6.33.0, which depends on
        FirebaseCore (= 6.10.3) was resolved to 6.10.3, which depends on
          FirebaseCoreDiagnostics (~> 1.6) was resolved to 1.7.0, which depends on
            nanopb (~> 1.30906.0)

    google_mobile_ads (from `.symlinks/plugins/google_mobile_ads/ios`) was resolved to 0.0.1, which depends on
      Google-Mobile-Ads-SDK (= 7.69.0) was resolved to 7.69.0, which depends on
        GoogleAppMeasurement (~> 7.0) was resolved to 7.3.0, which depends on
          nanopb (~> 2.30906.0)
```

As you can see, there are two different versions from `nanopb`. It's working when removing the fix version number `7.69.0` from the `google_mobile_ads.podspec`.


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
