### PR TITLE
Major version changes - response info

### DIFF
--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdInstanceManager.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdInstanceManager.java
@@ -18,9 +18,12 @@ import android.app.Activity;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.gms.ads.AdError;
+import com.google.android.gms.ads.ResponseInfo;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.StandardMethodCodec;
+import io.flutter.plugins.googlemobileads.FlutterAd.FlutterAdError;
+import io.flutter.plugins.googlemobileads.FlutterAd.FlutterResponseInfo;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -93,10 +96,11 @@ class AdInstanceManager {
     ads.clear();
   }
 
-  void onAdLoaded(@NonNull FlutterAd ad) {
+  void onAdLoaded(@NonNull FlutterAd ad, ResponseInfo responseInfo) {
     Map<Object, Object> arguments = new HashMap<>();
     arguments.put("adId", adIdFor(ad));
     arguments.put("eventName", "onAdLoaded");
+    arguments.put("responseInfo", new FlutterResponseInfo(responseInfo));
     channel.invokeMethod("onAdEvent", arguments);
   }
 
@@ -158,7 +162,7 @@ class AdInstanceManager {
     final Map<Object, Object> arguments = new HashMap<>();
     arguments.put("adId", adIdFor(ad));
     arguments.put("eventName", "onFailedToShowFullScreenContent");
-    arguments.put("error", error);
+    arguments.put("error", new FlutterAdError(error));
     channel.invokeMethod("onAdEvent", arguments);
   }
 

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdInstanceManager.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdInstanceManager.java
@@ -96,11 +96,14 @@ class AdInstanceManager {
     ads.clear();
   }
 
-  void onAdLoaded(@NonNull FlutterAd ad, ResponseInfo responseInfo) {
+  void onAdLoaded(@NonNull FlutterAd ad, @Nullable ResponseInfo responseInfo) {
     Map<Object, Object> arguments = new HashMap<>();
     arguments.put("adId", adIdFor(ad));
     arguments.put("eventName", "onAdLoaded");
-    arguments.put("responseInfo", new FlutterResponseInfo(responseInfo));
+    FlutterResponseInfo flutterResponseInfo = (responseInfo == null)
+        ? null
+        : new FlutterResponseInfo(responseInfo);
+    arguments.put("responseInfo", flutterResponseInfo);
     channel.invokeMethod("onAdEvent", arguments);
   }
 

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAd.java
@@ -40,7 +40,7 @@ abstract class FlutterAd {
     FlutterResponseInfo(@NonNull ResponseInfo responseInfo) {
       this.responseId = responseInfo.getResponseId();
       this.mediationAdapterClassName = responseInfo.getMediationAdapterClassName();
-      List<FlutterAdapterResponseInfo> adapterResponseInfos = new ArrayList<>();
+      final List<FlutterAdapterResponseInfo> adapterResponseInfos = new ArrayList<>();
       for (AdapterResponseInfo adapterInfo: responseInfo.getAdapterResponses()) {
         adapterResponseInfos.add(new FlutterAdapterResponseInfo(adapterInfo));
       }
@@ -226,7 +226,7 @@ abstract class FlutterAd {
       message = error.getMessage();
 
       if (error.getResponseInfo() != null) {
-        List<FlutterAdapterResponseInfo> adapterResponseInfos = new ArrayList<>();
+        final List<FlutterAdapterResponseInfo> adapterResponseInfos = new ArrayList<>();
         for (AdapterResponseInfo adapterInfo: error.getResponseInfo().getAdapterResponses()) {
           adapterResponseInfos.add(new FlutterAdapterResponseInfo(adapterInfo));
         }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAd.java
@@ -98,21 +98,27 @@ abstract class FlutterAd {
     private final long latencyMillis;
     @NonNull private final String description;
     @NonNull private final String credentials;
-    @Nullable private final FlutterAdError error;
+    @Nullable private FlutterAdError error;
 
     FlutterAdapterResponseInfo(@NonNull AdapterResponseInfo responseInfo) {
       this.adapterClassName = responseInfo.getAdapterClassName();
       this.latencyMillis = responseInfo.getLatencyMillis();
       this.description = responseInfo.toString();
-      this.credentials = responseInfo.getCredentials().toString();
-      this.error = new FlutterAdError(responseInfo.getAdError());
+      if (responseInfo.getCredentials() != null) {
+        this.credentials = responseInfo.getCredentials().toString();
+      } else {
+        credentials = "unknown credentials";
+      }
+      if (responseInfo.getAdError() != null) {
+        this.error = new FlutterAdError(responseInfo.getAdError());
+      }
     }
 
     FlutterAdapterResponseInfo(
       @NonNull String adapterClassName,
       long latencyMillis,
       @NonNull String description,
-      @NonNull String credentials,
+      @Nullable String credentials,
       @Nullable FlutterAdError error
     ) {
       this.adapterClassName = adapterClassName;
@@ -226,14 +232,7 @@ abstract class FlutterAd {
       message = error.getMessage();
 
       if (error.getResponseInfo() != null) {
-        final List<FlutterAdapterResponseInfo> adapterResponseInfos = new ArrayList<>();
-        for (AdapterResponseInfo adapterInfo: error.getResponseInfo().getAdapterResponses()) {
-          adapterResponseInfos.add(new FlutterAdapterResponseInfo(adapterInfo));
-        }
-        responseInfo = new FlutterResponseInfo(
-            error.getResponseInfo().getResponseId(),
-            error.getResponseInfo().getMediationAdapterClassName(),
-            adapterResponseInfos);
+        responseInfo = new FlutterResponseInfo(error.getResponseInfo());
       }
     }
 

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAd.java
@@ -154,7 +154,7 @@ abstract class FlutterAd {
         return false;
       }
 
-      FlutterAdapterResponseInfo that = (FlutterAdapterResponseInfo) obj;
+      final FlutterAdapterResponseInfo that = (FlutterAdapterResponseInfo) obj;
       return Objects.equals(adapterClassName, that.adapterClassName)
           && Objects.equals(latencyMillis, that.latencyMillis)
           && Objects.equals(description, that.description)

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdListener.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdListener.java
@@ -16,14 +16,25 @@ package io.flutter.plugins.googlemobileads;
 import androidx.annotation.NonNull;
 import com.google.android.gms.ads.AdListener;
 import com.google.android.gms.ads.LoadAdError;
+import com.google.android.gms.ads.ResponseInfo;
+
+/** A type for retrieving {@link ResponseInfo} from an ad after it is loaded. */
+interface ResponseInfoProvider {
+  ResponseInfo getResponseInfo();
+}
 
 class FlutterAdListener extends AdListener {
   @NonNull protected final AdInstanceManager manager;
   @NonNull protected final FlutterAd ad;
+  @NonNull protected final ResponseInfoProvider responseInfoProvider;
 
-  FlutterAdListener(@NonNull AdInstanceManager manager, @NonNull FlutterAd ad) {
+  FlutterAdListener(
+      @NonNull AdInstanceManager manager,
+      @NonNull FlutterAd ad,
+      @NonNull ResponseInfoProvider responseInfoProvider) {
     this.manager = manager;
     this.ad = ad;
+    this.responseInfoProvider = responseInfoProvider;
   }
 
   @Override
@@ -43,7 +54,7 @@ class FlutterAdListener extends AdListener {
 
   @Override
   public void onAdLoaded() {
-    manager.onAdLoaded(ad);
+    manager.onAdLoaded(ad, responseInfoProvider.getResponseInfo());
   }
 }
 
@@ -53,8 +64,11 @@ class FlutterAdListener extends AdListener {
  */
 class FlutterBannerAdListener extends FlutterAdListener {
 
-  FlutterBannerAdListener(@NonNull AdInstanceManager manager, @NonNull FlutterAd ad) {
-    super(manager, ad);
+  FlutterBannerAdListener(
+      @NonNull AdInstanceManager manager,
+      @NonNull FlutterAd ad,
+      ResponseInfoProvider responseInfoProvider) {
+    super(manager, ad, responseInfoProvider);
   }
 
   @Override

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerBannerAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerBannerAd.java
@@ -18,6 +18,7 @@ import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.gms.ads.AdSize;
+import com.google.android.gms.ads.ResponseInfo;
 import com.google.android.gms.ads.admanager.AdManagerAdView;
 import com.google.android.gms.ads.admanager.AppEventListener;
 import com.google.android.gms.common.internal.Preconditions;
@@ -76,7 +77,12 @@ class FlutterAdManagerBannerAd extends FlutterAd implements PlatformView, Flutte
       allSizes[i] = sizes.get(i).getAdSize();
     }
     view.setAdSizes(allSizes);
-    view.setAdListener(new FlutterBannerAdListener(manager, this));
+    view.setAdListener(new FlutterBannerAdListener(manager, this, new ResponseInfoProvider() {
+      @Override
+      public ResponseInfo getResponseInfo() {
+        return view.getResponseInfo();
+      }
+    }));
     view.loadAd(request.asAdManagerAdRequest());
   }
 

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerInterstitialAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerInterstitialAd.java
@@ -67,7 +67,9 @@ class FlutterAdManagerInterstitialAd extends FlutterAd.FlutterOverlayAd {
               manager.onAppEvent(FlutterAdManagerInterstitialAd.this, name, data);
             }
           });
-          manager.onAdLoaded(FlutterAdManagerInterstitialAd.this);
+          manager.onAdLoaded(
+              FlutterAdManagerInterstitialAd.this,
+              adManagerInterstitialAd.getResponseInfo());
         }
 
         @Override

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterBannerAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterBannerAd.java
@@ -18,6 +18,7 @@ import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.gms.ads.AdView;
+import com.google.android.gms.ads.ResponseInfo;
 import io.flutter.plugin.platform.PlatformView;
 import io.flutter.util.Preconditions;
 
@@ -53,7 +54,12 @@ class FlutterBannerAd extends FlutterAd implements PlatformView, FlutterDestroya
     view = bannerAdCreator.createAdView();
     view.setAdUnitId(adUnitId);
     view.setAdSize(size.getAdSize());
-    view.setAdListener(new FlutterBannerAdListener(manager, this));
+    view.setAdListener(new FlutterBannerAdListener(manager, this, new ResponseInfoProvider() {
+      @Override
+      public ResponseInfo getResponseInfo() {
+        return view.getResponseInfo();
+      }
+    }));
     view.loadAd(request.asAdRequest());
   }
 

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterInterstitialAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterInterstitialAd.java
@@ -53,7 +53,9 @@ class FlutterInterstitialAd extends FlutterAd.FlutterOverlayAd {
         public void onAdLoaded(
           @NonNull InterstitialAd interstitialAd) {
           FlutterInterstitialAd.this.ad = interstitialAd;
-          FlutterInterstitialAd.this.manager.onAdLoaded(FlutterInterstitialAd.this);
+          FlutterInterstitialAd.this.manager.onAdLoaded(
+              FlutterInterstitialAd.this,
+              interstitialAd.getResponseInfo());
         }
 
         @Override

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterNativeAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterNativeAd.java
@@ -19,6 +19,7 @@ import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.gms.ads.AdListener;
+import com.google.android.gms.ads.ResponseInfo;
 import com.google.android.gms.ads.nativead.NativeAd;
 import com.google.android.gms.ads.nativead.NativeAd.OnNativeAdLoadedListener;
 import com.google.android.gms.ads.nativead.NativeAdOptions;
@@ -39,6 +40,7 @@ class FlutterNativeAd extends FlutterAd implements PlatformView, FlutterDestroya
   @Nullable private FlutterAdManagerAdRequest adManagerRequest;
   @Nullable private Map<String, Object> customOptions;
   @Nullable private NativeAdView ad;
+  @Nullable private ResponseInfo responseInfo;
 
   static class Builder {
     @Nullable private AdInstanceManager manager;
@@ -139,9 +141,17 @@ class FlutterNativeAd extends FlutterAd implements PlatformView, FlutterDestroya
       @Override
       public void onNativeAdLoaded(@NonNull NativeAd nativeAd) {
         ad = adFactory.createNativeAd(nativeAd, customOptions);
+        responseInfo = nativeAd.getResponseInfo();
       }
     };
-    AdListener adListener = new FlutterAdListener(manager, this) {
+
+    ResponseInfoProvider responseInfoProvider = new ResponseInfoProvider() {
+      @Override
+      public ResponseInfo getResponseInfo() {
+        return responseInfo;
+      }
+    };
+    AdListener adListener = new FlutterAdListener(manager, this, responseInfoProvider) {
       @Override
       public void onAdClicked() {
         manager.onNativeAdClicked(FlutterNativeAd.this);

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterNativeAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterNativeAd.java
@@ -145,13 +145,13 @@ class FlutterNativeAd extends FlutterAd implements PlatformView, FlutterDestroya
       }
     };
 
-    ResponseInfoProvider responseInfoProvider = new ResponseInfoProvider() {
+    final ResponseInfoProvider responseInfoProvider = new ResponseInfoProvider() {
       @Override
       public ResponseInfo getResponseInfo() {
         return responseInfo;
       }
     };
-    AdListener adListener = new FlutterAdListener(manager, this, responseInfoProvider) {
+    final AdListener adListener = new FlutterAdListener(manager, this, responseInfoProvider) {
       @Override
       public void onAdClicked() {
         manager.onNativeAdClicked(FlutterNativeAd.this);

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedAd.java
@@ -110,7 +110,7 @@ class FlutterRewardedAd extends FlutterAd.FlutterOverlayAd {
             rewardedAd.setServerSideVerificationOptions(
               serverSideVerificationOptions.asServerSideVerificationOptions());
           }
-          manager.onAdLoaded(FlutterRewardedAd.this);
+          manager.onAdLoaded(FlutterRewardedAd.this, rewardedAd.getResponseInfo());
           super.onAdLoaded(rewardedAd);
         }
 

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerBannerAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerBannerAdTest.java
@@ -119,7 +119,7 @@ public class FlutterAdManagerBannerAdTest {
         return null;
       }
     }).when(mockAdView).setAdListener(any(AdListener.class));
-    ResponseInfo responseInfo = mock(ResponseInfo.class);
+    final ResponseInfo responseInfo = mock(ResponseInfo.class);
     doReturn(responseInfo).when(mockAdView).getResponseInfo();
     flutterBannerAd.load();
 

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerBannerAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerBannerAdTest.java
@@ -119,14 +119,15 @@ public class FlutterAdManagerBannerAdTest {
         return null;
       }
     }).when(mockAdView).setAdListener(any(AdListener.class));
-
+    ResponseInfo responseInfo = mock(ResponseInfo.class);
+    doReturn(responseInfo).when(mockAdView).getResponseInfo();
     flutterBannerAd.load();
 
     verify(mockAdView).loadAd(eq(mockAdRequest));
     verify(mockAdView).setAdListener(any(AdListener.class));
     verify(mockAdView).setAdUnitId(eq("testId"));
     verify(mockAdView).setAdSizes(adSize);
-    verify(mockManager).onAdLoaded(eq(flutterBannerAd));
+    verify(mockManager).onAdLoaded(eq(flutterBannerAd), eq(responseInfo));
     verify(mockManager).onAdImpression(eq(flutterBannerAd));
     verify(mockManager).onAdClosed(eq(flutterBannerAd));
     verify(mockManager).onAdOpened(eq(flutterBannerAd));

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerInterstitialAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerInterstitialAdTest.java
@@ -113,7 +113,7 @@ public class FlutterAdManagerInterstitialAdTest {
         any(AdManagerAdRequest.class),
         any(AdManagerInterstitialAdLoadCallback.class));
 
-    ResponseInfo responseInfo = mock(ResponseInfo.class);
+    final ResponseInfo responseInfo = mock(ResponseInfo.class);
     doReturn(responseInfo).when(mockAdManagerAd).getResponseInfo();
 
     flutterAdManagerInterstitialAd.load();

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerInterstitialAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerInterstitialAdTest.java
@@ -29,6 +29,7 @@ import android.content.Context;
 import com.google.android.gms.ads.AdError;
 import com.google.android.gms.ads.FullScreenContentCallback;
 import com.google.android.gms.ads.LoadAdError;
+import com.google.android.gms.ads.ResponseInfo;
 import com.google.android.gms.ads.admanager.AdManagerAdRequest;
 import com.google.android.gms.ads.admanager.AdManagerInterstitialAd;
 import com.google.android.gms.ads.admanager.AdManagerInterstitialAdLoadCallback;
@@ -112,6 +113,9 @@ public class FlutterAdManagerInterstitialAdTest {
         any(AdManagerAdRequest.class),
         any(AdManagerInterstitialAdLoadCallback.class));
 
+    ResponseInfo responseInfo = mock(ResponseInfo.class);
+    doReturn(responseInfo).when(mockAdManagerAd).getResponseInfo();
+
     flutterAdManagerInterstitialAd.load();
 
     verify(mockFlutterAdLoader).loadAdManagerInterstitial(
@@ -120,7 +124,7 @@ public class FlutterAdManagerInterstitialAdTest {
       eq(mockRequest),
       any(AdManagerInterstitialAdLoadCallback.class));
 
-    verify(mockManager).onAdLoaded(flutterAdManagerInterstitialAd);
+    verify(mockManager).onAdLoaded(flutterAdManagerInterstitialAd, responseInfo);
 
     doAnswer(new Answer() {
       @Override
@@ -159,7 +163,7 @@ public class FlutterAdManagerInterstitialAdTest {
         anyString(),
         any(AdManagerAdRequest.class),
         any(AdManagerInterstitialAdLoadCallback.class));
-
+    doReturn(mock(ResponseInfo.class)).when(mockAdManagerAd).getResponseInfo();
     flutterAdManagerInterstitialAd.load();
     final AdError adError = new AdError(-1, "test", "error");
     doAnswer(new Answer() {
@@ -193,6 +197,8 @@ public class FlutterAdManagerInterstitialAdTest {
         anyString(),
         any(AdManagerAdRequest.class),
         any(AdManagerInterstitialAdLoadCallback.class));
+
+    doReturn(mock(ResponseInfo.class)).when(mockAdManagerAd).getResponseInfo();
 
     doAnswer(new Answer() {
       @Override

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterBannerAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterBannerAdTest.java
@@ -105,7 +105,7 @@ public class FlutterBannerAdTest {
       }
     }).when(mockAdView).setAdListener(any(AdListener.class));
 
-    ResponseInfo responseInfo = mock(ResponseInfo.class);
+    final ResponseInfo responseInfo = mock(ResponseInfo.class);
     doReturn(responseInfo).when(mockAdView).getResponseInfo();
 
     flutterBannerAd.load();

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterBannerAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterBannerAdTest.java
@@ -31,6 +31,7 @@ import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.AdSize;
 import com.google.android.gms.ads.AdView;
 import com.google.android.gms.ads.LoadAdError;
+import com.google.android.gms.ads.ResponseInfo;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugins.googlemobileads.FlutterAd.FlutterLoadAdError;
 import org.junit.Before;
@@ -104,12 +105,15 @@ public class FlutterBannerAdTest {
       }
     }).when(mockAdView).setAdListener(any(AdListener.class));
 
+    ResponseInfo responseInfo = mock(ResponseInfo.class);
+    doReturn(responseInfo).when(mockAdView).getResponseInfo();
+
     flutterBannerAd.load();
     verify(mockAdView).loadAd(eq(mockAdRequest));
     verify(mockAdView).setAdListener(any(AdListener.class));
     verify(mockAdView).setAdUnitId(eq("testId"));
     verify(mockAdView).setAdSize(adSize);
-    verify(mockManager).onAdLoaded(eq(flutterBannerAd));
+    verify(mockManager).onAdLoaded(eq(flutterBannerAd), eq(responseInfo));
     verify(mockManager).onAdImpression(eq(flutterBannerAd));
     verify(mockManager).onAdClosed(eq(flutterBannerAd));
     verify(mockManager).onAdOpened(eq(flutterBannerAd));

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterInterstitialAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterInterstitialAdTest.java
@@ -117,7 +117,7 @@ public class FlutterInterstitialAdTest {
         anyString(),
         any(AdRequest.class),
         any(InterstitialAdLoadCallback.class));
-    ResponseInfo responseInfo = mock(ResponseInfo.class);
+    final ResponseInfo responseInfo = mock(ResponseInfo.class);
     doReturn(responseInfo).when(mockAd).getResponseInfo();
     flutterInterstitialAd.load();
 

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterInterstitialAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterInterstitialAdTest.java
@@ -102,13 +102,13 @@ public class FlutterInterstitialAdTest {
 
   @Test
   public void loadInterstitialAd_showSuccess() {
-    final InterstitialAd mockAdManagerAd = mock(InterstitialAd.class);
+    final InterstitialAd mockAd = mock(InterstitialAd.class);
     doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
         InterstitialAdLoadCallback adLoadCallback = invocation.getArgument(3);
         // Pass back null for ad
-        adLoadCallback.onAdLoaded(mockAdManagerAd);
+        adLoadCallback.onAdLoaded(mockAd);
         return null;
       }
     }).when(mockFlutterAdLoader)
@@ -117,7 +117,8 @@ public class FlutterInterstitialAdTest {
         anyString(),
         any(AdRequest.class),
         any(InterstitialAdLoadCallback.class));
-
+    ResponseInfo responseInfo = mock(ResponseInfo.class);
+    doReturn(responseInfo).when(mockAd).getResponseInfo();
     flutterInterstitialAd.load();
 
     verify(mockFlutterAdLoader).loadInterstitial(
@@ -126,7 +127,7 @@ public class FlutterInterstitialAdTest {
       eq(mockAdRequest),
       any(InterstitialAdLoadCallback.class));
 
-    verify(mockManager).onAdLoaded(flutterInterstitialAd);
+    verify(mockManager).onAdLoaded(eq(flutterInterstitialAd), eq(responseInfo));
 
     doAnswer(new Answer() {
       @Override
@@ -137,11 +138,11 @@ public class FlutterInterstitialAdTest {
         callback.onAdDismissedFullScreenContent();
         return null;
       }
-    }).when(mockAdManagerAd).setFullScreenContentCallback(any(FullScreenContentCallback.class));
+    }).when(mockAd).setFullScreenContentCallback(any(FullScreenContentCallback.class));
 
     flutterInterstitialAd.show();
-    verify(mockAdManagerAd).setFullScreenContentCallback(any(FullScreenContentCallback.class));
-    verify(mockAdManagerAd).show(eq(mockManager.activity));
+    verify(mockAd).setFullScreenContentCallback(any(FullScreenContentCallback.class));
+    verify(mockAd).show(eq(mockManager.activity));
     verify(mockManager).onAdShowedFullScreenContent(eq(flutterInterstitialAd));
     verify(mockManager).onAdDismissedFullScreenContent(eq(flutterInterstitialAd));
     verify(mockManager).onAdImpression(eq(flutterInterstitialAd));
@@ -149,13 +150,13 @@ public class FlutterInterstitialAdTest {
 
   @Test
   public void loadInterstitialAd_showFailure() {
-    final InterstitialAd mockAdManagerAd = mock(InterstitialAd.class);
+    final InterstitialAd mockAd = mock(InterstitialAd.class);
     doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
         InterstitialAdLoadCallback adLoadCallback = invocation.getArgument(3);
         // Pass back null for ad
-        adLoadCallback.onAdLoaded(mockAdManagerAd);
+        adLoadCallback.onAdLoaded(mockAd);
         return null;
       }
     }).when(mockFlutterAdLoader)
@@ -164,7 +165,7 @@ public class FlutterInterstitialAdTest {
         anyString(),
         any(AdRequest.class),
         any(InterstitialAdLoadCallback.class));
-
+    doReturn(mock(ResponseInfo.class)).when(mockAd).getResponseInfo();
     flutterInterstitialAd.load();
     final AdError adError = new AdError(1, "2", "3");
 
@@ -175,7 +176,7 @@ public class FlutterInterstitialAdTest {
         callback.onAdFailedToShowFullScreenContent(adError);
         return null;
       }
-    }).when(mockAdManagerAd).setFullScreenContentCallback(any(FullScreenContentCallback.class));
+    }).when(mockAd).setFullScreenContentCallback(any(FullScreenContentCallback.class));
 
     flutterInterstitialAd.show();
     verify(mockManager)

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterNativeAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterNativeAdTest.java
@@ -27,6 +27,7 @@ import android.app.Activity;
 import com.google.android.gms.ads.AdListener;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.LoadAdError;
+import com.google.android.gms.ads.ResponseInfo;
 import com.google.android.gms.ads.admanager.AdManagerAdRequest;
 import com.google.android.gms.ads.nativead.NativeAd;
 import com.google.android.gms.ads.nativead.NativeAd.OnNativeAdLoadedListener;
@@ -68,7 +69,9 @@ public class FlutterNativeAdTest {
             mockLoader,
             mockOptions);
 
+    final ResponseInfo responseInfo = mock(ResponseInfo.class);
     final NativeAd mockNativeAd = mock(NativeAd.class);
+    doReturn(responseInfo).when(mockNativeAd).getResponseInfo();
     final LoadAdError loadAdError = mock(LoadAdError.class);
     doReturn(1).when(loadAdError).getCode();
     doReturn("2").when(loadAdError).getDomain();
@@ -113,7 +116,7 @@ public class FlutterNativeAdTest {
     verify(testManager).onAdClosed(eq(nativeAd));
     verify(testManager).onNativeAdClicked(eq(nativeAd));
     verify(testManager).onAdImpression(eq(nativeAd));
-    verify(testManager).onAdLoaded(eq(nativeAd));
+    verify(testManager).onAdLoaded(eq(nativeAd), eq(responseInfo));
     FlutterLoadAdError expectedError = new FlutterLoadAdError(loadAdError);
     verify(testManager).onAdFailedToLoad(eq(nativeAd), eq(expectedError));
   }
@@ -136,7 +139,9 @@ public class FlutterNativeAdTest {
         mockLoader,
         mockOptions);
 
+    final ResponseInfo responseInfo = mock(ResponseInfo.class);
     final NativeAd mockNativeAd = mock(NativeAd.class);
+    doReturn(responseInfo).when(mockNativeAd).getResponseInfo();
     final LoadAdError loadAdError = mock(LoadAdError.class);
     doReturn(1).when(loadAdError).getCode();
     doReturn("2").when(loadAdError).getDomain();
@@ -182,7 +187,7 @@ public class FlutterNativeAdTest {
     verify(testManager).onAdClosed(eq(nativeAd));
     verify(testManager).onNativeAdClicked(eq(nativeAd));
     verify(testManager).onAdImpression(eq(nativeAd));
-    verify(testManager).onAdLoaded(eq(nativeAd));
+    verify(testManager).onAdLoaded(eq(nativeAd), eq(responseInfo));
     FlutterLoadAdError expectedError = new FlutterLoadAdError(loadAdError);
     verify(testManager).onAdFailedToLoad(eq(nativeAd), eq(expectedError));
   }

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterRewardedAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterRewardedAdTest.java
@@ -140,7 +140,7 @@ public class FlutterRewardedAdTest {
         anyString(),
         any(AdManagerAdRequest.class),
         any(RewardedAdLoadCallback.class));
-    ResponseInfo responseInfo = mock(ResponseInfo.class);
+    final ResponseInfo responseInfo = mock(ResponseInfo.class);
     doReturn(responseInfo).when(mockAd).getResponseInfo();
     flutterRewardedAd.load();
 
@@ -229,7 +229,7 @@ public class FlutterRewardedAdTest {
         anyString(),
         any(AdManagerAdRequest.class),
         any(RewardedAdLoadCallback.class));
-    ResponseInfo responseInfo = mock(ResponseInfo.class);
+    final ResponseInfo responseInfo = mock(ResponseInfo.class);
     doReturn(responseInfo).when(mockAd).getResponseInfo();
 
     mockFlutterAd.load();
@@ -286,7 +286,7 @@ public class FlutterRewardedAdTest {
         anyString(),
         any(AdRequest.class),
         any(RewardedAdLoadCallback.class));
-    ResponseInfo responseInfo = mock(ResponseInfo.class);
+    final ResponseInfo responseInfo = mock(ResponseInfo.class);
     doReturn(responseInfo).when(mockRewardedAd).getResponseInfo();
     flutterRewardedAd.load();
 

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterRewardedAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterRewardedAdTest.java
@@ -32,6 +32,7 @@ import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.FullScreenContentCallback;
 import com.google.android.gms.ads.LoadAdError;
 import com.google.android.gms.ads.OnUserEarnedRewardListener;
+import com.google.android.gms.ads.ResponseInfo;
 import com.google.android.gms.ads.admanager.AdManagerAdRequest;
 import com.google.android.gms.ads.rewarded.OnAdMetadataChangedListener;
 import com.google.android.gms.ads.rewarded.RewardItem;
@@ -123,14 +124,14 @@ public class FlutterRewardedAdTest {
       new FlutterServerSideVerificationOptions("userId", "customData");
     setupAdManagerMocks(options);
 
-    final RewardedAd mockAdManagerAd = mock(RewardedAd.class);
+    final RewardedAd mockAd = mock(RewardedAd.class);
     final LoadAdError loadAdError = new LoadAdError(1, "2", "3", null, null);
     doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
         RewardedAdLoadCallback adLoadCallback = invocation.getArgument(3);
         // Pass back null for ad
-        adLoadCallback.onAdLoaded(mockAdManagerAd);
+        adLoadCallback.onAdLoaded(mockAd);
         return null;
       }
     }).when(mockFlutterAdLoader)
@@ -139,7 +140,8 @@ public class FlutterRewardedAdTest {
         anyString(),
         any(AdManagerAdRequest.class),
         any(RewardedAdLoadCallback.class));
-
+    ResponseInfo responseInfo = mock(ResponseInfo.class);
+    doReturn(responseInfo).when(mockAd).getResponseInfo();
     flutterRewardedAd.load();
 
     verify(mockFlutterAdLoader).loadAdManagerRewarded(
@@ -148,7 +150,7 @@ public class FlutterRewardedAdTest {
       eq(mockAdManagerAdRequest),
       any(RewardedAdLoadCallback.class));
 
-    verify(mockManager).onAdLoaded(flutterRewardedAd);
+    verify(mockManager).onAdLoaded(eq(flutterRewardedAd), eq(responseInfo));
 
     doAnswer(new Answer() {
       @Override
@@ -159,7 +161,7 @@ public class FlutterRewardedAdTest {
         callback.onAdDismissedFullScreenContent();
         return null;
       }
-    }).when(mockAdManagerAd).setFullScreenContentCallback(any(FullScreenContentCallback.class));
+    }).when(mockAd).setFullScreenContentCallback(any(FullScreenContentCallback.class));
 
     final RewardItem mockRewardItem = mock(RewardItem.class);
     doReturn(5).when(mockRewardItem).getAmount();
@@ -171,7 +173,7 @@ public class FlutterRewardedAdTest {
         listener.onUserEarnedReward(mockRewardItem);
         return null;
       }
-    }).when(mockAdManagerAd).show(any(Activity.class), any(OnUserEarnedRewardListener.class));
+    }).when(mockAd).show(any(Activity.class), any(OnUserEarnedRewardListener.class));
 
     doAnswer(new Answer() {
       @Override
@@ -180,12 +182,12 @@ public class FlutterRewardedAdTest {
         listener.onAdMetadataChanged();
         return null;
       }
-    }).when(mockAdManagerAd).setOnAdMetadataChangedListener(any(OnAdMetadataChangedListener.class));
+    }).when(mockAd).setOnAdMetadataChangedListener(any(OnAdMetadataChangedListener.class));
 
     flutterRewardedAd.show();
