### PR TITLE
ci: use `ubuntu-latest` runner for `flutter` job

### DIFF
--- a/.github/workflows/google_mobile_ads.yaml
+++ b/.github/workflows/google_mobile_ads.yaml
@@ -70,7 +70,7 @@ jobs:
           DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
   
   flutter:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     timeout-minutes: 30
     steps:
@@ -96,6 +96,5 @@ jobs:
       - name: "Flutter Format"
         run: |
           flutter pub global activate flutter_plugin_tools
-          brew install clang-format
           flutter pub global run flutter_plugin_tools format
           ./.github/workflows/scripts/validate-formatting.sh


### PR DESCRIPTION
## Description

Change as per discussion here: https://github.com/googleads/googleads-mobile-flutter/pull/223#discussion_r632821963

cc @blasten 

## Related Issues

N/A

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
