### PR TITLE
Remove ad parameter from OnAdFailedToLoad for full screen ads

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.13.0
 
-* Updates GMA Android and iOS dependencies to 20.0.0 and 8.4.0, respectively.
+* Updates GMA Android and iOS dependencies to 20.1.0 and 8.5.0, respectively.
 * Renames APIs that use the `Publisher` prefix to `AdManager`.
 * Rewarded and Interstitial ads now provide static `load` methods and a new `FullScreenContentCallback` for full screen events.
 * Native ads use [GADNativeAdView](https://developers.google.com/ad-manager/mobile-ads-sdk/ios/api/reference/Classes/GADNativeAdView) for iOS 

--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -8,6 +8,8 @@ and [NativeAdView](https://developers.google.com/android/reference/com/google/an
 * Adds support for [ResponseInfo](https://developers.google.com/admob/android/response-info).
 * Adds support for [same app key](https://developers.google.com/admob/ios/ios14#same_app_key) on iOS.
 * Removes `testDevices` from `AdRequest`. Use `MobileAds.updateRequestConfiguration` to set test device ids.
+* Removes `Ad.isLoaded()`. Instead you should use the `onAdLoaded` callback to track whether an ad is loaded.
+* Removes need to call `Ad.dispose()` for Rewarded and Interstitial ads when they fail to load.
 
 ## 0.12.2
 

--- a/packages/google_mobile_ads/README.md
+++ b/packages/google_mobile_ads/README.md
@@ -339,9 +339,8 @@ InterstitialAd.load(
       // Keep a reference to the ad so you can show it later.
       this._interstitialAd = ad;
     },
-    onAdFailedToLoad: (InterstitialAd ad, LoadAdError error) {
-      print('$ad failed to load: $error');
-      ad.dispose();
+    onAdFailedToLoad: (LoadAdError error) {
+      print('InterstitialAd failed to load: $error');
     },
   ));
 ```
@@ -379,7 +378,7 @@ myInterstitial.show();
 
 Once `show()` is called, an `Ad` displayed this way can't be removed programmatically and requires user input. An `InterstitialAd` can only be shown once. Subsequent calls to show will trigger `onAdFailedToShowFullScreenContent`.
 
-Once an ad has called `load()`, it must call `dispose()` when access to it is no longer needed. The best practice for when to call `dispose()` is in the `InterstitialAdLoadCallback.onAdFailedToLoad`, `FullScreenContentCallback.onAdDismissedFullScreenContent`, and `FullScreenContentCallback.onAdFailedToShowFullScreenContent` callbacks.
+Once an ad has called `load()`, it must call `dispose()` when access to it is no longer needed. The best practice for when to call `dispose()` is in the `FullScreenContentCallback.onAdDismissedFullScreenContent` and `FullScreenContentCallback.onAdFailedToShowFullScreenContent` callbacks.
 
 That's it! Your app is now ready to display interstitial ads.
 
@@ -738,9 +737,8 @@ RewardedAd.load(
       // Keep a reference to the ad so you can show it later.
       this._rewardedAd = ad;
     },
-    onAdFailedToLoad: (RewardedAd ad, LoadAdError error) {
-      print('$ad failed to load: $error');
-      ad.dispose();
+    onAdFailedToLoad: (LoadAdError error) {
+      print('RewardedAd failed to load: $error');
     },
 );
 ```
@@ -782,7 +780,7 @@ myRewarded.show(onUserEarnedReward: (RewardedAd ad, RewardItem rewardItem) {
 
 Once `show()` is called, an `Ad` displayed this way can't be removed programmatically and require user input. An `RewardedAd` can only be shown once. Subsequent calls to show will trigger `onAdFailedToShowFullScreenContent`.
 
-Once an ad has called `load()`, it must call `dispose()` when access to it is no longer needed. The best practice for when to call `dispose()` is in the `RewardedAdLoadCallback.onAdFailedToLoad`, `FullScreenContentCallback.onAdDismissedFullScreenContent`, and `FullScreenContentCallback.onAdFailedToShowFullScreenContent` callbacks.
+Once an ad has called `load()`, it must call `dispose()` when access to it is no longer needed. The best practice for when to call `dispose()` is in the `FullScreenContentCallback.onAdDismissedFullScreenContent` and `FullScreenContentCallback.onAdFailedToShowFullScreenContent` callbacks.
 
 That's it! Your app is now ready to display rewarded ads.
 
@@ -1018,9 +1016,8 @@ AdManagerInterstitialAd.load(
       // Keep a reference to the ad so you can show it later.
       this._interstitialAd = ad;
     },
-    onAdFailedToLoad: (AdManagerInterstitialAd ad, LoadAdError error) {
-      print('$ad failed to load: $error');
-      ad.dispose();
+    onAdFailedToLoad: (LoadAdError error) {
+      print('InterstitialAd failed to load: $error');
     },
   ));
 ```
@@ -1058,7 +1055,7 @@ myInterstitial.show();
 
 Once `show()` is called, an `Ad` displayed this way can't be removed programmatically and requires user input. An `InterstitialAd` can only be shown once. Subsequent calls to show will trigger `onAdFailedToShowFullScreenContent`.
 
-Once an ad has called `load()`, it must call `dispose()` when access to it is no longer needed. The best practice for when to call `dispose()` is in the `AdManagerInterstitialAdLoadCallback.onAdFailedToLoad`, `FullScreenContentCallback.onAdDismissedFullScreenContent`, and `FullScreenContentCallback.onAdFailedToShowFullScreenContent` callbacks.
+Once an ad has called `load()`, it must call `dispose()` when access to it is no longer needed. The best practice for when to call `dispose()` is in the `FullScreenContentCallback.onAdDismissedFullScreenContent` and `FullScreenContentCallback.onAdFailedToShowFullScreenContent` callbacks.
 
 That's it! Your app is now ready to display interstitial ads.
 
@@ -1415,9 +1412,8 @@ RewardedAd.loadWithAdManagerAdRequest(
       // Keep a reference to the ad so you can show it later.
       this._rewardedAd = ad;
     },
-    onAdFailedToLoad: (RewardedAd ad, LoadAdError error) {
-      print('$ad failed to load: $error');
-      ad.dispose();
+    onAdFailedToLoad: (LoadAdError error) {
+      print('RewardedAd failed to load: $error');
     },
 );
 ```
@@ -1461,7 +1457,7 @@ myRewarded.show(onUserEarnedReward: (RewardedAd ad, RewardItem rewardItem) {
 
 Once `show()` is called, an `Ad` displayed this way can't be removed programmatically and require user input.  Do not call `show()` more than once for a loaded `RewardedAd`. Instead you should load a new ad.
 
-Once an ad has called `load()`, it must call `dispose()` when access to it is no longer needed. The best practice for when to call `dispose()` is in the `RewardedAdLoadCallback.onAdFailedToLoad`, `FullScreenContentCallback.onAdDismissedFullScreenContent`, and `FullScreenContentCallback.onAdFailedToShowFullScreenContent` callbacks.
+Once an ad has called `load()`, it must call `dispose()` when access to it is no longer needed. The best practice for when to call `dispose()` is in the `FullScreenContentCallback.onAdDismissedFullScreenContent` and `FullScreenContentCallback.onAdFailedToShowFullScreenContent` callbacks.
 
 That's it! Your app is now ready to display rewarded ads.
 

--- a/packages/google_mobile_ads/android/build.gradle
+++ b/packages/google_mobile_ads/android/build.gradle
@@ -32,7 +32,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-      api 'com.google.android.gms:play-services-ads:20.0.0'
+      api 'com.google.android.gms:play-services-ads:20.1.0'
       testImplementation 'junit:junit:4.12'
       testImplementation 'org.hamcrest:hamcrest:2.2'
       testImplementation 'org.mockito:mockito-inline:3.9.0'

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
@@ -241,7 +241,7 @@ class AdMessageCodec extends StandardMessageCodec {
       writeValue(stream, size.height);
     } else if (value instanceof FlutterAdSize.SmartBannerAdSize) {
       stream.write(VALUE_SMART_BANNER_AD_SIZE);
-    } else if (value instanceof FlutterAdSize) {
+    } else {
       stream.write(VALUE_AD_SIZE);
       writeValue(stream, value.width);
       writeValue(stream, value.height);

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAd.java
@@ -161,7 +161,7 @@ abstract class FlutterAd {
 
       final FlutterAdapterResponseInfo that = (FlutterAdapterResponseInfo) obj;
       return Objects.equals(adapterClassName, that.adapterClassName)
-          && Objects.equals(latencyMillis, that.latencyMillis)
+          && latencyMillis == that.latencyMillis
           && Objects.equals(description, that.description)
           && Objects.equals(credentials, that.credentials)
           && Objects.equals(error, that.error);

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequest.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequest.java
@@ -135,8 +135,11 @@ class FlutterAdManagerAdRequest {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (!(o instanceof FlutterAdManagerAdRequest)) return false;
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof FlutterAdManagerAdRequest)) {
+      return false;
+    }
 
     FlutterAdManagerAdRequest request = (FlutterAdManagerAdRequest) o;
 

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequest.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequest.java
@@ -20,6 +20,7 @@ import com.google.ads.mediation.admob.AdMobAdapter;
 import com.google.android.gms.ads.admanager.AdManagerAdRequest;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Instantiates and serializes {@link com.google.android.gms.ads.admanager.AdManagerAdRequest} for
@@ -143,19 +144,11 @@ class FlutterAdManagerAdRequest {
 
     FlutterAdManagerAdRequest request = (FlutterAdManagerAdRequest) o;
 
-    return objectEquals(keywords, request.keywords)
-        && objectEquals(contentUrl, request.contentUrl)
-        && objectEquals(customTargeting, request.customTargeting)
-        && objectEquals(nonPersonalizedAds, request.nonPersonalizedAds)
-        && objectEquals(customTargetingLists, request.customTargetingLists);
-  }
-
-  /**
-   * Calculate object equality between l and r. We can't use Objects.equals() due to backwards
-   * compatibility to API 16.
-   */
-  private boolean objectEquals(Object l, Object r) {
-    return (l == null) ? (r == null) : (l.equals(r));
+    return Objects.equals(keywords, request.keywords)
+        && Objects.equals(contentUrl, request.contentUrl)
+        && Objects.equals(customTargeting, request.customTargeting)
+        && Objects.equals(nonPersonalizedAds, request.nonPersonalizedAds)
+        && Objects.equals(customTargetingLists, request.customTargetingLists);
   }
 
   @Override

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterInterstitialAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterInterstitialAd.java
@@ -58,8 +58,6 @@ class FlutterInterstitialAd extends FlutterAd.FlutterOverlayAd {
                   interstitialAd.getResponseInfo());
             }
 
-            }
-
             @Override
             public void onAdFailedToLoad(@NonNull LoadAdError loadAdError) {
               FlutterInterstitialAd.this.manager.onAdFailedToLoad(

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterInterstitialAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterInterstitialAd.java
@@ -43,25 +43,32 @@ class FlutterInterstitialAd extends FlutterAd.FlutterOverlayAd {
 
   @Override
   void load() {
-    if (manager != null && adUnitId != null && request != null)
+    if (manager != null && adUnitId != null && request != null) {
       flutterAdLoader.loadInterstitial(
           manager.activity,
           adUnitId,
           request.asAdRequest(),
           new InterstitialAdLoadCallback() {
             @Override
-            public void onAdLoaded(@NonNull InterstitialAd interstitialAd) {
+            public void onAdLoaded(
+                @NonNull InterstitialAd interstitialAd) {
               FlutterInterstitialAd.this.ad = interstitialAd;
               FlutterInterstitialAd.this.manager.onAdLoaded(
-                  FlutterInterstitialAd.this, interstitialAd.getResponseInfo());
+                  FlutterInterstitialAd.this,
+                  interstitialAd.getResponseInfo());
+            }
+
             }
 
             @Override
             public void onAdFailedToLoad(@NonNull LoadAdError loadAdError) {
               FlutterInterstitialAd.this.manager.onAdFailedToLoad(
-                  FlutterInterstitialAd.this, new FlutterAd.FlutterLoadAdError(loadAdError));
+                  FlutterInterstitialAd.this,
+                  new FlutterAd.FlutterLoadAdError(loadAdError));
             }
-          });
+          }
+      );
+    }
   }
 
   @Override

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterInterstitialAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterInterstitialAd.java
@@ -50,22 +50,18 @@ class FlutterInterstitialAd extends FlutterAd.FlutterOverlayAd {
           request.asAdRequest(),
           new InterstitialAdLoadCallback() {
             @Override
-            public void onAdLoaded(
-                @NonNull InterstitialAd interstitialAd) {
+            public void onAdLoaded(@NonNull InterstitialAd interstitialAd) {
               FlutterInterstitialAd.this.ad = interstitialAd;
               FlutterInterstitialAd.this.manager.onAdLoaded(
-                  FlutterInterstitialAd.this,
-                  interstitialAd.getResponseInfo());
+                  FlutterInterstitialAd.this, interstitialAd.getResponseInfo());
             }
 
             @Override
             public void onAdFailedToLoad(@NonNull LoadAdError loadAdError) {
               FlutterInterstitialAd.this.manager.onAdFailedToLoad(
-                  FlutterInterstitialAd.this,
-                  new FlutterAd.FlutterLoadAdError(loadAdError));
+                  FlutterInterstitialAd.this, new FlutterAd.FlutterLoadAdError(loadAdError));
             }
-          }
-      );
+          });
     }
   }
 

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -377,7 +377,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
                 new FlutterAdSize.AdSizeFactory(),
                 call.<String>argument("orientation"),
                 call.<Integer>argument("width"));