-    verify(mockAdManagerAd).setFullScreenContentCallback(any(FullScreenContentCallback.class));
-    verify(mockAdManagerAd).show(eq(mockManager.activity), any(OnUserEarnedRewardListener.class));
-    verify(mockAdManagerAd).setOnAdMetadataChangedListener(any(OnAdMetadataChangedListener.class));
+    verify(mockAd).setFullScreenContentCallback(any(FullScreenContentCallback.class));
+    verify(mockAd).show(eq(mockManager.activity), any(OnUserEarnedRewardListener.class));
+    verify(mockAd).setOnAdMetadataChangedListener(any(OnAdMetadataChangedListener.class));
     ArgumentMatcher<ServerSideVerificationOptions> serverSideVerificationOptionsArgumentMatcher =
       new ArgumentMatcher<ServerSideVerificationOptions>() {
         @Override
@@ -194,7 +196,7 @@ public class FlutterRewardedAdTest {
             && argument.getUserId().equals(options.getUserId());
         }
       };
-    verify(mockAdManagerAd)
+    verify(mockAd)
       .setServerSideVerificationOptions(
         ArgumentMatchers.argThat(serverSideVerificationOptionsArgumentMatcher));
     verify(mockManager).onAdShowedFullScreenContent(eq(flutterRewardedAd));
