### PR TITLE
Support Same App Key API for IOS

### DIFF
--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
@@ -104,6 +104,10 @@
   } else if ([call.method isEqualToString:@"_init"]) {
     [_manager disposeAllAds];
     result(nil);
+  } else if ([call.method isEqualToString:@"MobileAds#setSameAppKeyEnabled"]) {
+    GADRequestConfiguration *requestConfig = GADMobileAds.sharedInstance.requestConfiguration;
+    [requestConfig setSameAppKeyEnabled:call.arguments[@"isEnabled"]];
+    result(nil);
   } else if ([call.method isEqualToString:@"MobileAds#updateRequestConfiguration"]) {
     NSString *maxAdContentRating = call.arguments[@"maxAdContentRating"];
     NSNumber *tagForChildDirectedTreatment = call.arguments[@"tagForChildDirectedTreatment"];

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
@@ -116,4 +116,29 @@
   OCMVerify([_mockAdInstanceManager disposeAllAds]);
 }
 
+- (void)testSetSameAppKeyEnabled {
+  id gadMobileAdsClassMock = OCMClassMock([GADMobileAds class]);
+  OCMStub(ClassMethod([gadMobileAdsClassMock sharedInstance]))
+    .andReturn((GADMobileAds *)gadMobileAdsClassMock);
+  GADRequestConfiguration *gadRequestConfigurationMock = OCMClassMock([GADRequestConfiguration class]);
+  OCMStub([gadMobileAdsClassMock requestConfiguration])
+    .andReturn(gadRequestConfigurationMock);
+  
+  FlutterMethodCall *methodCall = [FlutterMethodCall methodCallWithMethodName:@"MobileAds#setSameAppKeyEnabled"
+                                                                    arguments:@{@"isEnabled" : @(YES)}];
+
+  __block bool resultInvoked = false;
+  __block id _Nullable returnedResult;
+  FlutterResult result = ^(id _Nullable result) {
+    resultInvoked = true;
+    returnedResult = result;
+  };
+
+  [_fltGoogleMobileAdsPlugin handleMethodCall:methodCall result:result];
+
+  XCTAssertTrue(resultInvoked);
+  XCTAssertNil(returnedResult);
+  OCMVerify([gadRequestConfigurationMock setSameAppKeyEnabled:[OCMArg isEqual:@(YES)]]);
+}
+
 @end

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -393,6 +393,16 @@ class AdInstanceManager {
       },
     );
   }
+
+  /// Set whether same app key is enabled.
+  Future<void> setSameAppKeyEnabled(bool isEnabled) {
+    return channel.invokeMethod<void>(
+      'MobileAds#setSameAppKeyEnabled',
+      <dynamic, dynamic>{
+        'isEnabled': isEnabled,
+      },
+    );
+  }
 }
 
 class AdMessageCodec extends StandardMessageCodec {

--- a/packages/google_mobile_ads/lib/src/mobile_ads.dart
+++ b/packages/google_mobile_ads/lib/src/mobile_ads.dart
@@ -14,6 +14,7 @@
 
 import 'ad_instance_manager.dart';
 import 'request_configuration.dart';
+import 'package:flutter/foundation.dart';
 
 /// The initialization state of the mediation adapter.
 enum AdapterInitializationState {
@@ -54,6 +55,18 @@ class MobileAds {
   Future<void> updateRequestConfiguration(
       RequestConfiguration requestConfiguration) {
     return instanceManager.updateRequestConfiguration(requestConfiguration);
+  }
+
+  /// Set whether the Google Mobile Ads SDK Same App Key is enabled.
+  ///
+  /// The value set persists across app sessions. The key is enabled by default.
+  /// Note this is a no-op on Android.
+  Future<void> setSameAppKeyEnabled(bool isEnabled) {
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      return instanceManager.setSameAppKeyEnabled(isEnabled);
+    } else {
+      return Future.value();
+    }
   }
 
   /// Internal init to cleanup state for hot restart.

--- a/packages/google_mobile_ads/lib/src/mobile_ads.dart
+++ b/packages/google_mobile_ads/lib/src/mobile_ads.dart
@@ -57,10 +57,12 @@ class MobileAds {
     return instanceManager.updateRequestConfiguration(requestConfiguration);
   }
 
-  /// Set whether the Google Mobile Ads SDK Same App Key is enabled.
+  /// Set whether the Google Mobile Ads SDK Same App Key is enabled (iOS only).
   ///
   /// The value set persists across app sessions. The key is enabled by default.
-  /// Note this is a no-op on Android.
+  /// This is a no-op on Android.
+  /// More documentation on same app key is available at
+  /// https://developers.google.com/admob/ios/global-settings#same_app_key.
   Future<void> setSameAppKeyEnabled(bool isEnabled) {
     if (defaultTargetPlatform == TargetPlatform.iOS) {
       return instanceManager.setSameAppKeyEnabled(isEnabled);

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -36,6 +36,7 @@ void main() {
         log.add(methodCall);
         switch (methodCall.method) {
           case 'MobileAds#updateRequestConfiguration':
+          case 'MobileAds#setSameAppKeyEnabled':
           case 'loadBannerAd':
           case 'loadNativeAd':
           case 'showAdWithoutView':
@@ -66,6 +67,31 @@ void main() {
               'tagForChildDirectedTreatment': TagForChildDirectedTreatment.yes,
               'tagForUnderAgeOfConsent': TagForUnderAgeOfConsent.yes,
               'testDeviceIds': <String>['test-device-id'],
+            })
+      ]);
+    });
+
+
+    test('setSameAppKeyEnabled', () async {
+      await instanceManager.setSameAppKeyEnabled(true);
+
+      expect(log, <Matcher>[
+        isMethodCall('MobileAds#setSameAppKeyEnabled',
+            arguments: <String, dynamic>{
+              'isEnabled': true,
+            })
+      ]);
+
+      await instanceManager.setSameAppKeyEnabled(false);
+
+      expect(log, <Matcher>[
+        isMethodCall('MobileAds#setSameAppKeyEnabled',
+            arguments: <String, dynamic>{
+              'isEnabled': true,
+            }),
+        isMethodCall('MobileAds#setSameAppKeyEnabled',
+            arguments: <String, dynamic>{
+              'isEnabled': false,
             })
       ]);
     });

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -71,7 +71,6 @@ void main() {
       ]);
     });
 
