### PR TITLE
Fix crash on iOS - NSInvalidArgumentException

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.1+1
+
+* Fixes a [crash on iOS](https://github.com/googleads/googleads-mobile-flutter/issues/138).
+
 ## 0.13.1
 
 * Adds support for the paid event callback.

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
@@ -17,5 +17,5 @@ package io.flutter.plugins.googlemobileads;
 /** Constants used in the plugin. */
 public class Constants {
   /** Version request agent. Should be bumped alongside plugin versions. */
-  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-0.13.1";
+  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-0.13.1+1";
 }

--- a/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.h
@@ -28,7 +28,7 @@
     (id<FlutterBinaryMessenger> _Nonnull)binaryMessenger;
 - (id<FLTAd> _Nullable)adFor:(NSNumber *_Nonnull)adId;
 - (NSNumber *_Nullable)adIdFor:(id<FLTAd> _Nonnull)ad;
-- (void)loadAd:(id<FLTAd> _Nonnull)ad adId:(NSNumber *_Nonnull)adId;
+- (void)loadAd:(id<FLTAd> _Nonnull)ad;
 - (void)dispose:(NSNumber *_Nonnull)adId;
 - (void)showAdWithID:(NSNumber *_Nonnull)adId;
 - (void)onAdLoaded:(id<FLTAd> _Nonnull)ad responseInfo:(GADResponseInfo *_Nonnull)responseInfo;

--- a/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAdInstanceManager_Internal.m
@@ -52,8 +52,8 @@
   return nil;
 }
 