@@ -211,14 +213,14 @@ public class FlutterRewardedAdTest {
     setupAdManagerMocks(options);
 
     final FlutterRewardedAd mockFlutterAd = spy(flutterRewardedAd);
-    final RewardedAd mockAdManagerAd = mock(RewardedAd.class);
+    final RewardedAd mockAd = mock(RewardedAd.class);
     final LoadAdError loadAdError = new LoadAdError(1, "2", "3", null, null);
     doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
         RewardedAdLoadCallback adLoadCallback = invocation.getArgument(3);
         // Pass back null for ad
-        adLoadCallback.onAdLoaded(mockAdManagerAd);
+        adLoadCallback.onAdLoaded(mockAd);
         return null;
       }
     }).when(mockFlutterAdLoader)
@@ -227,6 +229,8 @@ public class FlutterRewardedAdTest {
         anyString(),
         any(AdManagerAdRequest.class),
         any(RewardedAdLoadCallback.class));
+    ResponseInfo responseInfo = mock(ResponseInfo.class);
+    doReturn(responseInfo).when(mockAd).getResponseInfo();
 
     mockFlutterAd.load();
 
@@ -236,7 +240,7 @@ public class FlutterRewardedAdTest {
       eq(mockAdManagerAdRequest),
       any(RewardedAdLoadCallback.class));
 
