### PR TITLE
Mark smart banner as deprecated.

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 0.13.1+1
+## 0.13.2
 
 * Fixes a crash where [PlatformView.getView() returns null](https://github.com/googleads/googleads-mobile-flutter/issues/46)
 * Fixes memory leaks on Android.
 * Fixes a [crash on iOS](https://github.com/googleads/googleads-mobile-flutter/issues/138).
+* Marks adaptive banner sizes as deprecated. Instead you should use adaptive banners.
 
 ## 0.13.1
 

--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Fixes a crash where [PlatformView.getView() returns null](https://github.com/googleads/googleads-mobile-flutter/issues/46)
 * Fixes memory leaks on Android.
 * Fixes a [crash on iOS](https://github.com/googleads/googleads-mobile-flutter/issues/138).
-* Marks adaptive banner sizes as deprecated. Instead you should use adaptive banners.
+* Marks smart banner sizes as deprecated. Instead you should use adaptive banners.
 
 ## 0.13.1
 

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
@@ -17,5 +17,5 @@ package io.flutter.plugins.googlemobileads;
 /** Constants used in the plugin. */
 public class Constants {
   /** Version request agent. Should be bumped alongside plugin versions. */
-  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-0.13.1+1";
+  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-0.13.2";
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdSize.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdSize.java
@@ -66,6 +66,8 @@ class FlutterAdSize {
   }
 
   static class SmartBannerAdSize extends FlutterAdSize {
+
+    @SuppressWarnings("deprecation")
     SmartBannerAdSize() {
       super(AdSize.SMART_BANNER);
     }

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
@@ -68,9 +68,12 @@
 - (instancetype _Nonnull)initWithOrientation:(NSString *_Nonnull)orientation {
   GADAdSize size;
   if ([orientation isEqualToString:@"portrait"]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     size = kGADAdSizeSmartBannerPortrait;
   } else if ([orientation isEqualToString:@"landscape"]) {
     size = kGADAdSizeSmartBannerLandscape;
+#pragma clang diagnostic pop
   } else {
     NSLog(@"SmartBanner orientation should be 'portrait' or 'landscape': %@", orientation);
     return nil;

--- a/packages/google_mobile_ads/ios/Classes/FLTConstants.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTConstants.h
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /** Versioned request agent string. */
-#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-0.13.1+1"
+#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-0.13.2"

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
@@ -58,14 +58,6 @@
       [[FLTServerSideVerificationOptions alloc] init];
   serverSideVerificationOptions.customRewardString = @"reward";
   serverSideVerificationOptions.userIdentifier = @"user-id";
-  FLTRewardedAd *ad =
-      [[FLTRewardedAd alloc] initWithAdUnitId:@"testId"
-                                      request:request
-                           rootViewController:UIApplication.sharedApplication.delegate.window
-                                                  .rootViewController
-                serverSideVerificationOptions:serverSideVerificationOptions
-                                         adId:@1];
-
   FlutterMethodCall *methodCall = [FlutterMethodCall
       methodCallWithMethodName:@"loadRewardedAd"
                      arguments:@{

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
@@ -72,8 +72,11 @@
   FLTSmartBannerSize *decodedSize = [_messageCodec decode:encodedMessage];
 
   XCTAssertTrue([decodedSize isKindOfClass:FLTSmartBannerSize.class]);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   XCTAssertEqual(decodedSize.size.size.width, kGADAdSizeSmartBannerPortrait.size.width);
   XCTAssertEqual(decodedSize.size.size.height, kGADAdSizeSmartBannerPortrait.size.height);
+#pragma clang diagnostic pop
 }
 
 - (void)testEncodeDecodeAdRequest {

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// ignore_for_file: deprecated_member_use_from_same_package
-
 import 'dart:async';
 import 'dart:io' show Platform;
 
@@ -244,6 +242,7 @@ class AnchoredAdaptiveBannerAdSize extends AdSize {
 }
 
 /// Ad units that render screen-width banner ads on any screen size across different devices in either [Orientation].
+@Deprecated('Use adaptive banner instead')
 class SmartBannerAdSize extends AdSize {
   /// Default constructor for [SmartBannerAdSize].
   SmartBannerAdSize(this.orientation) : super(width: -1, height: -1);
@@ -314,6 +313,7 @@ class AdSize {
   }
 
   /// Ad units that render screen-width banner ads on any screen size across different devices in either orientation on Android.
+  @Deprecated('Use adaptive banner instead')
   static AdSize get smartBanner {
     assert(defaultTargetPlatform == TargetPlatform.android);
     // Orientation is not used on Android.
@@ -321,16 +321,19 @@ class AdSize {
   }
 
   /// Ad units that render screen-width banner ads on any screen size across different devices in portrait on iOS.
+  @Deprecated('Use adaptive banner instead')
   static AdSize get smartBannerPortrait {
     return getSmartBanner(Orientation.portrait);
   }
 
   /// Ad units that render screen-width banner ads on any screen size across different devices in landscape on iOS.
+  @Deprecated('Use adaptive banner instead')
   static AdSize get smartBannerLandscape {
     return getSmartBanner(Orientation.landscape);
   }
 
   /// Ad units that render screen-width banner ads on any screen size across different devices in either [Orientation].
+  @Deprecated('Use adaptive banner instead')
   static SmartBannerAdSize getSmartBanner(Orientation orientation) {
     return SmartBannerAdSize(orientation);
   }

--- a/packages/google_mobile_ads/pubspec.yaml
+++ b/packages/google_mobile_ads/pubspec.yaml
@@ -16,7 +16,7 @@ name: google_mobile_ads
 description: Flutter plugin for Google Mobile Ads, supporting
   banner, interstitial (full-screen),  rewarded and native ads
 homepage: https://github.com/googleads/googleads-mobile-flutter/tree/master/packages/google_mobile_ads
-version: 0.13.1+1
+version: 0.13.2
 
 flutter:
   plugin:

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -22,6 +22,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/services.dart';
 
+// ignore_for_file: deprecated_member_use_from_same_package
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 


### PR DESCRIPTION
## Description

- Marks smart banner as deprecated, which is already deprecated in GMASDK android and iOS.
- Hides platform warnings for using smart banner

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