-- (void)loadAd:(id<FLTAd> _Nonnull)ad adId:(NSNumber *_Nonnull)adId {
-  [_ads setObject:ad forKey:adId];
+- (void)loadAd:(id<FLTAd> _Nonnull)ad {
+  [_ads setObject:ad forKey:ad.adId];
   ad.manager = self;
   [ad load];
 }
@@ -80,7 +80,7 @@
 - (void)onAdLoaded:(id<FLTAd> _Nonnull)ad responseInfo:(GADResponseInfo *_Nonnull)responseInfo {
   [_channel invokeMethod:@"onAdEvent"
                arguments:@{
-                 @"adId" : [self adIdFor:ad],
+                 @"adId" : ad.adId,
                  @"eventName" : @"onAdLoaded",
                  @"responseInfo" : [[FLTGADResponseInfo alloc] initWithResponseInfo:responseInfo]
                }];
@@ -89,7 +89,7 @@
 - (void)onAdFailedToLoad:(id<FLTAd> _Nonnull)ad error:(NSError *_Nonnull)error {
   [_channel invokeMethod:@"onAdEvent"
                arguments:@{
-                 @"adId" : [self adIdFor:ad],
+                 @"adId" : ad.adId,
                  @"eventName" : @"onAdFailedToLoad",
                  @"loadAdError" : [[FLTLoadAdError alloc] initWithError:error]
                }];
@@ -98,7 +98,7 @@
 - (void)onAppEvent:(id<FLTAd> _Nonnull)ad name:(NSString *)name data:(NSString *)data {
   [_channel invokeMethod:@"onAdEvent"
                arguments:@{
-                 @"adId" : [self adIdFor:ad],
+                 @"adId" : ad.adId,
                  @"eventName" : @"onAppEvent",
                  @"name" : name,
                  @"data" : data
@@ -129,7 +129,7 @@
                               reward:(FLTRewardItem *_Nonnull)reward {
   [_channel invokeMethod:@"onAdEvent"
                arguments:@{
-                 @"adId" : [self adIdFor:ad],
+                 @"adId" : ad.adId,
                  @"eventName" : @"onRewardedAdUserEarnedReward",
                  @"rewardItem" : reward,
                }];
@@ -138,7 +138,7 @@
 - (void)onPaidEvent:(id<FLTAd> _Nonnull)ad value:(FLTAdValue *_Nonnull)adValue {
   [_channel invokeMethod:@"onAdEvent"
                arguments:@{
-                 @"adId" : [self adIdFor:ad],
+                 @"adId" : ad.adId,
                  @"eventName" : @"onPaidEvent",
                  @"valueMicros" : adValue.valueMicros,
                  @"precision" : [NSNumber numberWithInteger:adValue.precision],
@@ -182,7 +182,7 @@
                                              error:(NSError *_Nonnull)error {
   [_channel invokeMethod:@"onAdEvent"
                arguments:@{
-                 @"adId" : [self adIdFor:ad],
+                 @"adId" : ad.adId,
                  @"eventName" : @"didFailToPresentFullScreenContentWithError",
                  @"error" : error
                }];
@@ -192,7 +192,7 @@
 - (void)sendAdEvent:(NSString *_Nonnull)eventName ad:(id<FLTAd>)ad {
   [_channel invokeMethod:@"onAdEvent"
                arguments:@{
-                 @"adId" : [self adIdFor:ad],
+                 @"adId" : ad.adId,
                  @"eventName" : eventName,
                }];
 }

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
@@ -104,6 +104,7 @@
 
 @protocol FLTAd <NSObject>
 @property(weak) FLTAdInstanceManager *_Nullable manager;
+@property(readonly) NSNumber *_Nonnull adId;
 - (void)load;
 @end
 
@@ -111,12 +112,16 @@
 - (void)show;
 @end
 
-@interface FLTBannerAd : NSObject <FLTAd, FlutterPlatformView, GADBannerViewDelegate>
-@property(weak) FLTAdInstanceManager *_Nullable manager;
+@interface FLTBaseAd : NSObject
+@property(readonly) NSNumber *_Nonnull adId;
+@end
+
+@interface FLTBannerAd : FLTBaseAd <FLTAd, FlutterPlatformView, GADBannerViewDelegate>
 - (instancetype _Nonnull)initWithAdUnitId:(NSString *_Nonnull)adUnitId
                                      size:(FLTAdSize *_Nonnull)size
                                   request:(FLTAdRequest *_Nonnull)request
-                       rootViewController:(UIViewController *_Nonnull)rootViewController;
+                       rootViewController:(UIViewController *_Nonnull)rootViewController
+                                     adId:(NSNumber *_Nonnull)adId;
 - (GADBannerView *_Nonnull)bannerView;
 @end
 
@@ -127,13 +132,15 @@
 - (instancetype _Nonnull)initWithAdUnitId:(NSString *_Nonnull)adUnitId
                                     sizes:(NSArray<FLTAdSize *> *_Nonnull)sizes
                                   request:(FLTGAMAdRequest *_Nonnull)request
-                       rootViewController:(UIViewController *_Nonnull)rootViewController;
+                       rootViewController:(UIViewController *_Nonnull)rootViewController
+                                     adId:(NSNumber *_Nonnull)adId;
 @end
 
-@interface FLTInterstitialAd : NSObject <FLTAd, FLTAdWithoutView, GADFullScreenContentDelegate>
+@interface FLTInterstitialAd : FLTBaseAd <FLTAd, FLTAdWithoutView, GADFullScreenContentDelegate>
 - (instancetype _Nonnull)initWithAdUnitId:(NSString *_Nonnull)adUnitId
                                   request:(FLTAdRequest *_Nonnull)request
-                       rootViewController:(UIViewController *_Nonnull)rootViewController;
+                       rootViewController:(UIViewController *_Nonnull)rootViewController
+                                     adId:(NSNumber *_Nonnull)adId;
 - (GADInterstitialAd *_Nullable)interstitial;
 - (NSString *_Nonnull)adUnitId;
 - (void)load;
@@ -143,26 +150,28 @@
 @interface FLTGAMInterstitialAd : FLTInterstitialAd <GADAppEventDelegate>
 - (instancetype _Nonnull)initWithAdUnitId:(NSString *_Nonnull)adUnitId
                                   request:(FLTGAMAdRequest *_Nonnull)request
-                       rootViewController:(UIViewController *_Nonnull)rootViewController;
+                       rootViewController:(UIViewController *_Nonnull)rootViewController
+                                     adId:(NSNumber *_Nonnull)adId;
 @end
 
-@interface FLTRewardedAd : NSObject <FLTAd, FLTAdWithoutView, GADFullScreenContentDelegate>
+@interface FLTRewardedAd : FLTBaseAd <FLTAd, FLTAdWithoutView, GADFullScreenContentDelegate>
 - (instancetype _Nonnull)initWithAdUnitId:(NSString *_Nonnull)adUnitId
                                   request:(FLTAdRequest *_Nonnull)request
                        rootViewController:(UIViewController *_Nonnull)rootViewController
             serverSideVerificationOptions:
-                (FLTServerSideVerificationOptions *_Nullable)serverSideVerificationOptions;
+                (FLTServerSideVerificationOptions *_Nullable)serverSideVerificationOptions
+                                     adId:(NSNumber *_Nonnull)adId;
 - (GADRewardedAd *_Nullable)rewardedAd;
 @end
 
 @interface FLTNativeAd
-    : NSObject <FLTAd, FlutterPlatformView, GADNativeAdDelegate, GADNativeAdLoaderDelegate>
-@property(weak) FLTAdInstanceManager *_Nullable manager;
+    : FLTBaseAd <FLTAd, FlutterPlatformView, GADNativeAdDelegate, GADNativeAdLoaderDelegate>
 - (instancetype _Nonnull)initWithAdUnitId:(NSString *_Nonnull)adUnitId
                                   request:(FLTAdRequest *_Nonnull)request
                           nativeAdFactory:(NSObject<FLTNativeAdFactory> *_Nonnull)nativeAdFactory
                             customOptions:(NSDictionary<NSString *, id> *_Nullable)customOptions
-                       rootViewController:(UIViewController *_Nonnull)rootViewController;
+                       rootViewController:(UIViewController *_Nonnull)rootViewController
+                                     adId:(NSNumber *_Nonnull)adId;
 - (GADAdLoader *_Nonnull)adLoader;
 @end
 

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
@@ -173,6 +173,14 @@
 }
 @end
 
+@interface FLTBaseAd ()
+@property(readwrite) NSNumber *_Nonnull adId;
+@end
+
+@implementation FLTBaseAd
+@synthesize adId;
+@end
+
 @implementation FLTBannerAd {
   GADBannerView *_bannerView;
   FLTAdRequest *_adRequest;
@@ -181,14 +189,15 @@
 - (instancetype)initWithAdUnitId:(NSString *_Nonnull)adUnitId
                             size:(FLTAdSize *_Nonnull)size
                          request:(FLTAdRequest *_Nonnull)request
-              rootViewController:(UIViewController *_Nonnull)rootViewController {
+              rootViewController:(UIViewController *_Nonnull)rootViewController
+                            adId:(NSNumber *_Nonnull)adId {
   self = [super init];
   if (self) {
     _adRequest = request;
     _bannerView = [[GADBannerView alloc] initWithAdSize:size.size];
     _bannerView.adUnitID = adUnitId;
+    self.adId = adId;
     self.bannerView.rootViewController = rootViewController;
-
     __weak FLTBannerAd *weakSelf = self;
     self.bannerView.paidEventHandler = ^(GADAdValue *_Nonnull value) {
       if (weakSelf.manager == nil) {
@@ -215,33 +224,36 @@
 #pragma mark - GADBannerViewDelegate
 
 - (void)bannerViewDidReceiveAd:(GADBannerView *)bannerView {
-  [_manager onAdLoaded:self responseInfo:bannerView.responseInfo];
+  [manager onAdLoaded:self responseInfo:bannerView.responseInfo];
 }
 
 - (void)bannerView:(GADBannerView *)bannerView didFailToReceiveAdWithError:(NSError *)error {
-  [_manager onAdFailedToLoad:self error:error];
+  [manager onAdFailedToLoad:self error:error];
 }
 
 - (void)bannerViewDidRecordImpression:(GADBannerView *)bannerView {
-  [_manager onBannerImpression:self];
+  [manager onBannerImpression:self];
 }
 
 - (void)bannerViewWillPresentScreen:(GADBannerView *)bannerView {
-  [_manager onBannerWillPresentScreen:self];
+  [manager onBannerWillPresentScreen:self];
 }
 
 - (void)bannerViewWillDismissScreen:(GADBannerView *)bannerView {
-  [_manager onBannerWillDismissScreen:self];
+  [manager onBannerWillDismissScreen:self];
 }
 
 - (void)bannerViewDidDismissScreen:(GADBannerView *)bannerView {
-  [_manager onBannerDidDismissScreen:self];
+  [manager onBannerDidDismissScreen:self];
 }
 
 #pragma mark - FlutterPlatformView
 - (nonnull UIView *)view {
   return self.bannerView;
 }
+
+@synthesize manager;
+
 @end
 
 @implementation FLTGAMBannerAd {
@@ -252,9 +264,11 @@
 - (instancetype)initWithAdUnitId:(NSString *_Nonnull)adUnitId
                            sizes:(NSArray<FLTAdSize *> *_Nonnull)sizes
                          request:(FLTGAMAdRequest *_Nonnull)request
-              rootViewController:(UIViewController *_Nonnull)rootViewController {
+              rootViewController:(UIViewController *_Nonnull)rootViewController
+                            adId:(NSNumber *_Nonnull)adId {
   self = [super init];
   if (self) {
+    self.adId = adId;
     _adRequest = request;
     _bannerView = [[GAMBannerView alloc] initWithAdSize:sizes[0].size];
     _bannerView.adUnitID = adUnitId;
@@ -314,9 +328,11 @@
 
 - (instancetype)initWithAdUnitId:(NSString *_Nonnull)adUnitId
                          request:(FLTAdRequest *_Nonnull)request
-              rootViewController:(UIViewController *_Nonnull)rootViewController {
+              rootViewController:(UIViewController *_Nonnull)rootViewController
+                            adId:(NSNumber *_Nonnull)adId {
   self = [super init];
   if (self) {
+    self.adId = adId;
     _adRequest = request;
     _adUnitId = [adUnitId copy];
     _rootViewController = rootViewController;
@@ -402,9 +418,11 @@
 
 - (instancetype)initWithAdUnitId:(NSString *_Nonnull)adUnitId
                          request:(FLTGAMAdRequest *_Nonnull)request
-              rootViewController:(UIViewController *_Nonnull)rootViewController {
+              rootViewController:(UIViewController *_Nonnull)rootViewController
+                            adId:(NSNumber *_Nonnull)adId {
   self = [super init];
   if (self) {
+    self.adId = adId;
     _adRequest = request;
     _adUnitId = [adUnitId copy];
     _rootViewController = rootViewController;
@@ -474,9 +492,11 @@
                           request:(FLTAdRequest *_Nonnull)request
                rootViewController:(UIViewController *_Nonnull)rootViewController
     serverSideVerificationOptions:
-        (FLTServerSideVerificationOptions *_Nullable)serverSideVerificationOptions {
+        (FLTServerSideVerificationOptions *_Nullable)serverSideVerificationOptions
+                             adId:(NSNumber *_Nonnull)adId {
   self = [super init];
   if (self) {
+    self.adId = adId;
     _adRequest = request;
     _rootViewController = rootViewController;
     _serverSideVerificationOptions = serverSideVerificationOptions;
@@ -587,9 +607,11 @@
                                   request:(FLTAdRequest *_Nonnull)request
                           nativeAdFactory:(NSObject<FLTNativeAdFactory> *_Nonnull)nativeAdFactory
                             customOptions:(NSDictionary<NSString *, id> *_Nullable)customOptions
-                       rootViewController:(UIViewController *_Nonnull)rootViewController {
+                       rootViewController:(UIViewController *_Nonnull)rootViewController
+                                     adId:(NSNumber *_Nonnull)adId {
   self = [super init];
   if (self) {
+    self.adId = adId;
     _adUnitId = adUnitId;
     _adRequest = request;
     _nativeAdFactory = nativeAdFactory;
@@ -638,39 +660,41 @@
                                                           precision:(NSInteger)value.precision
                                                        currencyCode:value.currencyCode]];
   };
-  [_manager onAdLoaded:self responseInfo:nativeAd.responseInfo];
+  [manager onAdLoaded:self responseInfo:nativeAd.responseInfo];
 }
 
 - (void)adLoader:(GADAdLoader *)adLoader didFailToReceiveAdWithError:(NSError *)error {
-  [_manager onAdFailedToLoad:self error:error];
+  [manager onAdFailedToLoad:self error:error];
 }
 
 #pragma mark - GADNativeAdDelegate
 
 - (void)nativeAdDidRecordClick:(GADNativeAd *)nativeAd {
-  [_manager onNativeAdClicked:self];
+  [manager onNativeAdClicked:self];
 }
 
 - (void)nativeAdDidRecordImpression:(GADNativeAd *)nativeAd {
-  [_manager onNativeAdImpression:self];
+  [manager onNativeAdImpression:self];
 }
 
 - (void)nativeAdWillPresentScreen:(GADNativeAd *)nativeAd {
-  [_manager onNativeAdWillPresentScreen:self];
+  [manager onNativeAdWillPresentScreen:self];
 }
 
 - (void)nativeAdWillDismissScreen:(nonnull GADNativeAd *)nativeAd {
-  [_manager onNativeAdWillDismissScreen:self];
+  [manager onNativeAdWillDismissScreen:self];
 }
 
 - (void)nativeAdDidDismissScreen:(GADNativeAd *)nativeAd {
-  [_manager onNativeAdDidDismissScreen:self];
+  [manager onNativeAdDidDismissScreen:self];
 }
 
 #pragma mark - FlutterPlatformView
 - (UIView *)view {
   return _view;
 }
+
+@synthesize manager;
 
 @end
 

--- a/packages/google_mobile_ads/ios/Classes/FLTConstants.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTConstants.h
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /** Versioned request agent string. */
-#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-0.13.1"
+#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-0.13.1+1"

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
@@ -158,15 +158,17 @@
     FLTBannerAd *ad = [[FLTBannerAd alloc] initWithAdUnitId:call.arguments[@"adUnitId"]
                                                        size:call.arguments[@"size"]
                                                     request:call.arguments[@"request"]
-                                         rootViewController:rootController];
-    [_manager loadAd:ad adId:call.arguments[@"adId"]];
+                                         rootViewController:rootController
+                                                       adId:call.arguments[@"adId"]];
+    [_manager loadAd:ad];
     result(nil);
   } else if ([call.method isEqualToString:@"loadAdManagerBannerAd"]) {
     FLTGAMBannerAd *ad = [[FLTGAMBannerAd alloc] initWithAdUnitId:call.arguments[@"adUnitId"]
                                                             sizes:call.arguments[@"sizes"]
                                                           request:call.arguments[@"request"]
-                                               rootViewController:rootController];
-    [_manager loadAd:ad adId:call.arguments[@"adId"]];
+                                               rootViewController:rootController
+                                                             adId:call.arguments[@"adId"]];
+    [_manager loadAd:ad];
     result(nil);
   } else if ([call.method isEqualToString:@"loadNativeAd"]) {
     NSString *factoryId = call.arguments[@"factoryId"];
@@ -190,23 +192,24 @@
                                                     request:request
                                             nativeAdFactory:(id)factory
                                               customOptions:call.arguments[@"customOptions"]
-                                         rootViewController:rootController];
-    [_manager loadAd:ad adId:call.arguments[@"adId"]];
+                                         rootViewController:rootController
+                                                       adId:call.arguments[@"adId"]];
+    [_manager loadAd:ad];
     result(nil);
   } else if ([call.method isEqualToString:@"loadInterstitialAd"]) {
     FLTInterstitialAd *ad = [[FLTInterstitialAd alloc] initWithAdUnitId:call.arguments[@"adUnitId"]
                                                                 request:call.arguments[@"request"]
-                                                     rootViewController:rootController];
-
-    [_manager loadAd:ad adId:call.arguments[@"adId"]];
+                                                     rootViewController:rootController
+                                                                   adId:call.arguments[@"adId"]];
+    [_manager loadAd:ad];
     result(nil);
   } else if ([call.method isEqualToString:@"loadAdManagerInterstitialAd"]) {
     FLTGAMInterstitialAd *ad =
         [[FLTGAMInterstitialAd alloc] initWithAdUnitId:call.arguments[@"adUnitId"]
                                                request:call.arguments[@"request"]
-                                    rootViewController:rootController];
-
-    [_manager loadAd:ad adId:call.arguments[@"adId"]];
+                                    rootViewController:rootController
+                                                  adId:call.arguments[@"adId"]];
+    [_manager loadAd:ad];
     result(nil);
   } else if ([call.method isEqualToString:@"loadRewardedAd"]) {
     FLTAdRequest *request;
@@ -225,8 +228,9 @@
         [[FLTRewardedAd alloc] initWithAdUnitId:call.arguments[@"adUnitId"]
                                         request:request
                              rootViewController:rootController
-                  serverSideVerificationOptions:call.arguments[@"serverSideVerificationOptions"]];
-    [_manager loadAd:ad adId:call.arguments[@"adId"]];
+                  serverSideVerificationOptions:call.arguments[@"serverSideVerificationOptions"]
+                                           adId:call.arguments[@"adId"]];
+    [_manager loadAd:ad];
     result(nil);
   } else if ([call.method isEqualToString:@"disposeAd"]) {
     [_manager dispose:call.arguments[@"adId"]];

--- a/packages/google_mobile_ads/ios/Tests/FLTBannerAdTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTBannerAdTest.m
@@ -35,7 +35,8 @@
   FLTBannerAd *bannerAd = [[FLTBannerAd alloc] initWithAdUnitId:@"testId"
                                                            size:size
                                                         request:[[FLTAdRequest alloc] init]
-                                             rootViewController:mockRootViewController];
+                                             rootViewController:mockRootViewController
+                                                           adId:@1];
   bannerAd.manager = mockManager;
 
   [bannerAd load];
@@ -96,7 +97,8 @@
                                                      size:[[FLTAdSize alloc] initWithWidth:@(1)
                                                                                     height:@(2)]
                                                   request:request
-                                       rootViewController:mockRootViewController];
+                                       rootViewController:mockRootViewController
+                                                     adId:@1];
 
   XCTAssertEqual(ad.bannerView.adUnitID, @"testId");
   XCTAssertEqual(ad.bannerView.rootViewController, mockRootViewController);

--- a/packages/google_mobile_ads/ios/Tests/FLTGAMBannerAdTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGAMBannerAdTest.m
@@ -37,7 +37,8 @@
         initWithAdUnitId:@"testId"
                    sizes:@[ [[FLTAdSize alloc] initWithWidth:@(1) height:@(2)] ]
                  request:[[FLTGAMAdRequest alloc] init]
-      rootViewController:mockRootViewController];
+      rootViewController:mockRootViewController
+                    adId:@1];
   bannerAd.manager = mockManager;
 
   [bannerAd load];
@@ -100,7 +101,8 @@
         initWithAdUnitId:@"testId"
                    sizes:@[ [[FLTAdSize alloc] initWithWidth:@(1) height:@(2)] ]
                  request:request
-      rootViewController:mockRootViewController];
+      rootViewController:mockRootViewController
+                    adId:@1];
 
   XCTAssertEqual(ad.bannerView.adUnitID, @"testId");
   XCTAssertEqual(ad.bannerView.rootViewController, mockRootViewController);

--- a/packages/google_mobile_ads/ios/Tests/FLTGamInterstitialAdTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGamInterstitialAdTest.m
@@ -38,7 +38,8 @@
   UIViewController *mockRootViewController = OCMClassMock([UIViewController class]);
   FLTGAMInterstitialAd *ad = [[FLTGAMInterstitialAd alloc] initWithAdUnitId:@"testId"
                                                                     request:request
-                                                         rootViewController:mockRootViewController];
+                                                         rootViewController:mockRootViewController
+                                                                       adId:@1];
   ad.manager = mockManager;
 
   id interstitialClassMock = OCMClassMock([GAMInterstitialAd class]);
@@ -136,7 +137,8 @@
   UIViewController *mockRootViewController = OCMClassMock([UIViewController class]);
   FLTGAMInterstitialAd *ad = [[FLTGAMInterstitialAd alloc] initWithAdUnitId:@"testId"
                                                                     request:request
-                                                         rootViewController:mockRootViewController];
+                                                         rootViewController:mockRootViewController
+                                                                       adId:@1];
   ad.manager = mockManager;
 
   id interstitialClassMock = OCMClassMock([GAMInterstitialAd class]);

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
@@ -63,7 +63,8 @@
                                       request:request
                            rootViewController:UIApplication.sharedApplication.delegate.window
                                                   .rootViewController
-                serverSideVerificationOptions:serverSideVerificationOptions];
+                serverSideVerificationOptions:serverSideVerificationOptions
+                                         adId:@1];
 
   FlutterMethodCall *methodCall = [FlutterMethodCall
       methodCallWithMethodName:@"loadRewardedAd"
@@ -94,8 +95,7 @@
     XCTAssertEqualObjects(options, serverSideVerificationOptions);
     return YES;
   };
-  OCMVerify([_mockAdInstanceManager loadAd:[OCMArg checkWithBlock:verificationBlock]
-                                      adId:[OCMArg isEqual:@2]]);
+  OCMVerify([_mockAdInstanceManager loadAd:[OCMArg checkWithBlock:verificationBlock]]);
 }
 
 - (void)testInternalInit {

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsTest.m
@@ -353,10 +353,10 @@ static NSString *channel = @"plugins.flutter.io/google_mobile_ads";
 
   XCTAssertNil([_manager adFor:@(1)]);
   XCTAssertNil([_manager adIdFor:bannerAd]);
-  
+
   GADBannerView *mockGADBannerView = OCMClassMock([GADBannerView class]);
   [bannerAd bannerViewDidRecordImpression:mockGADBannerView];
-  
+
   NSData *impressionData = [self getDataForEvent:@"onBannerImpression" adId:@1];
   OCMVerify(([_mockMessenger sendOnChannel:channel message:impressionData]));
 }

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsTest.m
@@ -46,12 +46,13 @@ static NSString *channel = @"plugins.flutter.io/google_mobile_ads";
       [[FLTBannerAd alloc] initWithAdUnitId:@"testId"
                                        size:size
                                     request:[[FLTAdRequest alloc] init]
-                         rootViewController:OCMClassMock([UIViewController class])];
+                         rootViewController:OCMClassMock([UIViewController class])
+                                       adId:@1];
 
   FLTBannerAd *mockBannerAd = OCMPartialMock(bannerAd);
   OCMStub([mockBannerAd load]);
 
-  [_manager loadAd:bannerAd adId:@(1)];
+  [_manager loadAd:bannerAd];
 
   OCMVerify([mockBannerAd load]);
   XCTAssertEqual([_manager adFor:@(1)], bannerAd);
@@ -64,11 +65,12 @@ static NSString *channel = @"plugins.flutter.io/google_mobile_ads";
       [[FLTBannerAd alloc] initWithAdUnitId:@"testId"
                                        size:size
                                     request:[[FLTAdRequest alloc] init]
-                         rootViewController:OCMClassMock([UIViewController class])];
+                         rootViewController:OCMClassMock([UIViewController class])
+                                       adId:@1];
   FLTBannerAd *mockBannerAd = OCMPartialMock(bannerAd);
   OCMStub([mockBannerAd load]);
 
-  [_manager loadAd:bannerAd adId:@(1)];
+  [_manager loadAd:bannerAd];
   [_manager dispose:@(1)];
 
   XCTAssertNil([_manager adFor:@(1)]);
@@ -81,7 +83,8 @@ static NSString *channel = @"plugins.flutter.io/google_mobile_ads";
       [[FLTBannerAd alloc] initWithAdUnitId:@"testId"
                                        size:size
                                     request:[[FLTAdRequest alloc] init]
-                         rootViewController:OCMClassMock([UIViewController class])];
+                         rootViewController:OCMClassMock([UIViewController class])
+                                       adId:@1];
   FLTBannerAd *mockBannerAd1 = OCMPartialMock(bannerAd1);
   OCMStub([mockBannerAd1 load]);
 
@@ -89,12 +92,13 @@ static NSString *channel = @"plugins.flutter.io/google_mobile_ads";
       [[FLTBannerAd alloc] initWithAdUnitId:@"testId"
                                        size:size
                                     request:[[FLTAdRequest alloc] init]
-                         rootViewController:OCMClassMock([UIViewController class])];
+                         rootViewController:OCMClassMock([UIViewController class])
+                                       adId:@2];
   FLTBannerAd *mockBannerAd2 = OCMPartialMock(bannerAd2);
   OCMStub([mockBannerAd2 load]);
 
-  [_manager loadAd:bannerAd1 adId:@(1)];
-  [_manager loadAd:bannerAd2 adId:@(2)];
+  [_manager loadAd:bannerAd1];
+  [_manager loadAd:bannerAd2];
   [_manager disposeAllAds];
 
   XCTAssertNil([_manager adFor:@(1)]);
@@ -109,8 +113,9 @@ static NSString *channel = @"plugins.flutter.io/google_mobile_ads";
                                     request:[[FLTAdRequest alloc] init]
                             nativeAdFactory:OCMProtocolMock(@protocol(FLTNativeAdFactory))
                               customOptions:nil
-                         rootViewController:OCMClassMock([UIViewController class])];
-  [_manager loadAd:ad adId:@(1)];
+                         rootViewController:OCMClassMock([UIViewController class])
+                                       adId:@1];
+  [_manager loadAd:ad];
 
   GADResponseInfo *responseInfo = OCMClassMock([GADResponseInfo class]);
   FLTGADResponseInfo *fltResponseInfo =
@@ -132,8 +137,9 @@ static NSString *channel = @"plugins.flutter.io/google_mobile_ads";
                                     request:[[FLTAdRequest alloc] init]
                             nativeAdFactory:OCMProtocolMock(@protocol(FLTNativeAdFactory))
                               customOptions:nil
-                         rootViewController:OCMClassMock([UIViewController class])];
-  [_manager loadAd:ad adId:@(1)];
+                         rootViewController:OCMClassMock([UIViewController class])
+                                       adId:@1];
+  [_manager loadAd:ad];
 
   NSDictionary *userInfo = @{NSLocalizedDescriptionKey : @"message"};
   NSError *error = [NSError errorWithDomain:@"domain" code:1 userInfo:userInfo];
@@ -152,7 +158,8 @@ static NSString *channel = @"plugins.flutter.io/google_mobile_ads";
 
 - (void)testAdInstanceManagerOnAdFailedToShow {
   FLTInterstitialAd *ad = OCMClassMock([FLTInterstitialAd class]);
-  [_manager loadAd:ad adId:@(1)];
+  OCMStub([ad adId]).andReturn(@1);
+  [_manager loadAd:ad];
 
   NSDictionary *userInfo = @{NSLocalizedDescriptionKey : @"message"};
   NSError *error = [NSError errorWithDomain:@"domain" code:1 userInfo:userInfo];
@@ -176,8 +183,9 @@ static NSString *channel = @"plugins.flutter.io/google_mobile_ads";
                                     request:[[FLTAdRequest alloc] init]
                             nativeAdFactory:OCMProtocolMock(@protocol(FLTNativeAdFactory))
                               customOptions:nil
-                         rootViewController:OCMClassMock([UIViewController class])];
-  [_manager loadAd:ad adId:@(1)];
+                         rootViewController:OCMClassMock([UIViewController class])
+                                       adId:@1];
+  [_manager loadAd:ad];
 
   [_manager onAppEvent:ad name:@"color" data:@"red"];
 
