### PR TITLE
Add BannerAd reload on orientation change to example

### DIFF
--- a/packages/google_mobile_ads/example/lib/main.dart
+++ b/packages/google_mobile_ads/example/lib/main.dart
@@ -159,8 +159,8 @@ class _MyAppState extends State<MyApp> {
     final MediaQueryData mediaQuery = MediaQuery.of(context);
     final AnchoredAdaptiveBannerAdSize? size =
         await AdSize.getAnchoredAdaptiveBannerAdSize(
-        mediaQuery.orientation,
-        mediaQuery.size.width.truncate(),
+      mediaQuery.orientation,
+      mediaQuery.size.width.truncate(),
     );
 
     if (size == null) {

--- a/packages/google_mobile_ads/example/lib/main.dart
+++ b/packages/google_mobile_ads/example/lib/main.dart
@@ -53,6 +53,8 @@ class _MyAppState extends State<MyApp> {
   BannerAd? _anchoredBanner;
   bool _loadingAnchoredBanner = false;
 
+  Orientation? _orientation;
+
   @override
   void initState() {
     super.initState();
@@ -177,10 +179,12 @@ class _MyAppState extends State<MyApp> {
           setState(() {
             _anchoredBanner = ad as BannerAd?;
           });
+          _loadingAnchoredBanner = false;
         },
         onAdFailedToLoad: (Ad ad, LoadAdError error) {
           print('$BannerAd failedToLoad: $error');
           ad.dispose();
+          _loadingAnchoredBanner = false;
         },
         onAdOpened: (Ad ad) => print('$BannerAd onAdOpened.'),
         onAdClosed: (Ad ad) => print('$BannerAd onAdClosed.'),
@@ -201,7 +205,11 @@ class _MyAppState extends State<MyApp> {
   Widget build(BuildContext context) {
     return MaterialApp(
       home: Builder(builder: (BuildContext context) {
-        if (!_loadingAnchoredBanner) {
+        final MediaQueryData mediaQuery = MediaQuery.of(context);
+        if (!_loadingAnchoredBanner && mediaQuery.orientation != _orientation) {
+          _orientation = mediaQuery.orientation;
+          _anchoredBanner?.dispose();
+          _anchoredBanner = null;
           _loadingAnchoredBanner = true;
           _createAnchoredBanner(context);
         }

--- a/packages/google_mobile_ads/example/lib/main.dart
+++ b/packages/google_mobile_ads/example/lib/main.dart
@@ -156,10 +156,11 @@ class _MyAppState extends State<MyApp> {
   }
 
   Future<void> _createAnchoredBanner(BuildContext context) async {
+    final MediaQueryData mediaQuery = MediaQuery.of(context);
     final AnchoredAdaptiveBannerAdSize? size =
         await AdSize.getAnchoredAdaptiveBannerAdSize(
-      Orientation.portrait,
-      MediaQuery.of(context).size.width.truncate(),
+        mediaQuery.orientation,
+        mediaQuery.size.width.truncate(),
     );
 
     if (size == null) {


### PR DESCRIPTION
## Description

Improve the example to reload the `BannerAd` on an `Orientation` change.

## Related Issues

Fixes https://github.com/googleads/googleads-mobile-flutter/issues/324

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
