### PR TITLE
Prevent init from invoking result.success() multiple times.

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.2 + 1
+
+* Fixes [Issue #130](https://github.com/googleads/googleads-mobile-flutter/issues/130)
+
 ## 0.13.2
 
 * Fixes a crash where [PlatformView.getView() returns null](https://github.com/googleads/googleads-mobile-flutter/issues/46)

--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.13.2 + 1
+## 0.13.2+1
 
 * Fixes [Issue #130](https://github.com/googleads/googleads-mobile-flutter/issues/130)
 

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
@@ -17,5 +17,5 @@ package io.flutter.plugins.googlemobileads;
 /** Constants used in the plugin. */
 public class Constants {
   /** Version request agent. Should be bumped alongside plugin versions. */
-  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-0.13.2";
+  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-0.13.2+1";
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterMobileAdsWrapper.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterMobileAdsWrapper.java
@@ -1,0 +1,32 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.flutter.plugins.googlemobileads;
+
+import android.content.Context;
+import androidx.annotation.NonNull;
+import com.google.android.gms.ads.MobileAds;
+import com.google.android.gms.ads.initialization.OnInitializationCompleteListener;
+
+/** A wrapper around static methods in {@link com.google.android.gms.ads.MobileAds}. */
+public class FlutterMobileAdsWrapper {
+
+  public FlutterMobileAdsWrapper() {}
+
+  /** Initializes the sdk. */
+  public void initialize(
+      @NonNull Context context, @NonNull OnInitializationCompleteListener listener) {
+    MobileAds.initialize(context, listener);
+  }
+}

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -409,7 +409,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
     @Override
     public void onInitializationComplete(@NonNull InitializationStatus initializationStatus) {
       // Make sure not to invoke this more than once, since Dart will throw an exception if success
-      // is invoked more than once.
+      // is invoked more than once. See b/193418432.
       if (isInitializationCompleted) {
         return;
       }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -60,19 +60,24 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
   @Nullable private AdInstanceManager instanceManager;
   @Nullable private ActivityPluginBinding activityBinding;
   private final Map<String, NativeAdFactory> nativeAdFactories = new HashMap<>();
-
+  private final FlutterMobileAdsWrapper flutterMobileAds;
   /**
    * Public constructor for the plugin. Dependency initialization is handled in lifecycle methods
    * below.
    */
-  public GoogleMobileAdsPlugin() {}
+  public GoogleMobileAdsPlugin() {
+    this.flutterMobileAds = new FlutterMobileAdsWrapper();
+  }
 
   /** Constructor for testing. */
   @VisibleForTesting
   protected GoogleMobileAdsPlugin(
-      @Nullable FlutterPluginBinding pluginBinding, @Nullable AdInstanceManager instanceManager) {
+      @Nullable FlutterPluginBinding pluginBinding,
+      @Nullable AdInstanceManager instanceManager,
+      @NonNull FlutterMobileAdsWrapper flutterMobileAds) {
     this.pluginBinding = pluginBinding;
     this.instanceManager = instanceManager;
+    this.flutterMobileAds = flutterMobileAds;
   }
 
   /**
@@ -226,14 +231,8 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
         break;
 
       case "MobileAds#initialize":
-        MobileAds.initialize(
-            instanceManager.activity,
-            new OnInitializationCompleteListener() {
-              @Override
-              public void onInitializationComplete(InitializationStatus initializationStatus) {
-                result.success(new FlutterInitializationStatus(initializationStatus));
-              }
-            });
+        flutterMobileAds.initialize(
+            instanceManager.activity, new FlutterInitializationListener(result));
         break;
       case "MobileAds#updateRequestConfiguration":
         RequestConfiguration.Builder builder = MobileAds.getRequestConfiguration().toBuilder();
@@ -392,6 +391,30 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
         break;
       default:
         result.notImplemented();
+    }
+  }
+
+  /** An {@link OnInitializationCompleteListener} that invokes result.success() at most once. */
+  private static final class FlutterInitializationListener
+      implements OnInitializationCompleteListener {
+
+    private final Result result;
+    private int numTimesInvoked;
+
+    private FlutterInitializationListener(@NonNull final Result result) {
+      this.result = result;
+      numTimesInvoked = 0;
+    }
+
+    @Override
+    public void onInitializationComplete(@NonNull InitializationStatus initializationStatus) {
+      // Make sure not to invoke this more than once, since Dart will throw an exception if success
+      // is invoked more than once.
+      if (numTimesInvoked > 0) {
+        return;
+      }
+      result.success(new FlutterInitializationStatus(initializationStatus));
+      numTimesInvoked += 1;
     }
   }
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -399,22 +399,22 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
       implements OnInitializationCompleteListener {
 
     private final Result result;
-    private int numTimesInvoked;
+    private boolean isInitializationCompleted;
 
     private FlutterInitializationListener(@NonNull final Result result) {
       this.result = result;
-      numTimesInvoked = 0;
+      isInitializationCompleted = false;
     }
 
     @Override
     public void onInitializationComplete(@NonNull InitializationStatus initializationStatus) {
       // Make sure not to invoke this more than once, since Dart will throw an exception if success
       // is invoked more than once.
-      if (numTimesInvoked > 0) {
+      if (isInitializationCompleted) {
         return;
       }
       result.success(new FlutterInitializationStatus(initializationStatus));
-      numTimesInvoked += 1;
+      isInitializationCompleted = true;
     }
   }
 }

--- a/packages/google_mobile_ads/ios/Classes/FLTConstants.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTConstants.h
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /** Versioned request agent string. */
-#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-0.13.2"
+#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-0.13.2+1"

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
@@ -27,24 +27,24 @@
 
 @implementation FLTInitializationHandler {
   FlutterResult _result;
-  int _numCalls;
+  BOOL _isInitializationCompleted;
 }
 
 - (instancetype)initWithResult:(FlutterResult)result {
   self = [super init];
   if (self) {
-    _numCalls = 0;
+    _isInitializationCompleted = false;
     _result = result;
   }
   return self;
 }
 
 - (void)handleInitializationComplete:(GADInitializationStatus *_Nonnull)status {
-  if (_numCalls > 0) {
+  if (_isInitializationCompleted) {
     return;
   }
   _result([[FLTInitializationStatus alloc] initWithStatus:status]);
-  _numCalls += 1;
+  _isInitializationCompleted = true;
 }
 
 @end

--- a/packages/google_mobile_ads/pubspec.yaml
+++ b/packages/google_mobile_ads/pubspec.yaml
@@ -16,7 +16,7 @@ name: google_mobile_ads
 description: Flutter plugin for Google Mobile Ads, supporting
   banner, interstitial (full-screen),  rewarded and native ads
 homepage: https://github.com/googleads/googleads-mobile-flutter/tree/master/packages/google_mobile_ads
-version: 0.13.2
+version: 0.13.2+1
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Prevents the init handlers from invoking result.success() more than once.

## Related Issues

https://github.com/googleads/googleads-mobile-flutter/issues/130

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.