@@ -198,8 +206,9 @@ static NSString *channel = @"plugins.flutter.io/google_mobile_ads";
                                     request:[[FLTAdRequest alloc] init]
                             nativeAdFactory:OCMProtocolMock(@protocol(FLTNativeAdFactory))
                               customOptions:nil
-                         rootViewController:OCMClassMock([UIViewController class])];
-  [_manager loadAd:ad adId:@(1)];
+                         rootViewController:OCMClassMock([UIViewController class])
+                                       adId:@1];
+  [_manager loadAd:ad];
 
   [_manager onNativeAdClicked:ad];
   NSData *clickData = [self getDataForEvent:@"onNativeAdClicked" adId:@1];
@@ -226,8 +235,9 @@ static NSString *channel = @"plugins.flutter.io/google_mobile_ads";
   FLTRewardedAd *ad = [[FLTRewardedAd alloc] initWithAdUnitId:@"testId"
                                                       request:[[FLTAdRequest alloc] init]
                                            rootViewController:OCMClassMock([UIViewController class])
-                                serverSideVerificationOptions:nil];
-  [_manager loadAd:ad adId:@(1)];
+                                serverSideVerificationOptions:nil
+                                                         adId:@1];
+  [_manager loadAd:ad];
 
   [_manager onRewardedAdUserEarnedReward:ad
                                   reward:[[FLTRewardItem alloc] initWithAmount:@(1) type:@"type"]];
