### PR TITLE
Fix Swift Native Ads Crash

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.1+1
+
+* Fixes a [crash with Swift based native ads](https://github.com/googleads/googleads-mobile-flutter/issues/121)
+
 ## 0.12.1
 
 * Rewarded ads now take an optional `ServerSideVerification`, to support [custom data in rewarded ads](https://developers.google.com/admob/ios/rewarded-video-ssv#custom_data).

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
@@ -17,5 +17,5 @@ package io.flutter.plugins.googlemobileads;
 /** Constants used in the plugin. */
 public class Constants {
   /** Version request agent. Should be bumped alongside plugin versions. */
-  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-0.12.1";
+  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-0.12.1+1";
 }

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
@@ -429,7 +429,10 @@
 }
 
 - (void)adLoader:(GADAdLoader *)adLoader didReceiveUnifiedNativeAd:(GADUnifiedNativeAd *)nativeAd {
-  _view = [_nativeAdFactory createNativeAd:nativeAd customOptions:_customOptions];
+  // Use Nil instead of Null to fix crash with Swift integrations.
+  NSDictionary<NSString *, id> *customOptions =
+      [[NSNull null] isEqual:_customOptions] ? nil : _customOptions;
+  _view = [_nativeAdFactory createNativeAd:nativeAd customOptions:customOptions];
   nativeAd.delegate = self;
   [_manager onAdLoaded:self];
 }

--- a/packages/google_mobile_ads/ios/Classes/FLTConstants.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTConstants.h
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /** Versioned request agent string. */
-#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-0.12.1"
+#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-0.12.1+1"

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsTest.m
@@ -153,12 +153,13 @@
 - (void)testLoadNativeAd {
   FLTAdRequest *request = [[FLTAdRequest alloc] init];
   request.keywords = @[ @"apple" ];
-  FLTNativeAd *ad =
-      [[FLTNativeAd alloc] initWithAdUnitId:@"testAdUnitId"
-                                    request:request
-                            nativeAdFactory:OCMProtocolMock(@protocol(FLTNativeAdFactory))
-                              customOptions:nil
-                         rootViewController:OCMClassMock([UIViewController class])];
+  id mockNativeAdFactory = OCMProtocolMock(@protocol(FLTNativeAdFactory));
+
+  FLTNativeAd *ad = [[FLTNativeAd alloc] initWithAdUnitId:@"testAdUnitId"
+                                                  request:request
+                                          nativeAdFactory:mockNativeAdFactory
+                                            customOptions:[NSNull null]
+                                       rootViewController:OCMClassMock([UIViewController class])];
 
   FLTNativeAd *mockNativeAd = OCMPartialMock(ad);
   GADAdLoader *mockLoader = OCMClassMock([GADAdLoader class]);
@@ -169,6 +170,11 @@
                           GADRequest *requestArg = obj;
                           return [requestArg.keywords isEqualToArray:@[ @"apple" ]];
                         }]]);
+
+  // Check that nil is used instead of null when customOptions is Null
+  GADUnifiedNativeAd *mockUnifiedNativeAd = OCMClassMock([GADUnifiedNativeAd class]);
+  [ad adLoader:mockLoader didReceiveUnifiedNativeAd:mockUnifiedNativeAd];
+  OCMVerify([mockNativeAdFactory createNativeAd:mockUnifiedNativeAd customOptions:[OCMArg isNil]]);
 }
 
 - (void)testLoadRewardedAd {

--- a/packages/google_mobile_ads/pubspec.yaml
+++ b/packages/google_mobile_ads/pubspec.yaml
@@ -16,7 +16,7 @@ name: google_mobile_ads
 description: Flutter plugin for Google Mobile Ads, supporting
   banner, interstitial (full-screen),  rewarded and native ads
 homepage: https://github.com/googleads/googleads-mobile-flutter/tree/master/packages/google_mobile_ads
-version: 0.12.1
+version: 0.12.1+1
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Fixes a crash for Swift implementations of `FLTNativeAdFactory`. Passing Null for customOptions causes a runtime exception. This is fixed by directly passing `nil` instead.

## Related Issues

https://github.com/googleads/googleads-mobile-flutter/issues/121

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.