-        if (size.size == AdSize.INVALID) {
+        if (AdSize.INVALID.equals(size.size)) {
           result.success(null);
         } else {
           result.success(size);

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
+/** Tests for {@link AdMessageCodec}. */
 public class AdMessageCodecTest {
   static class TestMessageCodec extends AdMessageCodec {
     TestMessageCodec(@NonNull Context context, @NonNull FlutterAdSize.AdSizeFactory adSizeFactory) {

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerInterstitialAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerInterstitialAdTest.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+/** Tests for {@link FlutterAdManagerInterstitialAd}. */
 public class FlutterAdManagerInterstitialAdTest {
 
   private AdInstanceManager mockManager;

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterNativeAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterNativeAdTest.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+/** Tests for {@link FlutterNativeAd}. */
 public class FlutterNativeAdTest {
 
   private AdInstanceManager testManager;

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
@@ -15,9 +15,12 @@
 package io.flutter.plugins.googlemobileads;
 
 import static org.hamcrest.Matchers.hasEntry;
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -47,6 +50,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+/** Tests {@link AdInstanceManager}. */
 public class GoogleMobileAdsTest {
   private AdInstanceManager testManager;
   private final FlutterAdRequest request = new FlutterAdRequest.Builder().build();

--- a/packages/google_mobile_ads/example/ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/packages/google_mobile_ads/example/ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/packages/google_mobile_ads/example/ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/packages/google_mobile_ads/example/ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/packages/google_mobile_ads/example/lib/main.dart
+++ b/packages/google_mobile_ads/example/lib/main.dart
@@ -71,9 +71,8 @@ class _MyAppState extends State<MyApp> {
             _interstitialAd = ad;
             _numInterstitialLoadAttempts = 0;
           },
-          onAdFailedToLoad: (InterstitialAd ad, LoadAdError error) {
-            print('$ad failed to load: $error.');
-            ad.dispose();
+          onAdFailedToLoad: (LoadAdError error) {
+            print('InterstitialAd failed to load: $error.');
             _numInterstitialLoadAttempts += 1;
             _interstitialAd = null;
             if (_numInterstitialLoadAttempts <= maxFailedLoadAttempts) {
@@ -116,9 +115,8 @@ class _MyAppState extends State<MyApp> {
             _rewardedAd = ad;
             _numRewardedLoadAttempts = 0;
           },
-          onAdFailedToLoad: (RewardedAd ad, LoadAdError error) {
-            print('$ad failed to load: $error');
-            ad.dispose();
+          onAdFailedToLoad: (LoadAdError error) {
+            print('RewardedAd failed to load: $error');
             _rewardedAd = null;
             _numRewardedLoadAttempts += 1;
             if (_numRewardedLoadAttempts <= maxFailedLoadAttempts) {

--- a/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.h
@@ -30,7 +30,7 @@
 - (void)loadAd:(id<FLTAd> _Nonnull)ad adId:(NSNumber *_Nonnull)adId;
 - (void)dispose:(NSNumber *_Nonnull)adId;
 - (void)showAdWithID:(NSNumber *_Nonnull)adId;
-- (void)onAdLoaded:(id<FLTAd> _Nonnull)ad responseInfo:(GADResponseInfo * _Nonnull)responseInfo;
+- (void)onAdLoaded:(id<FLTAd> _Nonnull)ad responseInfo:(GADResponseInfo *_Nonnull)responseInfo;
 - (void)onAdFailedToLoad:(id<FLTAd> _Nonnull)ad error:(NSError *_Nonnull)error;
 - (void)onAppEvent:(id<FLTAd> _Nonnull)ad
               name:(NSString *_Nullable)name

--- a/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.h
@@ -30,7 +30,7 @@
 - (void)loadAd:(id<FLTAd> _Nonnull)ad adId:(NSNumber *_Nonnull)adId;
 - (void)dispose:(NSNumber *_Nonnull)adId;
 - (void)showAdWithID:(NSNumber *_Nonnull)adId;
-- (void)onAdLoaded:(id<FLTAd> _Nonnull)ad responseInfo:(GADResponseInfo *)responseInfo;
+- (void)onAdLoaded:(id<FLTAd> _Nonnull)ad responseInfo:(GADResponseInfo * _Nonnull)responseInfo;
 - (void)onAdFailedToLoad:(id<FLTAd> _Nonnull)ad error:(NSError *_Nonnull)error;
 - (void)onAppEvent:(id<FLTAd> _Nonnull)ad
               name:(NSString *_Nullable)name

--- a/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.m
@@ -169,8 +169,12 @@
 
 - (void)didFailToPresentFullScreenContentWithError:(id<FLTAd> _Nonnull)ad
                                              error:(NSError *_Nonnull)error {
-  [_channel invokeMethod:@"didFailToPresentFullScreenContentWithError"
-               arguments:@{@"adId" : [self adIdFor:ad], @"error" : error}];
+  [_channel invokeMethod:@"onAdEvent"
+               arguments:@{
+                 @"adId" : [self adIdFor:ad],
+                 @"eventName" : @"didFailToPresentFullScreenContentWithError",
+                 @"error" : error
+               }];
 }
 
 /// Sends an ad event with the provided name.

--- a/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.m
@@ -77,7 +77,7 @@
   [ad show];
 }
 
-- (void)onAdLoaded:(id<FLTAd> _Nonnull)ad responseInfo:(GADResponseInfo *)responseInfo {
+- (void)onAdLoaded:(id<FLTAd> _Nonnull)ad responseInfo:(GADResponseInfo * _Nonnull)responseInfo {
   [_channel invokeMethod:@"onAdEvent"
                arguments:@{
                  @"adId" : [self adIdFor:ad],

--- a/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.m
@@ -77,7 +77,7 @@
   [ad show];
 }
 
-- (void)onAdLoaded:(id<FLTAd> _Nonnull)ad responseInfo:(GADResponseInfo * _Nonnull)responseInfo {
+- (void)onAdLoaded:(id<FLTAd> _Nonnull)ad responseInfo:(GADResponseInfo *_Nonnull)responseInfo {
   [_channel invokeMethod:@"onAdEvent"
                arguments:@{
                  @"adId" : [self adIdFor:ad],

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
@@ -106,7 +106,8 @@
     result(nil);
   } else if ([call.method isEqualToString:@"MobileAds#setSameAppKeyEnabled"]) {
     GADRequestConfiguration *requestConfig = GADMobileAds.sharedInstance.requestConfiguration;
-    [requestConfig setSameAppKeyEnabled:call.arguments[@"isEnabled"]];
+    NSNumber *isEnabled = call.arguments[@"isEnabled"];
+    [requestConfig setSameAppKeyEnabled:isEnabled.boolValue];
     result(nil);
   } else if ([call.method isEqualToString:@"MobileAds#updateRequestConfiguration"]) {
     NSString *maxAdContentRating = call.arguments[@"maxAdContentRating"];

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
@@ -116,7 +116,7 @@
   OCMVerify([_mockAdInstanceManager disposeAllAds]);
 }
 
-- (void)testSetSameAppKeyEnabled {
+- (void)testSetSameAppKeyEnabledYes {
   id gadMobileAdsClassMock = OCMClassMock([GADMobileAds class]);
   OCMStub(ClassMethod([gadMobileAdsClassMock sharedInstance]))
       .andReturn((GADMobileAds *)gadMobileAdsClassMock);
@@ -140,6 +140,49 @@
   XCTAssertTrue(resultInvoked);
   XCTAssertNil(returnedResult);
   OCMVerify([gadRequestConfigurationMock setSameAppKeyEnabled:[OCMArg isEqual:@(YES)]]);
+}
+
+- (void)testSetSameAppKeyEnabledNo {
+  id gadMobileAdsClassMock = OCMClassMock([GADMobileAds class]);
+  OCMStub(ClassMethod([gadMobileAdsClassMock sharedInstance]))
+      .andReturn((GADMobileAds *)gadMobileAdsClassMock);
+  GADRequestConfiguration *gadRequestConfigurationMock =
+      OCMClassMock([GADRequestConfiguration class]);
+  OCMStub([gadMobileAdsClassMock requestConfiguration]).andReturn(gadRequestConfigurationMock);
+
+  FlutterMethodCall *methodCall =
+      [FlutterMethodCall methodCallWithMethodName:@"MobileAds#setSameAppKeyEnabled"
+                                        arguments:@{@"isEnabled" : @0}];
+
+  __block bool resultInvoked = false;
+  __block id _Nullable returnedResult;
+  FlutterResult result = ^(id _Nullable result) {
+    resultInvoked = true;
+    returnedResult = result;
+  };
+
+  [_fltGoogleMobileAdsPlugin handleMethodCall:methodCall result:result];
+
+  XCTAssertTrue(resultInvoked);
+  XCTAssertNil(returnedResult);
+  OCMVerify([gadRequestConfigurationMock setSameAppKeyEnabled:NO]);
+
+  FlutterMethodCall *methodCallWithBool =
+      [FlutterMethodCall methodCallWithMethodName:@"MobileAds#setSameAppKeyEnabled"
+                                        arguments:@{@"isEnabled" : @NO}];
+
+  __block bool resultInvokedWithBool = false;
+  __block id _Nullable returnedResultWithBool;
+  FlutterResult resultWithBool = ^(id _Nullable result) {
+    resultInvokedWithBool = true;
+    returnedResultWithBool = result;
+  };
+
+  [_fltGoogleMobileAdsPlugin handleMethodCall:methodCallWithBool result:resultWithBool];
+
+  XCTAssertTrue(resultInvokedWithBool);
+  XCTAssertNil(returnedResultWithBool);
+  OCMVerify([gadRequestConfigurationMock setSameAppKeyEnabled:NO]);
 }
 
 @end

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsTest.m
@@ -150,6 +150,26 @@ static NSString *channel = @"plugins.flutter.io/google_mobile_ads";
   OCMVerify([_mockMessenger sendOnChannel:channel message:data]);
 }
 
+- (void)testAdInstanceManagerOnAdFailedToShow {
+  FLTInterstitialAd *ad = OCMClassMock([FLTInterstitialAd class]);
+  [_manager loadAd:ad adId:@(1)];
+
+  NSDictionary *userInfo = @{NSLocalizedDescriptionKey : @"message"};
+  NSError *error = [NSError errorWithDomain:@"domain" code:1 userInfo:userInfo];
+
+  [_manager didFailToPresentFullScreenContentWithError:ad error:error];
+  NSData *data = [_methodCodec
+      encodeMethodCall:[FlutterMethodCall
+                           methodCallWithMethodName:@"onAdEvent"
+                                          arguments:@{
+                                            @"adId" : @1,
+                                            @"eventName" :
+                                                @"didFailToPresentFullScreenContentWithError",
+                                            @"error" : error,
+                                          }]];
+  OCMVerify([_mockMessenger sendOnChannel:channel message:data]);
+}
+
 - (void)testAdInstanceManagerOnAppEvent {
   FLTNativeAd *ad =
       [[FLTNativeAd alloc] initWithAdUnitId:@"testAdUnitId"

--- a/packages/google_mobile_ads/ios/google_mobile_ads.podspec
+++ b/packages/google_mobile_ads/ios/google_mobile_ads.podspec
@@ -15,7 +15,7 @@ Google Mobile Ads plugin for Flutter.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'Google-Mobile-Ads-SDK','8.4.0'
+  s.dependency 'Google-Mobile-Ads-SDK','8.5.0'
   s.ios.deployment_target = '9.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS' => 'armv7 arm64 x86_64' }
   s.static_framework = true

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -352,12 +352,6 @@ abstract class Ad {
     return instanceManager.disposeAd(this);
   }
 
-  /// Whether this [Ad.load] has been called for this [Ad] and [AdListener.onAdLoaded] callback has been called.
-  Future<bool> isLoaded() async {
-    return instanceManager.adIdFor(this) != null &&
-        instanceManager.onAdLoadedCalled(this);
-  }
-
   /// Contains information about the loaded request.
   ///
   /// Only present if the ad has been successfully loaded.

--- a/packages/google_mobile_ads/lib/src/ad_listeners.dart
+++ b/packages/google_mobile_ads/lib/src/ad_listeners.dart
@@ -22,9 +22,8 @@ typedef AdEventCallback = void Function(Ad ad);
 /// Generic callback type for an event occurring on an Ad.
 typedef GenericAdEventCallback<Ad> = void Function(Ad ad);
 
-/// A generic callback type for when an error occurs loading an ad.
-typedef GenericAdLoadErrorCallback<Ad> = void Function(
-    Ad ad, LoadAdError error);
+/// A callback type for when an error occurs loading a full screen ad.
+typedef FullScreenAdLoadErrorCallback = void Function(LoadAdError error);
 
 /// The callback type for when a user earns a reward from a [RewardedAd].
 typedef OnUserEarnedRewardCallback = void Function(
@@ -223,9 +222,7 @@ abstract class FullScreenAdLoadCallback<T> {
   final GenericAdEventCallback<T> onAdLoaded;
 
   /// Called when an error occurs loading the ad.
-  ///
-  /// [Ad.dispose] should be called here.
-  final GenericAdLoadErrorCallback<T> onAdFailedToLoad;
+  final FullScreenAdLoadErrorCallback onAdFailedToLoad;
 }
 
 /// This class holds callbacks for loading a [RewardedAd].
@@ -235,7 +232,7 @@ class RewardedAdLoadCallback extends FullScreenAdLoadCallback<RewardedAd> {
   /// [Ad.dispose] should be invoked from [onAdFailedToLoad].
   const RewardedAdLoadCallback({
     required GenericAdEventCallback<RewardedAd> onAdLoaded,
-    required GenericAdLoadErrorCallback<RewardedAd> onAdFailedToLoad,
+    required FullScreenAdLoadErrorCallback onAdFailedToLoad,
   }) : super(onAdLoaded: onAdLoaded, onAdFailedToLoad: onAdFailedToLoad);
 }
 
@@ -247,7 +244,7 @@ class InterstitialAdLoadCallback
   /// [Ad.dispose] should be invoked from [onAdFailedToLoad].
   const InterstitialAdLoadCallback({
     required GenericAdEventCallback<InterstitialAd> onAdLoaded,
-    required GenericAdLoadErrorCallback<InterstitialAd> onAdFailedToLoad,
+    required FullScreenAdLoadErrorCallback onAdFailedToLoad,
   }) : super(onAdLoaded: onAdLoaded, onAdFailedToLoad: onAdFailedToLoad);
 }
 
@@ -259,7 +256,6 @@ class AdManagerInterstitialAdLoadCallback
   /// [Ad.dispose] should be invoked from [onAdFailedToLoad].
   const AdManagerInterstitialAdLoadCallback({
     required GenericAdEventCallback<AdManagerInterstitialAd> onAdLoaded,
-    required GenericAdLoadErrorCallback<AdManagerInterstitialAd>
-        onAdFailedToLoad,
+    required FullScreenAdLoadErrorCallback onAdFailedToLoad,
   }) : super(onAdLoaded: onAdLoaded, onAdFailedToLoad: onAdFailedToLoad);
 }


### PR DESCRIPTION
## Description

- Removes the ad parameter from `OnAdFailedToLoad` callbacks for rewarded and interstitial ads.
- Updates instance manager to clean up the resources internally, removing the need to call ad.dispose().
- Also removes the `Ad.isLoaded` API. There is no need for this API with the existence of `onAdLoaded` callbacks
- Also fixes some lint errors in java code

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/googleads/googleads-mobile-flutter/issues). Indicate, which of these issues are resolved or fixed by this PR.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.