@@ -250,8 +260,9 @@ static NSString *channel = @"plugins.flutter.io/google_mobile_ads";
                                     request:[[FLTAdRequest alloc] init]
                             nativeAdFactory:OCMProtocolMock(@protocol(FLTNativeAdFactory))
                               customOptions:nil
-                         rootViewController:OCMClassMock([UIViewController class])];
-  [_manager loadAd:ad adId:@(1)];
+                         rootViewController:OCMClassMock([UIViewController class])
+                                       adId:@1];
+  [_manager loadAd:ad];
 
   NSDecimalNumber *valueDecimal = [[NSDecimalNumber alloc] initWithInt:1];
   FLTAdValue *value = [[FLTAdValue alloc] initWithValue:valueDecimal
@@ -277,11 +288,12 @@ static NSString *channel = @"plugins.flutter.io/google_mobile_ads";
   FLTBannerAd *ad = [[FLTBannerAd alloc] initWithAdUnitId:@"testId"
                                                      size:size
                                                   request:[[FLTAdRequest alloc] init]
-                                       rootViewController:OCMClassMock([UIViewController class])];
+                                       rootViewController:OCMClassMock([UIViewController class])
+                                                     adId:@1];
   FLTBannerAd *mockBannerAd = OCMPartialMock(ad);
   OCMStub([mockBannerAd load]);
 