-    verify(mockManager).onAdLoaded(mockFlutterAd);
+    verify(mockManager).onAdLoaded(eq(mockFlutterAd), eq(responseInfo));
 
     doAnswer(new Answer() {
       @Override
@@ -245,12 +249,12 @@ public class FlutterRewardedAdTest {
         callback.onAdShowedFullScreenContent();
         return null;
       }
-    }).when(mockAdManagerAd).setFullScreenContentCallback(any(FullScreenContentCallback.class));
+    }).when(mockAd).setFullScreenContentCallback(any(FullScreenContentCallback.class));
 
     mockFlutterAd.show();
-    verify(mockAdManagerAd).setFullScreenContentCallback(any(FullScreenContentCallback.class));
-    verify(mockAdManagerAd).show(eq(mockManager.activity), any(OnUserEarnedRewardListener.class));
-    verify(mockAdManagerAd).setOnAdMetadataChangedListener(any(OnAdMetadataChangedListener.class));
+    verify(mockAd).setFullScreenContentCallback(any(FullScreenContentCallback.class));
+    verify(mockAd).show(eq(mockManager.activity), any(OnUserEarnedRewardListener.class));
+    verify(mockAd).setOnAdMetadataChangedListener(any(OnAdMetadataChangedListener.class));
     ArgumentMatcher<ServerSideVerificationOptions> serverSideVerificationOptionsArgumentMatcher =
       new ArgumentMatcher<ServerSideVerificationOptions>() {
         @Override
@@ -258,7 +262,7 @@ public class FlutterRewardedAdTest {
           return argument.getCustomData().isEmpty() && argument.getUserId().isEmpty();
         }
       };
-    verify(mockAdManagerAd)
+    verify(mockAd)
       .setServerSideVerificationOptions(
         ArgumentMatchers.argThat(serverSideVerificationOptionsArgumentMatcher));
   }
@@ -282,7 +286,8 @@ public class FlutterRewardedAdTest {
         anyString(),
         any(AdRequest.class),
         any(RewardedAdLoadCallback.class));