-
     test('setSameAppKeyEnabled', () async {
       await instanceManager.setSameAppKeyEnabled(true);
 

--- a/packages/google_mobile_ads/test/mobile_ads_test.dart
+++ b/packages/google_mobile_ads/test/mobile_ads_test.dart
@@ -47,6 +47,8 @@ void main() {
             });
           case '_init':
             return null;
+          case 'MobileAds#setSameAppKeyEnabled':
+            return null;
           default:
             assert(false);
             return null;
@@ -128,6 +130,21 @@ void main() {
       expect(status.state, AdapterInitializationState.notReady);
       expect(status.description, 'desc');
       expect(status.latency, 0);
+    });
+
+    test('$MobileAds.setSameAppKeyEnabled', () async {
+      await MobileAds.instance.setSameAppKeyEnabled(true);
+
+      expect(log, <Matcher>[
+        isMethodCall('MobileAds#setSameAppKeyEnabled', arguments: {'isEnabled': true})
+      ]);
+
+      await MobileAds.instance.setSameAppKeyEnabled(false);
+
+      expect(log, <Matcher>[
+        isMethodCall('MobileAds#setSameAppKeyEnabled', arguments: {'isEnabled': true}),
+        isMethodCall('MobileAds#setSameAppKeyEnabled', arguments: {'isEnabled': false})
+      ]);
     });
   });
 }

--- a/packages/google_mobile_ads/test/mobile_ads_test.dart
+++ b/packages/google_mobile_ads/test/mobile_ads_test.dart
@@ -136,14 +136,17 @@ void main() {
       await MobileAds.instance.setSameAppKeyEnabled(true);
 
       expect(log, <Matcher>[
-        isMethodCall('MobileAds#setSameAppKeyEnabled', arguments: {'isEnabled': true})
+        isMethodCall('MobileAds#setSameAppKeyEnabled',
+            arguments: {'isEnabled': true})
       ]);
 
       await MobileAds.instance.setSameAppKeyEnabled(false);
 
       expect(log, <Matcher>[
-        isMethodCall('MobileAds#setSameAppKeyEnabled', arguments: {'isEnabled': true}),
-        isMethodCall('MobileAds#setSameAppKeyEnabled', arguments: {'isEnabled': false})
+        isMethodCall('MobileAds#setSameAppKeyEnabled',
+            arguments: {'isEnabled': true}),
+        isMethodCall('MobileAds#setSameAppKeyEnabled',
+            arguments: {'isEnabled': false})
       ]);
     });
   });


### PR DESCRIPTION
## Description

Add support for the [same app key](https://developers.google.com/admob/ios/global-settings#same_app_key) API on iOS.

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