-  [_manager loadAd:ad adId:@(1)];
+  [_manager loadAd:ad];
 
   [_manager onBannerImpression:ad];
   NSData *impressionData = [self getDataForEvent:@"onBannerImpression" adId:@1];
@@ -304,8 +316,9 @@ static NSString *channel = @"plugins.flutter.io/google_mobile_ads";
   FLTRewardedAd *ad = [[FLTRewardedAd alloc] initWithAdUnitId:@"testId"
                                                       request:[[FLTAdRequest alloc] init]
                                            rootViewController:OCMClassMock([UIViewController class])
-                                serverSideVerificationOptions:nil];
-  [_manager loadAd:ad adId:@(1)];
+                                serverSideVerificationOptions:nil
+                                                         adId:@1];
+  [_manager loadAd:ad];
 
   [_manager onAdDidPresentFullScreenContent:ad];
   NSData *didPresentData = [self getDataForEvent:@"onAdDidPresentFullScreenContent" adId:@1];
@@ -321,6 +334,30 @@ static NSString *channel = @"plugins.flutter.io/google_mobile_ads";
 
   [_manager adDidRecordImpression:ad];
   NSData *impressionData = [self getDataForEvent:@"adDidRecordImpression" adId:@1];
+  OCMVerify(([_mockMessenger sendOnChannel:channel message:impressionData]));
+}
+
+- (void)testEventSentForDisposedAd {
+  FLTAdSize *size = [[FLTAdSize alloc] initWithWidth:@(1) height:@(2)];
+  FLTBannerAd *bannerAd =
+      [[FLTBannerAd alloc] initWithAdUnitId:@"testId"
+                                       size:size
+                                    request:[[FLTAdRequest alloc] init]
+                         rootViewController:OCMClassMock([UIViewController class])
+                                       adId:@1];
+  FLTBannerAd *mockBannerAd = OCMPartialMock(bannerAd);
+  OCMStub([mockBannerAd load]);
+
+  [_manager loadAd:bannerAd];
+  [_manager dispose:@(1)];
+
+  XCTAssertNil([_manager adFor:@(1)]);
+  XCTAssertNil([_manager adIdFor:bannerAd]);
+  
+  GADBannerView *mockGADBannerView = OCMClassMock([GADBannerView class]);
+  [bannerAd bannerViewDidRecordImpression:mockGADBannerView];
+  
+  NSData *impressionData = [self getDataForEvent:@"onBannerImpression" adId:@1];
   OCMVerify(([_mockMessenger sendOnChannel:channel message:impressionData]));
 }
 