-
+    ResponseInfo responseInfo = mock(ResponseInfo.class);
+    doReturn(responseInfo).when(mockRewardedAd).getResponseInfo();
     flutterRewardedAd.load();
 
     verify(mockFlutterAdLoader).loadRewarded(
@@ -291,7 +296,7 @@ public class FlutterRewardedAdTest {
       eq(mockAdRequest),
       any(RewardedAdLoadCallback.class));
 
-    verify(mockManager).onAdLoaded(flutterRewardedAd);
+    verify(mockManager).onAdLoaded(eq(flutterRewardedAd), eq(responseInfo));
     final AdError adError = new AdError(0, "ad", "error");
     doAnswer(new Answer() {
       @Override

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
@@ -251,6 +251,27 @@ public class GoogleMobileAdsTest {
   }
 
   @Test
+  public void flutterAdListener_onAdLoaded_responseInfoNull() {
+    final FlutterBannerAd bannerAd = new FlutterBannerAd(
+        testManager,
+        "testId",
+        request,
+        new FlutterAdSize(1, 2),
+        new BannerAdCreator(testManager.activity));
+    testManager.trackAd(bannerAd, 0);
+
+    testManager.onAdLoaded(bannerAd, null);
+
+    final MethodCall call = getLastMethodCall();
+    assertEquals("onAdEvent", call.method);
+    //noinspection rawtypes
+    assertThat(call.arguments, (Matcher) hasEntry("eventName", "onAdLoaded"));
+    //noinspection rawtypes
+    assertThat(call.arguments, (Matcher) hasEntry("adId", 0));
+    assertThat(call.arguments, (Matcher) hasEntry("responseInfo", null));
+  }
+
+  @Test
   public void flutterAdListener_onAdFailedToLoad() {
     final FlutterBannerAd bannerAd = new FlutterBannerAd(
         testManager,

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
@@ -231,8 +231,16 @@ public class GoogleMobileAdsTest {
     doReturn(credentials).when(adapterInfo).getCredentials();
     doReturn("description").when(adapterInfo).toString();
 
+    AdapterResponseInfo adapterInfoWithNullError = mock(AdapterResponseInfo.class);
+    doReturn("adapter-class").when(adapterInfoWithNullError).getAdapterClassName();
+    doReturn(null).when(adapterInfoWithNullError).getAdError();
+    doReturn(123L).when(adapterInfoWithNullError).getLatencyMillis();
+    doReturn(null).when(adapterInfoWithNullError).getCredentials();
+    doReturn("description").when(adapterInfoWithNullError).toString();
+
     List<AdapterResponseInfo> adapterResponses = new ArrayList<>();
     adapterResponses.add(adapterInfo);
+    adapterResponses.add(adapterInfoWithNullError);
 
     ResponseInfo responseInfo = mock(ResponseInfo.class);
     doReturn("response-id").when(responseInfo).getResponseId();

--- a/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.h
@@ -30,7 +30,8 @@
 - (void)loadAd:(id<FLTAd> _Nonnull)ad adId:(NSNumber *_Nonnull)adId;
 - (void)dispose:(NSNumber *_Nonnull)adId;
 - (void)showAdWithID:(NSNumber *_Nonnull)adId;
-- (void)onAdLoaded:(id<FLTAd> _Nonnull)ad;
+- (void)onAdLoaded:(id<FLTAd> _Nonnull)ad
+      responseInfo:(GADResponseInfo *)responseInfo;
 - (void)onAdFailedToLoad:(id<FLTAd> _Nonnull)ad error:(NSError *_Nonnull)error;
 - (void)onAppEvent:(id<FLTAd> _Nonnull)ad
               name:(NSString *_Nullable)name

--- a/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.m
@@ -77,8 +77,14 @@
   [ad show];
 }
 
-- (void)onAdLoaded:(id<FLTAd> _Nonnull)ad {
-  [self sendAdEvent:@"onAdLoaded" ad:ad];
+- (void)onAdLoaded:(id<FLTAd> _Nonnull)ad
+      responseInfo:(GADResponseInfo *)responseInfo {
+  [_channel invokeMethod:@"onAdEvent"
+               arguments:@{
+                 @"adId" : [self adIdFor:ad],
+                 @"eventName" : @"onAdLoaded",
+                 @"responseInfo" : [[FLTGADResponseInfo alloc] initWithResponseInfo:responseInfo]
+               }];
 }
 
 - (void)onAdFailedToLoad:(id<FLTAd> _Nonnull)ad error:(NSError *_Nonnull)error {

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
@@ -35,11 +35,26 @@
 @end
 
 /**
+ * Wrapper around `GADAdNetworkResponseInfo`.
+ */
+@interface FLTGADAdNetworkResponseInfo : NSObject
+
+@property NSString *_Nullable adNetworkClassName;
+@property NSNumber *_Nullable latency;
+@property NSString *_Nullable dictionaryDescription;
+@property NSString *_Nullable credentialsDescription;
+@property NSError *_Nullable error;
+
+- (instancetype _Nonnull)initWithResponseInfo:(GADAdNetworkResponseInfo *_Nonnull)responseInfo;
+@end
+
+/**
  * Wrapper around `GADResponseInfo`.
  */
 @interface FLTGADResponseInfo : NSObject
 @property NSString *_Nullable responseIdentifier;
 @property NSString *_Nullable adNetworkClassName;
+@property NSArray<FLTGADAdNetworkResponseInfo *> *_Nullable adNetworkInfoArray;
 
 - (instancetype _Nonnull)initWithResponseInfo:(GADResponseInfo *_Nonnull)responseInfo;
 @end

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
@@ -59,6 +59,28 @@
   if (self) {
     _responseIdentifier = responseInfo.responseIdentifier;
     _adNetworkClassName = responseInfo.adNetworkClassName;
+    NSMutableArray<FLTGADAdNetworkResponseInfo *> *infoArray =
+      [[NSMutableArray alloc] init];
+    for (GADAdNetworkResponseInfo * adNetworkInfo in responseInfo.adNetworkInfoArray) {
+      [infoArray addObject:[[FLTGADAdNetworkResponseInfo alloc] initWithResponseInfo:adNetworkInfo]];
+    }
+    _adNetworkInfoArray = infoArray;
+  }
+  return self;
+}
+@end
+
+@implementation FLTGADAdNetworkResponseInfo
+
+- (instancetype _Nonnull)initWithResponseInfo:(GADAdNetworkResponseInfo *_Nonnull)responseInfo {
+  self = [super init];
+  if (self) {
+    _adNetworkClassName = responseInfo.adNetworkClassName;
+    NSNumber *timeInMillis = [[NSNumber alloc] initWithDouble:responseInfo.latency * 1000];
+    _latency = @(timeInMillis.longValue);
+    _dictionaryDescription = responseInfo.dictionaryRepresentation.description;
+    _credentialsDescription = responseInfo.credentials.description;
+    _error = responseInfo.error;
   }
   return self;
 }
@@ -135,7 +157,7 @@
 
 
 - (void)bannerViewDidReceiveAd:(GADBannerView *)bannerView {
-  [_manager onAdLoaded:self];
+  [_manager onAdLoaded:self responseInfo:bannerView.responseInfo];
 }
 
 - (void)bannerView:(GADBannerView *)bannerView didFailToReceiveAdWithError:(NSError *)error {
@@ -251,7 +273,7 @@
                         }
                         ad.fullScreenContentDelegate = self;
                         self->_interstitialView = ad;
-                        [self.manager onAdLoaded:self];
+                        [self.manager onAdLoaded:self responseInfo:ad.responseInfo];
                       }];
 }
 
@@ -321,7 +343,7 @@ didFailToPresentFullScreenContentWithError:(nonnull NSError *)error {
        [self.manager onAdFailedToLoad:self error:error];
        return;
      }
-    [self.manager onAdLoaded:self];
+    [self.manager onAdLoaded:self responseInfo:ad.responseInfo];
     ad.fullScreenContentDelegate = self;
     ad.appEventDelegate = self;
      self->_insterstitial = ad;
@@ -400,7 +422,7 @@ didFailToPresentFullScreenContentWithError:(nonnull NSError *)error {
     
     rewardedAd.fullScreenContentDelegate = self;
     self->_rewardedView = rewardedAd;
-    [self.manager onAdLoaded:self];
+    [self.manager onAdLoaded:self responseInfo:rewardedAd.responseInfo];
   }];
 }
   
@@ -501,7 +523,7 @@ didFailToPresentFullScreenContentWithError:(nonnull NSError *)error {
       [[NSNull null] isEqual:_customOptions] ? nil : _customOptions;
   _view = [_nativeAdFactory createNativeAd:nativeAd customOptions:customOptions];
   nativeAd.delegate = self;
-  [_manager onAdLoaded:self];
+  [_manager onAdLoaded:self responseInfo:nativeAd.responseInfo];
 }
 
 - (void)adLoader:(GADAdLoader *)adLoader didFailToReceiveAdWithError:(NSError *)error {

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
@@ -26,7 +26,8 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
   FLTAdMobFieldInitializationStatus = 137,
   FLTAdmobFieldServerSideVerificationOptions = 138,
   FLTAdmobFieldAdError = 139,
-  FLTAdmobFieldGadResponseInfo = 140
+  FLTAdmobFieldGadResponseInfo = 140,
+  FLTAdmobFieldGADAdNetworkResponseInfo = 141
 };
 
 @interface FLTGoogleMobileAdsReader : FlutterStandardReader
@@ -70,10 +71,27 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     case FLTAdmobFieldGadResponseInfo: {
       NSString *responseIdentifier = [self readValueOfType:[self readByte]];
       NSString *adNetworkClassName = [self readValueOfType:[self readByte]];
+      NSArray<FLTGADAdNetworkResponseInfo *> *adNetworkInfoArray =
+        [self readValueOfType:[self readByte]];
       FLTGADResponseInfo * gadResponseInfo = [[FLTGADResponseInfo alloc] init];
       gadResponseInfo.adNetworkClassName = adNetworkClassName;
       gadResponseInfo.responseIdentifier = responseIdentifier;
+      gadResponseInfo.adNetworkInfoArray = adNetworkInfoArray;
       return gadResponseInfo;
+    }
+    case FLTAdmobFieldGADAdNetworkResponseInfo: {
+      NSString * adNetworkClassName = [self readValueOfType:[self readByte]];
+      NSNumber *latency = [self readValueOfType:[self readByte]];
+      NSString *dictionaryDescription = [self readValueOfType:[self readByte]];
+      NSString *credentialsDescription = [self readValueOfType:[self readByte]];
+      NSError *error = [self readValueOfType:[self readByte]];
+      FLTGADAdNetworkResponseInfo *adNetworkResponseInfo = [[FLTGADAdNetworkResponseInfo alloc] init];
+      adNetworkResponseInfo.adNetworkClassName = adNetworkClassName;
+      adNetworkResponseInfo.latency = latency;
+      adNetworkResponseInfo.dictionaryDescription = dictionaryDescription;
+      adNetworkResponseInfo.credentialsDescription = credentialsDescription;
+      adNetworkResponseInfo.error = error;
+      return adNetworkResponseInfo;
     }
     case FLTAdMobFieldLoadError: {
       NSNumber *code = [self readValueOfType:[self readByte]];
@@ -172,6 +190,15 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     GADResponseInfo *responseInfo = value;
     [self writeValue:responseInfo.responseIdentifier];
     [self writeValue:responseInfo.adNetworkClassName];
+    [self writeValue:responseInfo.adNetworkInfoArray];
+  } else if ([value isKindOfClass:[FLTGADAdNetworkResponseInfo class]]) {
+    [self writeByte:FLTAdmobFieldGADAdNetworkResponseInfo];
+    FLTGADAdNetworkResponseInfo *networkResponseInfo = value;
+    [self writeValue:networkResponseInfo.adNetworkClassName];
+    [self writeValue:networkResponseInfo.latency];
+    [self writeValue:networkResponseInfo.dictionaryDescription];
+    [self writeValue:networkResponseInfo.credentialsDescription];
+    [self writeValue:networkResponseInfo.error];
   } else if ([value isKindOfClass:[FLTLoadAdError class]]) {
     [self writeByte:FLTAdMobFieldLoadError];
     FLTLoadAdError *error = value;

--- a/packages/google_mobile_ads/ios/Tests/FLTBannerAdTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTBannerAdTest.m
@@ -43,19 +43,23 @@
   
   XCTAssertEqual(bannerAd.bannerView.delegate, bannerAd);
   
-  [bannerAd.bannerView.delegate bannerViewDidReceiveAd:OCMClassMock([GADBannerView class])];
-  OCMVerify([mockManager onAdLoaded:[OCMArg isEqual:bannerAd]]);
+  GADBannerView *bannerMock = OCMClassMock([GADBannerView class]);
+  GADResponseInfo *responseInfo = OCMClassMock([GADResponseInfo class]);
+  OCMStub([bannerMock responseInfo]).andReturn(responseInfo);
   
-  [bannerAd.bannerView.delegate bannerViewDidDismissScreen:OCMClassMock([GADBannerView class])];
+  [bannerAd.bannerView.delegate bannerViewDidReceiveAd:bannerMock];
+  OCMVerify([mockManager onAdLoaded:[OCMArg isEqual:bannerAd] responseInfo:[OCMArg isEqual:responseInfo]]);
+  
+  [bannerAd.bannerView.delegate bannerViewDidDismissScreen:bannerMock];
   OCMVerify([mockManager onBannerDidDismissScreen:[OCMArg isEqual:bannerAd]]);
 
-  [bannerAd.bannerView.delegate bannerViewWillDismissScreen:OCMClassMock([GADBannerView class])];
+  [bannerAd.bannerView.delegate bannerViewWillDismissScreen:bannerMock];
   OCMVerify([mockManager onBannerWillDismissScreen:[OCMArg isEqual:bannerAd]]);
   
-  [bannerAd.bannerView.delegate bannerViewWillPresentScreen:OCMClassMock([GADBannerView class])];
+  [bannerAd.bannerView.delegate bannerViewWillPresentScreen:bannerMock];
   OCMVerify([mockManager onBannerWillPresentScreen:[OCMArg isEqual:bannerAd]]);
   
-  [bannerAd.bannerView.delegate bannerViewDidRecordImpression:OCMClassMock([GADBannerView class])];
+  [bannerAd.bannerView.delegate bannerViewDidRecordImpression:bannerMock];
   OCMVerify([mockManager onBannerImpression:[OCMArg isEqual:bannerAd]]);
   
   NSString *domain = @"domain";

--- a/packages/google_mobile_ads/ios/Tests/FLTGAMBannerAdTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGAMBannerAdTest.m
@@ -47,7 +47,8 @@
   XCTAssertEqual(adView.delegate, bannerAd);
   
   [bannerAd.bannerView.delegate bannerViewDidReceiveAd:OCMClassMock([GADBannerView class])];
-  OCMVerify([mockManager onAdLoaded:[OCMArg isEqual:bannerAd]]);
+  OCMVerify([mockManager onAdLoaded:[OCMArg isEqual:bannerAd]
+             responseInfo:[OCMArg isEqual:adView.responseInfo]]);
   
   [bannerAd.bannerView.delegate bannerViewDidDismissScreen:OCMClassMock([GADBannerView class])];
   OCMVerify([mockManager onBannerDidDismissScreen:[OCMArg isEqual:bannerAd]]);

--- a/packages/google_mobile_ads/ios/Tests/FLTGamInterstitialAdTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGamInterstitialAdTest.m
@@ -72,12 +72,15 @@
     [delegate interstitialAd:interstitialClassMock didReceiveAppEvent:@"event" withInfo:@"info"];
   });
 