--- a/packages/google_mobile_ads/ios/Tests/FLTInterstitialAdTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTInterstitialAdTest.m
@@ -38,7 +38,8 @@
   UIViewController *mockRootViewController = OCMClassMock([UIViewController class]);
   FLTInterstitialAd *ad = [[FLTInterstitialAd alloc] initWithAdUnitId:@"testId"
                                                               request:request
-                                                   rootViewController:mockRootViewController];
+                                                   rootViewController:mockRootViewController
+                                                                 adId:@1];
   ad.manager = mockManager;
 
   id interstitialClassMock = OCMClassMock([GADInterstitialAd class]);
@@ -121,7 +122,8 @@
   UIViewController *mockRootViewController = OCMClassMock([UIViewController class]);
   FLTInterstitialAd *ad = [[FLTInterstitialAd alloc] initWithAdUnitId:@"testId"
                                                               request:request
-                                                   rootViewController:mockRootViewController];
+                                                   rootViewController:mockRootViewController
+                                                                 adId:@1];
   ad.manager = mockManager;
 
   id interstitialClassMock = OCMClassMock([GADInterstitialAd class]);

--- a/packages/google_mobile_ads/ios/Tests/FLTNativeAdTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTNativeAdTest.m
@@ -49,7 +49,8 @@
                                                   request:gadOrGAMRequest
                                           nativeAdFactory:mockNativeAdFactory
                                             customOptions:customOptions
-                                       rootViewController:OCMClassMock([UIViewController class])];
+                                       rootViewController:OCMClassMock([UIViewController class])
+                                                     adId:@1];
   ad.manager = mockManager;
 
   XCTAssertEqual(ad.adLoader.adUnitID, @"testAdUnitId");

--- a/packages/google_mobile_ads/ios/Tests/FLTRewardedAdTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTRewardedAdTest.m
@@ -69,7 +69,8 @@
   FLTRewardedAd *ad = [[FLTRewardedAd alloc] initWithAdUnitId:@"testId"
                                                       request:request
                                            rootViewController:mockRootViewController
-                                serverSideVerificationOptions:options];
+                                serverSideVerificationOptions:options
+                                                         adId:@1];
   ad.manager = mockManager;
 
   // Stub the load call to invoke successful load callback.
@@ -194,7 +195,8 @@
   FLTRewardedAd *ad = [[FLTRewardedAd alloc] initWithAdUnitId:@"testId"
                                                       request:request
                                            rootViewController:mockRootViewController
-                                serverSideVerificationOptions:nil];
+                                serverSideVerificationOptions:nil
+                                                         adId:@1];
   ad.manager = mockManager;
 
   id rewardedClassMock = OCMClassMock([GADRewardedAd class]);

--- a/packages/google_mobile_ads/pubspec.yaml
+++ b/packages/google_mobile_ads/pubspec.yaml
@@ -16,7 +16,7 @@ name: google_mobile_ads
 description: Flutter plugin for Google Mobile Ads, supporting
   banner, interstitial (full-screen),  rewarded and native ads
 homepage: https://github.com/googleads/googleads-mobile-flutter/tree/master/packages/google_mobile_ads
-version: 0.13.1
+version: 0.13.1+1
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Makes `adId` a property in ad objects on iOS. Events for disposed ads are still propagated to dart, which will no-op and log a debug message.

## Related Issues

https://github.com/googleads/googleads-mobile-flutter/issues/138
https://github.com/googleads/googleads-mobile-flutter/issues/277
## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