+  GADResponseInfo *responseInfo = OCMClassMock([GADResponseInfo class]);
+  OCMStub([interstitialClassMock responseInfo]).andReturn(responseInfo);
+  
   [ad load];
 
   OCMVerify(ClassMethod([interstitialClassMock loadWithAdManagerAdUnitID:[OCMArg isEqual:@"testId"]
                                                                  request:[OCMArg isEqual:gadRequest]
                                                        completionHandler:[OCMArg any]]));
-  OCMVerify([mockManager onAdLoaded:[OCMArg isEqual:ad]]);
+  OCMVerify([mockManager onAdLoaded:[OCMArg isEqual:ad] responseInfo:[OCMArg isEqual:responseInfo]]);
   OCMVerify([interstitialClassMock setFullScreenContentDelegate:[OCMArg isEqual:ad]]);
   XCTAssertEqual(ad.interstitial, interstitialClassMock);
   

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
@@ -156,6 +156,86 @@
   XCTAssertEqualObjects(decodedError.message, @"message");
   XCTAssertEqualObjects(decodedError.responseInfo.adNetworkClassName, className);
   XCTAssertEqualObjects(decodedError.responseInfo.responseIdentifier, identifier);
+  XCTAssertTrue(decodedError.responseInfo.adNetworkInfoArray.count == 0);
+}
+
+- (void)testEncodeDecodeFLTGADLoadErrorWithResponseInfo {
+  GADAdNetworkResponseInfo *mockNetworkResponse = OCMClassMock([GADAdNetworkResponseInfo class]);
+  OCMStub([mockNetworkResponse adNetworkClassName]).andReturn(@"adapter-class");
+
+  GADResponseInfo *mockResponseInfo = OCMClassMock([GADResponseInfo class]);
+  NSString *identifier = @"test-identifier";
+  NSString *className = @"test-class-name";
+  OCMStub([mockResponseInfo responseIdentifier]).andReturn(identifier);
+  OCMStub([mockResponseInfo adNetworkClassName]).andReturn(className);
+  OCMStub([mockResponseInfo adNetworkInfoArray]).andReturn(@[ mockNetworkResponse ]);
+  NSDictionary *userInfo = @{
+    NSLocalizedDescriptionKey : @"message",
+    GADErrorUserInfoKeyResponseInfo: mockResponseInfo
+  };
+  NSError *error = [NSError errorWithDomain:@"domain" code:1 userInfo:userInfo];
+  FLTLoadAdError *loadAdError = [[FLTLoadAdError alloc] initWithError:error];
+
+  NSData *encodedMessage = [_messageCodec encode:loadAdError];
+  FLTLoadAdError *decodedError = [_messageCodec decode:encodedMessage];
+
+  XCTAssertEqual(decodedError.code, 1);
+  XCTAssertEqualObjects(decodedError.domain, @"domain");
+  XCTAssertEqualObjects(decodedError.message, @"message");
+  XCTAssertEqualObjects(decodedError.responseInfo.adNetworkClassName, className);
+  XCTAssertEqualObjects(decodedError.responseInfo.responseIdentifier, identifier);
+  XCTAssertTrue(decodedError.responseInfo.adNetworkInfoArray.count == 1);
+  XCTAssertEqualObjects(
+      decodedError.responseInfo.adNetworkInfoArray.firstObject.adNetworkClassName, @"adapter-class");
+}
+
+
+- (void)testEncodeDecodeFLTGADResponseInfo {
+  NSDictionary *descriptionsDict = @{ @"descriptions" : @"dict" };
+  NSDictionary *credentialsDict = @{ @"credentials" : @"dict" };
+
+  NSError *error = OCMClassMock([NSError class]);
+  OCMStub([error domain]).andReturn(@"domain");
+  OCMStub([error code]).andReturn(1);
+  OCMStub([error localizedDescription]).andReturn(@"error");
+  
+  GADAdNetworkResponseInfo * mockGADResponseInfo =
+    OCMClassMock([GADAdNetworkResponseInfo class]);
+  OCMStub([mockGADResponseInfo adNetworkClassName]).andReturn(@"adapter-class");
+  OCMStub([mockGADResponseInfo latency]).andReturn(123.1234);
+  OCMStub([mockGADResponseInfo dictionaryRepresentation]).andReturn(descriptionsDict);
+  OCMStub([mockGADResponseInfo credentials]).andReturn(credentialsDict);
+  OCMStub([mockGADResponseInfo error]).andReturn(error);
+  
+  FLTGADAdNetworkResponseInfo *adNetworkResponseInfo =
+    [[FLTGADAdNetworkResponseInfo alloc] initWithResponseInfo:mockGADResponseInfo];
+  
+  FLTGADResponseInfo *responseInfo = [[FLTGADResponseInfo alloc] init];
+  responseInfo.adNetworkClassName = @"class-name";
+  responseInfo.responseIdentifier = @"identifier";
+  responseInfo.adNetworkInfoArray = @[adNetworkResponseInfo];
+
+  NSData *encodedMessage = [_messageCodec encode:responseInfo];
+  FLTGADResponseInfo *decodedResponseInfo = [_messageCodec decode:encodedMessage];
+  
+  XCTAssertEqualObjects(decodedResponseInfo.adNetworkClassName,
+                        @"class-name");
+  XCTAssertEqualObjects(decodedResponseInfo.responseIdentifier,
+                        @"identifier");
+  XCTAssertEqual(decodedResponseInfo.adNetworkInfoArray.count, 1);
+  
+  FLTGADAdNetworkResponseInfo *decodedInfo = decodedResponseInfo.adNetworkInfoArray.firstObject;
+
+  XCTAssertEqualObjects(decodedInfo.adNetworkClassName, @"adapter-class");
+  XCTAssertEqualObjects(decodedInfo.latency, @(123123));
+  XCTAssertEqualObjects(
+                        decodedInfo.dictionaryDescription,
+                        @"{\n    descriptions = dict;\n}");
+  XCTAssertEqualObjects(decodedInfo.credentialsDescription,
+                        @"{\n    credentials = dict;\n}");
+  XCTAssertEqual(decodedInfo.error.code, 1);
+  XCTAssertEqualObjects(decodedInfo.error.domain, @"domain");
+  XCTAssertEqualObjects(decodedInfo.error.localizedDescription, @"error");
 }
 
 

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsTest.m
@@ -111,9 +111,17 @@ static NSString *channel = @"plugins.flutter.io/google_mobile_ads";
                               customOptions:nil
                          rootViewController:OCMClassMock([UIViewController class])];
   [_manager loadAd:ad adId:@(1)];
-
-  [_manager onAdLoaded:ad];
-  NSData *data = [self getDataForEvent:@"onAdLoaded" adId:@1];
+  
+  GADResponseInfo *responseInfo = OCMClassMock([GADResponseInfo class]);
+  FLTGADResponseInfo * fltResponseInfo = [[FLTGADResponseInfo alloc] initWithResponseInfo:responseInfo];
+  [_manager onAdLoaded:ad responseInfo:responseInfo];
+  NSData *data = [_methodCodec
+      encodeMethodCall:[FlutterMethodCall methodCallWithMethodName:@"onAdEvent"
+                                                         arguments:@{
+                                                           @"adId" : @1,
+                                                           @"eventName" : @"onAdLoaded",
+                                                           @"responseInfo" : fltResponseInfo,
+                                                         }]];
   OCMVerify([_mockMessenger sendOnChannel:channel message:data]);
 }
 

--- a/packages/google_mobile_ads/ios/Tests/FLTInterstitialAdTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTInterstitialAdTest.m
@@ -63,13 +63,16 @@
     [delegate adWillDismissFullScreenContent:interstitialClassMock];
     [delegate ad:interstitialClassMock didFailToPresentFullScreenContentWithError:error];
   });
+  
+  GADResponseInfo *mockResponseInfo = OCMClassMock([GADResponseInfo class]);
+  OCMStub([interstitialClassMock responseInfo]).andReturn(mockResponseInfo);
 
   [ad load];
 
   OCMVerify(ClassMethod([interstitialClassMock loadWithAdUnitID:[OCMArg isEqual:@"testId"]
                                           request:[OCMArg isEqual:gadRequest]
                                 completionHandler:[OCMArg any]]));
-  OCMVerify([mockManager onAdLoaded:[OCMArg isEqual:ad]]);
+  OCMVerify([mockManager onAdLoaded:[OCMArg isEqual:ad] responseInfo:[OCMArg isEqual:mockResponseInfo]]);
   OCMVerify([interstitialClassMock setFullScreenContentDelegate:[OCMArg isEqual:ad]]);
   XCTAssertEqual(ad.interstitial, interstitialClassMock);
   

--- a/packages/google_mobile_ads/ios/Tests/FLTNativeAdTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTNativeAdTest.m
@@ -67,7 +67,9 @@
                         }]]);
 
   // Check that nil is used instead of null when customOptions is Null
+  GADResponseInfo *mockResponseInfo = OCMClassMock([GADResponseInfo class]);
   GADNativeAd *mockGADNativeAd = OCMClassMock([GADNativeAd class]);
+  OCMStub([mockGADNativeAd responseInfo]).andReturn(mockResponseInfo);
   [ad adLoader:mockLoader didReceiveNativeAd:mockGADNativeAd];
   if ([NSNull.null isEqual:customOptions] || customOptions == nil) {
     OCMVerify([mockNativeAdFactory createNativeAd:mockGADNativeAd customOptions:[OCMArg isNil]]);
@@ -89,7 +91,8 @@
   [(id<GADNativeAdLoaderDelegate>)ad.adLoader.delegate adLoader:mockLoader
                                              didReceiveNativeAd:mockGADNativeAd];
   
-  OCMVerify([mockManager onAdLoaded:[OCMArg isEqual:ad]]);
+  OCMVerify([mockManager onAdLoaded:[OCMArg isEqual:ad]
+                       responseInfo:[OCMArg isEqual:mockResponseInfo]]);
   
   NSError *error = OCMClassMock([NSError class]);
   [(id<GADNativeAdLoaderDelegate>)ad.adLoader.delegate adLoader:mockLoader

--- a/packages/google_mobile_ads/ios/Tests/FLTRewardedAdTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTRewardedAdTest.m
@@ -98,6 +98,8 @@
     [delegate adWillDismissFullScreenContent:rewardedClassMock];
     [delegate ad:rewardedClassMock didFailToPresentFullScreenContentWithError:error];
   });
+  GADResponseInfo *responseInfo = OCMClassMock([GADResponseInfo class]);
+  OCMStub([rewardedClassMock responseInfo]).andReturn(responseInfo);
   // Stub presentFromRootViewController to invoke reward callback.
   GADAdReward *mockReward = OCMClassMock([GADAdReward class]);
   OCMStub([mockReward amount]).andReturn(@1.0);
@@ -119,7 +121,7 @@
   OCMVerify(ClassMethod([rewardedClassMock loadWithAdUnitID:[OCMArg isEqual:@"testId"]
                                                     request:[OCMArg isEqual:gadOrGAMRequest]
                                           completionHandler:[OCMArg any]]));
-  OCMVerify([mockManager onAdLoaded:[OCMArg isEqual:ad]]);
+  OCMVerify([mockManager onAdLoaded:[OCMArg isEqual:ad] responseInfo:[OCMArg isEqual:responseInfo]]);
   OCMVerify([rewardedClassMock setFullScreenContentDelegate:[OCMArg isEqual:ad]]);
   XCTAssertEqual(ad.rewardedAd, rewardedClassMock);
   if (options != nil) {

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -111,7 +111,7 @@ class AdapterResponseInfo {
   /// A log friendly string version of this object.
   final String description;
 
-  /// A string description of adapter credentials specified in the AdMob or Ad Manager UI
+  /// A string description of adapter credentials specified in the AdMob or Ad Manager UI.
   final String credentials;
 
   /// The error that occurred while rendering the ad.

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -65,7 +65,10 @@ class AdError {
 class ResponseInfo {
   /// Constructs a [ResponseInfo] with the [responseId] and [mediationAdapterClassName].
   @protected
-  const ResponseInfo({this.responseId, this.mediationAdapterClassName});
+  const ResponseInfo({
+    this.responseId,
+    this.mediationAdapterClassName,
+    this.adapterResponses});
 
   /// An identifier for the loaded ad.
   final String? responseId;
@@ -73,11 +76,48 @@ class ResponseInfo {
   /// The mediation adapter class name of the ad network that loaded the ad.
   final String? mediationAdapterClassName;
 
+  /// The [AdapterResponseInfo]s containing metadata for each adapter included
+  /// in the ad response.
+  ///
+  /// Can be used to debug the mediation waterfall execution.
+  final List<AdapterResponseInfo>? adapterResponses;
+
   @override
   String toString() {
     return '$runtimeType(responseId: $responseId, '
         'mediationAdapterClassName: $mediationAdapterClassName)';
   }
+}
+
+/// Response information for an individual ad network in an ad response.
+class AdapterResponseInfo {
+
+  /// Constructs an [AdapterResponseInfo].
+  @protected
+  AdapterResponseInfo({
+    required this.adapterClassName,
+    required this.latencyMillis,
+    required this.message,
+    required this.credentials,
+    this.adError,
+  });
+
+  /// A class name that identifies the ad network adapter.
+  final String adapterClassName;
+
+  /// The amount of time the ad network adapter spent loading an ad.
+  ///
+  /// 0 if the adapter was not attempted.
+  final int latencyMillis;
+
+  /// A log friendly string version of this object.
+  final String message;
+
+  /// A string description of adapter credentials specified in the AdMob or Ad Manager UI
+  final String credentials;
+
+  /// The error that occurred while rendering the ad.
+  final AdError? adError;
 }
 
 /// Represents errors that occur when loading an ad.
@@ -256,7 +296,7 @@ class AdSize {
 /// A valid [adUnitId] is required.
 abstract class Ad {
   /// Default constructor, used by subclasses.
-  const Ad({required this.adUnitId});
+  Ad({required this.adUnitId, this.responseInfo});
 
   /// Identifies the source of [Ad]s for your application.
   ///
@@ -273,6 +313,11 @@ abstract class Ad {
     return instanceManager.adIdFor(this) != null &&
         instanceManager.onAdLoadedCalled(this);
   }
+
+  /// Contains information about the loaded request.
+  ///
+  /// Only present if the ad has been successfully loaded.
+  ResponseInfo? responseInfo;
 }
 
 /// Base class for mobile [Ad] that has an in-line view.
@@ -280,7 +325,7 @@ abstract class Ad {
 /// A valid [adUnitId] and [size] are required.
 abstract class AdWithView extends Ad {
   /// Default constructor, used by subclasses.
-  const AdWithView({required String adUnitId, required this.listener})
+  AdWithView({required String adUnitId, required this.listener})
       : super(adUnitId: adUnitId);
 
   /// The [AdWithViewListener] for the ad.

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -95,7 +95,7 @@ class AdapterResponseInfo {
   AdapterResponseInfo({
     required this.adapterClassName,
     required this.latencyMillis,
-    required this.message,
+    required this.description,
     required this.credentials,
     this.adError,
   });
@@ -109,7 +109,7 @@ class AdapterResponseInfo {
   final int latencyMillis;
 
   /// A log friendly string version of this object.
-  final String message;
+  final String description;
 
   /// A string description of adapter credentials specified in the AdMob or Ad Manager UI
   final String credentials;
@@ -121,7 +121,7 @@ class AdapterResponseInfo {
   String toString() {
     return '$runtimeType(adapterClassName: $adapterClassName, '
         'latencyMillis: $latencyMillis), '
-        'message: $message, '
+        'description: $description, '
         'credentials: $credentials, '
         'adError: $adError)';
   }

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -85,7 +85,8 @@ class ResponseInfo {
   @override
   String toString() {
     return '$runtimeType(responseId: $responseId, '
-        'mediationAdapterClassName: $mediationAdapterClassName)';
+        'mediationAdapterClassName: $mediationAdapterClassName, '
+         'adapterResponses: $adapterResponses)' ;
   }
 }
 
@@ -118,6 +119,15 @@ class AdapterResponseInfo {
 
   /// The error that occurred while rendering the ad.
   final AdError? adError;
+
+  @override
+  String toString() {
+    return '$runtimeType(adapterClassName: $adapterClassName, '
+        'latencyMillis: $latencyMillis), '
+        'message: $message, '
+        'credentials: $credentials, '
+        'adError: $adError)';
+  }
 }
 
 /// Represents errors that occur when loading an ad.

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -65,10 +65,8 @@ class AdError {
 class ResponseInfo {
   /// Constructs a [ResponseInfo] with the [responseId] and [mediationAdapterClassName].
   @protected
-  const ResponseInfo({
-    this.responseId,
-    this.mediationAdapterClassName,
-    this.adapterResponses});
+  const ResponseInfo(
+      {this.responseId, this.mediationAdapterClassName, this.adapterResponses});
 
   /// An identifier for the loaded ad.
   final String? responseId;
@@ -86,13 +84,12 @@ class ResponseInfo {
   String toString() {
     return '$runtimeType(responseId: $responseId, '
         'mediationAdapterClassName: $mediationAdapterClassName, '
-         'adapterResponses: $adapterResponses)' ;
+        'adapterResponses: $adapterResponses)';
   }
 }
 
 /// Response information for an individual ad network in an ad response.
 class AdapterResponseInfo {
-
   /// Constructs an [AdapterResponseInfo].
   @protected
   AdapterResponseInfo({

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -182,8 +182,8 @@ class AdInstanceManager {
   void _invokeOnAdLoaded(
       Ad ad, String eventName, Map<dynamic, dynamic> arguments) {
     _onAdLoadedAds.add(ad);
-    
-    ad.responseInfo = arguments['responseInfo']; 
+
+    ad.responseInfo = arguments['responseInfo'];
     if (ad is AdWithView) {
       ad.listener.onAdLoaded?.call(ad);
     } else if (ad is RewardedAd) {
@@ -611,16 +611,16 @@ class AdMessageCodec extends StandardMessageCodec {
         return ResponseInfo(
           responseId: readValueOfType(buffer.getUint8(), buffer),
           mediationAdapterClassName: readValueOfType(buffer.getUint8(), buffer),
-          adapterResponses: readValueOfType(buffer.getUint8(), buffer)?.cast<AdapterResponseInfo>(),
+          adapterResponses: readValueOfType(buffer.getUint8(), buffer)
+              ?.cast<AdapterResponseInfo>(),
         );
       case _valueAdapterResponseInfo:
         return AdapterResponseInfo(
-          adapterClassName: readValueOfType(buffer.getUint8(), buffer),
-          latencyMillis: readValueOfType(buffer.getUint8(), buffer),
-          message: readValueOfType(buffer.getUint8(), buffer),
-          credentials: readValueOfType(buffer.getUint8(), buffer),
-          adError: readValueOfType(buffer.getUint8(), buffer)
-        );
+            adapterClassName: readValueOfType(buffer.getUint8(), buffer),
+            latencyMillis: readValueOfType(buffer.getUint8(), buffer),
+            message: readValueOfType(buffer.getUint8(), buffer),
+            credentials: readValueOfType(buffer.getUint8(), buffer),
+            adError: readValueOfType(buffer.getUint8(), buffer));
       case _valueLoadAdError:
         return LoadAdError(
           readValueOfType(buffer.getUint8(), buffer),

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -547,7 +547,7 @@ class AdMessageCodec extends StandardMessageCodec {
       buffer.putUint8(_valueAdapterResponseInfo);
       writeValue(buffer, value.adapterClassName);
       writeValue(buffer, value.latencyMillis);
-      writeValue(buffer, value.message);
+      writeValue(buffer, value.description);
       writeValue(buffer, value.credentials);
       writeValue(buffer, value.adError);
     } else if (value is LoadAdError) {
@@ -618,7 +618,7 @@ class AdMessageCodec extends StandardMessageCodec {
         return AdapterResponseInfo(
             adapterClassName: readValueOfType(buffer.getUint8(), buffer),
             latencyMillis: readValueOfType(buffer.getUint8(), buffer),
-            message: readValueOfType(buffer.getUint8(), buffer),
+            description: readValueOfType(buffer.getUint8(), buffer),
             credentials: readValueOfType(buffer.getUint8(), buffer),
             adError: readValueOfType(buffer.getUint8(), buffer));
       case _valueLoadAdError:

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -182,6 +182,8 @@ class AdInstanceManager {
   void _invokeOnAdLoaded(
       Ad ad, String eventName, Map<dynamic, dynamic> arguments) {
     _onAdLoadedAds.add(ad);
+    
+    ad.responseInfo = arguments['responseInfo']; 
     if (ad is AdWithView) {
       ad.listener.onAdLoaded?.call(ad);
     } else if (ad is RewardedAd) {
@@ -519,6 +521,7 @@ class AdMessageCodec extends StandardMessageCodec {
   static const int _valueServerSideVerificationOptions = 138;
   static const int _valueAdError = 139;
   static const int _valueResponseInfo = 140;
+  static const int _valueAdapterResponseInfo = 141;
 
   @override
   void writeValue(WriteBuffer buffer, dynamic value) {
@@ -539,6 +542,14 @@ class AdMessageCodec extends StandardMessageCodec {
       buffer.putUint8(_valueResponseInfo);
       writeValue(buffer, value.responseId);
       writeValue(buffer, value.mediationAdapterClassName);
+      writeValue(buffer, value.adapterResponses);
+    } else if (value is AdapterResponseInfo) {
+      buffer.putUint8(_valueAdapterResponseInfo);
+      writeValue(buffer, value.adapterClassName);
+      writeValue(buffer, value.latencyMillis);
+      writeValue(buffer, value.message);
+      writeValue(buffer, value.credentials);
+      writeValue(buffer, value.adError);
     } else if (value is LoadAdError) {
       buffer.putUint8(_valueLoadAdError);
       writeValue(buffer, value.code);
@@ -600,6 +611,15 @@ class AdMessageCodec extends StandardMessageCodec {
         return ResponseInfo(
           responseId: readValueOfType(buffer.getUint8(), buffer),
           mediationAdapterClassName: readValueOfType(buffer.getUint8(), buffer),
+          adapterResponses: readValueOfType(buffer.getUint8(), buffer)?.cast<AdapterResponseInfo>(),
+        );
+      case _valueAdapterResponseInfo:
+        return AdapterResponseInfo(
+          adapterClassName: readValueOfType(buffer.getUint8(), buffer),
+          latencyMillis: readValueOfType(buffer.getUint8(), buffer),
+          message: readValueOfType(buffer.getUint8(), buffer),
+          credentials: readValueOfType(buffer.getUint8(), buffer),
+          adError: readValueOfType(buffer.getUint8(), buffer)
         );
       case _valueLoadAdError:
         return LoadAdError(

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -632,8 +632,17 @@ void main() {
       );
 
       await banner.load();
+      AdError adError = AdError(1, 'domain', 'error-message');
+      AdapterResponseInfo adapterResponseInfo = AdapterResponseInfo(
+          adapterClassName: 'adapter-name',
+          latencyMillis: 500,
+          message: 'message',
+          credentials: 'credentials',
+          adError: adError);
+
+      List<AdapterResponseInfo> adapterResponses = [adapterResponseInfo];
       ResponseInfo responseInfo = ResponseInfo(
-          responseId: 'id', mediationAdapterClassName: 'className');
+          responseId: 'id', mediationAdapterClassName: 'className', adapterResponses: adapterResponses,);
 
       final MethodCall methodCall = MethodCall('onAdEvent', <dynamic, dynamic>{
         'adId': 0,
@@ -658,6 +667,14 @@ void main() {
       expect(results[1].responseInfo.responseId, responseInfo.responseId);
       expect(results[1].responseInfo.mediationAdapterClassName,
           responseInfo.mediationAdapterClassName);
+      List<AdapterResponseInfo> responses = results[1].responseInfo.adapterResponses;
+      expect(responses.first.adapterClassName, 'adapter-name');
+      expect(responses.first.latencyMillis, 500);
+      expect(responses.first.message, 'message');
+      expect(responses.first.credentials, 'credentials');
+      expect(responses.first.adError!.code, 1);
+      expect(responses.first.adError!.message, 'error-message');
+      expect(responses.first.adError!.domain, 'domain');
     });
 
     test('onNativeAdClicked', () async {
@@ -837,6 +854,7 @@ void main() {
       final ResponseInfo responseInfo = ResponseInfo(
         responseId: 'id',
         mediationAdapterClassName: 'class',
+        adapterResponses: null
       );
       final ByteData byteData = codec.encodeMessage(
         LoadAdError(1, 'domain', 'message', responseInfo),
@@ -848,6 +866,7 @@ void main() {
       expect(error.responseInfo?.responseId, responseInfo.responseId);
       expect(error.responseInfo?.mediationAdapterClassName,
           responseInfo.mediationAdapterClassName);
+      expect(error.responseInfo?.adapterResponses, null);
     });
 
     test('encode/decode $RewardItem', () async {

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -642,7 +642,10 @@ void main() {
 
       List<AdapterResponseInfo> adapterResponses = [adapterResponseInfo];
       ResponseInfo responseInfo = ResponseInfo(
-          responseId: 'id', mediationAdapterClassName: 'className', adapterResponses: adapterResponses,);
+        responseId: 'id',
+        mediationAdapterClassName: 'className',
+        adapterResponses: adapterResponses,
+      );
 
       final MethodCall methodCall = MethodCall('onAdEvent', <dynamic, dynamic>{
         'adId': 0,
@@ -667,7 +670,8 @@ void main() {
       expect(results[1].responseInfo.responseId, responseInfo.responseId);
       expect(results[1].responseInfo.mediationAdapterClassName,
           responseInfo.mediationAdapterClassName);
-      List<AdapterResponseInfo> responses = results[1].responseInfo.adapterResponses;
+      List<AdapterResponseInfo> responses =
+          results[1].responseInfo.adapterResponses;
       expect(responses.first.adapterClassName, 'adapter-name');
       expect(responses.first.latencyMillis, 500);
       expect(responses.first.message, 'message');
@@ -852,10 +856,9 @@ void main() {
 
     test('encode/decode $LoadAdError', () async {
       final ResponseInfo responseInfo = ResponseInfo(
-        responseId: 'id',
-        mediationAdapterClassName: 'class',
-        adapterResponses: null
-      );
+          responseId: 'id',
+          mediationAdapterClassName: 'class',
+          adapterResponses: null);
       final ByteData byteData = codec.encodeMessage(
         LoadAdError(1, 'domain', 'message', responseInfo),
       )!;

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -636,7 +636,7 @@ void main() {
       AdapterResponseInfo adapterResponseInfo = AdapterResponseInfo(
           adapterClassName: 'adapter-name',
           latencyMillis: 500,
-          message: 'message',
+          description: 'message',
           credentials: 'credentials',
           adError: adError);
 
@@ -674,7 +674,7 @@ void main() {
           results[1].responseInfo.adapterResponses;
       expect(responses.first.adapterClassName, 'adapter-name');
       expect(responses.first.latencyMillis, 500);
-      expect(responses.first.message, 'message');
+      expect(responses.first.description, 'message');
       expect(responses.first.credentials, 'credentials');
       expect(responses.first.adError!.code, 1);
       expect(responses.first.adError!.message, 'error-message');


### PR DESCRIPTION
## Description

- Adds  support for `AdapterResponse` to `ResponseInfo` 
- Adds `ResponseInfo` to the base `Ad` class, which gets set after an ad successfully loads

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/googleads/googleads-mobile-flutter/issues). Indicate, which of these issues are resolved or fixed by this PR.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.