### PR TITLE
Set location and pub provided id

### DIFF
--- a/packages/google_mobile_ads/android/build.gradle
+++ b/packages/google_mobile_ads/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-      classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.0'
     }
 }
 
@@ -32,10 +32,16 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-      api 'com.google.android.gms:play-services-ads:20.1.0'
-      testImplementation 'junit:junit:4.12'
-      testImplementation 'org.hamcrest:hamcrest:2.2'
-      testImplementation 'org.mockito:mockito-inline:3.9.0'
+        api 'com.google.android.gms:play-services-ads:20.1.0'
+        testImplementation 'junit:junit:4.12'
+        testImplementation 'org.hamcrest:hamcrest:2.2'
+        testImplementation 'org.mockito:mockito-inline:3.9.0'
+        testImplementation 'org.robolectric:robolectric:4.4'
+    }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
     }
 }
 

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
@@ -68,12 +68,24 @@ class AdMessageCodec extends StandardMessageCodec {
   protected void writeValue(ByteArrayOutputStream stream, Object value) {
     if (value instanceof FlutterAdSize) {
       writeAdSize(stream, (FlutterAdSize) value);
+    } else if (value instanceof FlutterAdManagerAdRequest) {
+      stream.write(VALUE_ADMANAGER_AD_REQUEST);
+      final FlutterAdManagerAdRequest request = (FlutterAdManagerAdRequest) value;
+      writeValue(stream, request.getKeywords());
+      writeValue(stream, request.getContentUrl());
+      writeValue(stream, request.getCustomTargeting());
+      writeValue(stream, request.getCustomTargetingLists());
+      writeValue(stream, request.getNonPersonalizedAds());
+      writeValue(stream, request.getNeighboringContentUrls());
+      writeValue(stream, request.getHttpTimeoutMillis());
     } else if (value instanceof FlutterAdRequest) {
       stream.write(VALUE_AD_REQUEST);
       final FlutterAdRequest request = (FlutterAdRequest) value;
       writeValue(stream, request.getKeywords());
       writeValue(stream, request.getContentUrl());
       writeValue(stream, request.getNonPersonalizedAds());
+      writeValue(stream, request.getNeighboringContentUrls());
+      writeValue(stream, request.getHttpTimeoutMillis());
     } else if (value instanceof FlutterRewardedAd.FlutterRewardItem) {
       stream.write(VALUE_REWARD_ITEM);
       final FlutterRewardedAd.FlutterRewardItem item = (FlutterRewardedAd.FlutterRewardItem) value;
@@ -106,14 +118,6 @@ class AdMessageCodec extends StandardMessageCodec {
       writeValue(stream, error.code);
       writeValue(stream, error.domain);
       writeValue(stream, error.message);
-    } else if (value instanceof FlutterAdManagerAdRequest) {
-      stream.write(VALUE_ADMANAGER_AD_REQUEST);
-      final FlutterAdManagerAdRequest request = (FlutterAdManagerAdRequest) value;
-      writeValue(stream, request.getKeywords());
-      writeValue(stream, request.getContentUrl());
-      writeValue(stream, request.getCustomTargeting());
-      writeValue(stream, request.getCustomTargetingLists());
-      writeValue(stream, request.getNonPersonalizedAds());
     } else if (value instanceof FlutterAdapterStatus.AdapterInitializationState) {
       stream.write(VALUE_INITIALIZATION_STATE);
       final FlutterAdapterStatus.AdapterInitializationState state =
@@ -183,6 +187,8 @@ class AdMessageCodec extends StandardMessageCodec {
             .setKeywords((List<String>) readValueOfType(buffer.get(), buffer))
             .setContentUrl((String) readValueOfType(buffer.get(), buffer))
             .setNonPersonalizedAds(booleanValueOf(readValueOfType(buffer.get(), buffer)))
+            .setNeighboringContentUrls((List<String>) readValueOfType(buffer.get(), buffer))
+            .setHttpTimeoutMillis((Integer) readValueOfType(buffer.get(), buffer))
             .build();
       case VALUE_REWARD_ITEM:
         return new FlutterRewardedAd.FlutterRewardItem(
@@ -212,14 +218,16 @@ class AdMessageCodec extends StandardMessageCodec {
             (String) readValueOfType(buffer.get(), buffer),
             (String) readValueOfType(buffer.get(), buffer));
       case VALUE_ADMANAGER_AD_REQUEST:
-        return new FlutterAdManagerAdRequest.Builder()
-            .setKeywords((List<String>) readValueOfType(buffer.get(), buffer))
-            .setContentUrl((String) readValueOfType(buffer.get(), buffer))
-            .setCustomTargeting((Map<String, String>) readValueOfType(buffer.get(), buffer))
-            .setCustomTargetingLists(
-                (Map<String, List<String>>) readValueOfType(buffer.get(), buffer))
-            .setNonPersonalizedAds((Boolean) readValueOfType(buffer.get(), buffer))
-            .build();
+        FlutterAdManagerAdRequest.Builder builder = new FlutterAdManagerAdRequest.Builder();
+        builder.setKeywords((List<String>) readValueOfType(buffer.get(), buffer));
+        builder.setContentUrl((String) readValueOfType(buffer.get(), buffer));
+        builder.setCustomTargeting((Map<String, String>) readValueOfType(buffer.get(), buffer));
+        builder.setCustomTargetingLists(
+            (Map<String, List<String>>) readValueOfType(buffer.get(), buffer));
+        builder.setNonPersonalizedAds((Boolean) readValueOfType(buffer.get(), buffer));
+        builder.setNeighboringContentUrls((List<String>) readValueOfType(buffer.get(), buffer));
+        builder.setHttpTimeoutMillis((Integer) readValueOfType(buffer.get(), buffer));
+        return builder.build();
       case VALUE_INITIALIZATION_STATE:
         final String state = (String) readValueOfType(buffer.get(), buffer);
         switch (state) {

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
@@ -279,9 +279,10 @@ class AdMessageCodec extends StandardMessageCodec {
             (Boolean) readValueOfType(buffer.get(), buffer));
       case VALUE_LOCATION_PARAMS:
         Location location = new Location("");
-        location.setAccuracy((float) readValueOfType(buffer.get(), buffer));
-        location.setLongitude((float) readValueOfType(buffer.get(), buffer));
-        location.setLatitude((float) readValueOfType(buffer.get(), buffer));
+        // This is necessary because StandardMessageCodec converts floats to double.
+        location.setAccuracy(((Double) readValueOfType(buffer.get(), buffer)).floatValue());
+        location.setLongitude((double) readValueOfType(buffer.get(), buffer));
+        location.setLatitude((double) readValueOfType(buffer.get(), buffer));
         location.setTime((long) readValueOfType(buffer.get(), buffer));
         return location;
       default:

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
@@ -16,6 +16,7 @@
 package io.flutter.plugins.googlemobileads;
 
 import android.content.Context;
+import android.location.Location;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -49,6 +50,7 @@ class AdMessageCodec extends StandardMessageCodec {
   static final byte VALUE_SMART_BANNER_AD_SIZE = (byte) 143;
   static final byte VALUE_NATIVE_AD_OPTIONS = (byte) 144;
   static final byte VALUE_VIDEO_OPTIONS = (byte) 145;
+  static final byte VALUE_LOCATION_PARAMS = (byte) 146;
 
   @NonNull final Context context;
   @NonNull final FlutterAdSize.AdSizeFactory adSizeFactory;
@@ -78,6 +80,7 @@ class AdMessageCodec extends StandardMessageCodec {
       writeValue(stream, request.getNonPersonalizedAds());
       writeValue(stream, request.getNeighboringContentUrls());
       writeValue(stream, request.getHttpTimeoutMillis());
+      writeValue(stream, request.getLocation());
     } else if (value instanceof FlutterAdRequest) {
       stream.write(VALUE_AD_REQUEST);
       final FlutterAdRequest request = (FlutterAdRequest) value;
@@ -86,6 +89,7 @@ class AdMessageCodec extends StandardMessageCodec {
       writeValue(stream, request.getNonPersonalizedAds());
       writeValue(stream, request.getNeighboringContentUrls());
       writeValue(stream, request.getHttpTimeoutMillis());
+      writeValue(stream, request.getLocation());
     } else if (value instanceof FlutterRewardedAd.FlutterRewardItem) {
       stream.write(VALUE_REWARD_ITEM);
       final FlutterRewardedAd.FlutterRewardItem item = (FlutterRewardedAd.FlutterRewardItem) value;
@@ -162,6 +166,13 @@ class AdMessageCodec extends StandardMessageCodec {
       writeValue(stream, options.clickToExpandRequested);
       writeValue(stream, options.customControlsRequested);
       writeValue(stream, options.startMuted);
+    } else if (value instanceof Location) {
+      stream.write(VALUE_LOCATION_PARAMS);
+      Location location = (Location) value;
+      writeValue(stream, location.getAccuracy());
+      writeValue(stream, location.getLongitude());
+      writeValue(stream, location.getLatitude());
+      writeValue(stream, location.getTime());
     } else {
       super.writeValue(stream, value);
     }
@@ -189,6 +200,7 @@ class AdMessageCodec extends StandardMessageCodec {
             .setNonPersonalizedAds(booleanValueOf(readValueOfType(buffer.get(), buffer)))
             .setNeighboringContentUrls((List<String>) readValueOfType(buffer.get(), buffer))
             .setHttpTimeoutMillis((Integer) readValueOfType(buffer.get(), buffer))
+            .setLocation((Location) readValueOfType(buffer.get(), buffer))
             .build();
       case VALUE_REWARD_ITEM:
         return new FlutterRewardedAd.FlutterRewardItem(
@@ -227,6 +239,7 @@ class AdMessageCodec extends StandardMessageCodec {
         builder.setNonPersonalizedAds((Boolean) readValueOfType(buffer.get(), buffer));
         builder.setNeighboringContentUrls((List<String>) readValueOfType(buffer.get(), buffer));
         builder.setHttpTimeoutMillis((Integer) readValueOfType(buffer.get(), buffer));
+        builder.setLocation((Location) readValueOfType(buffer.get(), buffer));
         return builder.build();
       case VALUE_INITIALIZATION_STATE:
         final String state = (String) readValueOfType(buffer.get(), buffer);
@@ -264,6 +277,13 @@ class AdMessageCodec extends StandardMessageCodec {
             (Boolean) readValueOfType(buffer.get(), buffer),
             (Boolean) readValueOfType(buffer.get(), buffer),
             (Boolean) readValueOfType(buffer.get(), buffer));
+      case VALUE_LOCATION_PARAMS:
+        Location location = new Location("");
+        location.setAccuracy((float) readValueOfType(buffer.get(), buffer));
+        location.setLongitude((float) readValueOfType(buffer.get(), buffer));
+        location.setLatitude((float) readValueOfType(buffer.get(), buffer));
+        location.setTime((long) readValueOfType(buffer.get(), buffer));
+        return location;
       default:
         return super.readValueOfType(type, buffer);
     }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequest.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequest.java
@@ -26,29 +26,15 @@ import java.util.Objects;
  * Instantiates and serializes {@link com.google.android.gms.ads.admanager.AdManagerAdRequest} for
  * the Google Mobile Ads Plugin.
  */
-class FlutterAdManagerAdRequest {
-  @Nullable private List<String> keywords;
-  @Nullable private String contentUrl;
+class FlutterAdManagerAdRequest extends FlutterAdRequest {
+
   @Nullable private Map<String, String> customTargeting;
   @Nullable private Map<String, List<String>> customTargetingLists;
-  @Nullable private Boolean nonPersonalizedAds;
 
-  public static class Builder {
-    @Nullable private List<String> keywords;
-    @Nullable private String contentUrl;
+  static class Builder extends FlutterAdRequest.Builder {
+
     @Nullable private Map<String, String> customTargeting;
     @Nullable private Map<String, List<String>> customTargetingLists;
-    @Nullable private Boolean nonPersonalizedAds;
-
-    public Builder setKeywords(@Nullable List<String> keywords) {
-      this.keywords = keywords;
-      return this;
-    }
-
-    public Builder setContentUrl(@Nullable String contentUrl) {
-      this.contentUrl = contentUrl;
-      return this;
-    }
 
     public Builder setCustomTargeting(@Nullable Map<String, String> customTargeting) {
       this.customTargeting = customTargeting;
@@ -61,34 +47,41 @@ class FlutterAdManagerAdRequest {
       return this;
     }
 
-    public Builder setNonPersonalizedAds(@Nullable Boolean nonPersonalizedAds) {
-      this.nonPersonalizedAds = nonPersonalizedAds;
-      return this;
-    }
-
     FlutterAdManagerAdRequest build() {
-      final FlutterAdManagerAdRequest request = new FlutterAdManagerAdRequest();
-      request.keywords = keywords;
-      request.contentUrl = contentUrl;
-      request.customTargeting = customTargeting;
-      request.customTargetingLists = customTargetingLists;
-      request.nonPersonalizedAds = nonPersonalizedAds;
-      return request;
+      return new FlutterAdManagerAdRequest(
+          getKeywords(),
+          getContentUrl(),
+          customTargeting,
+          customTargetingLists,
+          getNonPersonalizedAds(),
+          getNeighboringContentUrls(),
+          getHttpTimeoutMillis());
     }
   }
 
-  private FlutterAdManagerAdRequest() {}
+  private FlutterAdManagerAdRequest(
+      @Nullable List<String> keywords,
+      @Nullable String contentUrl,
+      @Nullable Map<String, String> customTargeting,
+      @Nullable Map<String, List<String>> customTargetingLists,
+      @Nullable Boolean nonPersonalizedAds,
+      @Nullable List<String> neighboringContentUrls,
+      @Nullable Integer httpTimeoutMillis) {
+    super(keywords, contentUrl, nonPersonalizedAds, neighboringContentUrls, httpTimeoutMillis);
+    this.customTargeting = customTargeting;
+    this.customTargetingLists = customTargetingLists;
+  }
 
   AdManagerAdRequest asAdManagerAdRequest() {
     final AdManagerAdRequest.Builder builder = new AdManagerAdRequest.Builder();
-    if (keywords != null) {
-      for (final String keyword : keywords) {
+    if (getKeywords() != null) {
+      for (final String keyword : getKeywords()) {
         builder.addKeyword(keyword);
       }
     }
 
-    if (contentUrl != null) {
-      builder.setContentUrl(contentUrl);
+    if (getContentUrl() != null) {
+      builder.setContentUrl(getContentUrl());
     }
     if (customTargeting != null) {
       for (final Map.Entry<String, String> entry : customTargeting.entrySet()) {
@@ -100,7 +93,7 @@ class FlutterAdManagerAdRequest {
         builder.addCustomTargeting(entry.getKey(), entry.getValue());
       }
     }
-    if (nonPersonalizedAds != null && nonPersonalizedAds) {
+    if (getNonPersonalizedAds() != null && getNonPersonalizedAds()) {
       final Bundle extras = new Bundle();
       extras.putString("npa", "1");
       builder.addNetworkExtrasBundle(AdMobAdapter.class, extras);
@@ -110,28 +103,13 @@ class FlutterAdManagerAdRequest {
   }
 
   @Nullable
-  public List<String> getKeywords() {
-    return keywords;
-  }
-
-  @Nullable
-  public String getContentUrl() {
-    return contentUrl;
-  }
-
-  @Nullable
-  public Map<String, String> getCustomTargeting() {
+  protected Map<String, String> getCustomTargeting() {
     return customTargeting;
   }
 
   @Nullable
-  public Map<String, List<String>> getCustomTargetingLists() {
+  protected Map<String, List<String>> getCustomTargetingLists() {
     return customTargetingLists;
-  }
-
-  @Nullable
-  public Boolean getNonPersonalizedAds() {
-    return nonPersonalizedAds;
   }
 
   @Override
@@ -143,20 +121,13 @@ class FlutterAdManagerAdRequest {
     }
 
     FlutterAdManagerAdRequest request = (FlutterAdManagerAdRequest) o;
-
-    return Objects.equals(keywords, request.keywords)
-        && Objects.equals(contentUrl, request.contentUrl)
+    return super.equals(o)
         && Objects.equals(customTargeting, request.customTargeting)
-        && Objects.equals(nonPersonalizedAds, request.nonPersonalizedAds)
         && Objects.equals(customTargetingLists, request.customTargetingLists);
   }
 
   @Override
   public int hashCode() {
-    int result = keywords != null ? keywords.hashCode() : 0;
-    result = 31 * result + (contentUrl != null ? contentUrl.hashCode() : 0);
-    result = 31 * result + (customTargeting != null ? customTargeting.hashCode() : 0);
-    result = 31 * result + (customTargetingLists != null ? customTargetingLists.hashCode() : 0);
-    return result;
+    return Objects.hash(super.hashCode(), customTargeting, customTargetingLists);
   }
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequest.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequest.java
@@ -70,7 +70,13 @@ class FlutterAdManagerAdRequest extends FlutterAdRequest {
       @Nullable List<String> neighboringContentUrls,
       @Nullable Integer httpTimeoutMillis,
       @Nullable Location location) {
-    super(keywords, contentUrl, nonPersonalizedAds, neighboringContentUrls, httpTimeoutMillis, location);
+    super(
+        keywords,
+        contentUrl,
+        nonPersonalizedAds,
+        neighboringContentUrls,
+        httpTimeoutMillis,
+        location);
     this.customTargeting = customTargeting;
     this.customTargetingLists = customTargetingLists;
   }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequest.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequest.java
@@ -14,6 +14,7 @@
 
 package io.flutter.plugins.googlemobileads;
 
+import android.location.Location;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
 import com.google.ads.mediation.admob.AdMobAdapter;
@@ -55,7 +56,8 @@ class FlutterAdManagerAdRequest extends FlutterAdRequest {
           customTargetingLists,
           getNonPersonalizedAds(),
           getNeighboringContentUrls(),
-          getHttpTimeoutMillis());
+          getHttpTimeoutMillis(),
+          getLocation());
     }
   }
 
@@ -66,8 +68,9 @@ class FlutterAdManagerAdRequest extends FlutterAdRequest {
       @Nullable Map<String, List<String>> customTargetingLists,
       @Nullable Boolean nonPersonalizedAds,
       @Nullable List<String> neighboringContentUrls,
-      @Nullable Integer httpTimeoutMillis) {
-    super(keywords, contentUrl, nonPersonalizedAds, neighboringContentUrls, httpTimeoutMillis);
+      @Nullable Integer httpTimeoutMillis,
+      @Nullable Location location) {
+    super(keywords, contentUrl, nonPersonalizedAds, neighboringContentUrls, httpTimeoutMillis, location);
     this.customTargeting = customTargeting;
     this.customTargetingLists = customTargetingLists;
   }
@@ -97,6 +100,9 @@ class FlutterAdManagerAdRequest extends FlutterAdRequest {
       final Bundle extras = new Bundle();
       extras.putString("npa", "1");
       builder.addNetworkExtrasBundle(AdMobAdapter.class, extras);
+    }
+    if (getLocation() != null) {
+      builder.setLocation(getLocation());
     }
     builder.setRequestAgent(Constants.REQUEST_AGENT_PREFIX_VERSIONED);
     return builder.build();

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdRequest.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdRequest.java
@@ -14,6 +14,7 @@
 
 package io.flutter.plugins.googlemobileads;
 
+import android.location.Location;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
 import com.google.ads.mediation.admob.AdMobAdapter;
@@ -27,6 +28,7 @@ class FlutterAdRequest {
   @Nullable private final Boolean nonPersonalizedAds;
   @Nullable private final List<String> neighboringContentUrls;
   @Nullable private final Integer httpTimeoutMillis;
+  @Nullable private final Location location;
 
   protected static class Builder {
     @Nullable private List<String> keywords;
@@ -34,6 +36,7 @@ class FlutterAdRequest {
     @Nullable private Boolean nonPersonalizedAds;
     @Nullable private List<String> neighboringContentUrls;
     @Nullable private Integer httpTimeoutMillis;
+    @Nullable private Location location;
 
     Builder setKeywords(@Nullable List<String> keywords) {
       this.keywords = keywords;
@@ -57,6 +60,11 @@ class FlutterAdRequest {
 
     Builder setHttpTimeoutMillis(@Nullable Integer httpTimeoutMillis) {
       this.httpTimeoutMillis = httpTimeoutMillis;
+      return this;
+    }
+
+    Builder setLocation(@Nullable Location location) {
+      this.location = location;
       return this;
     }
 
@@ -85,9 +93,19 @@ class FlutterAdRequest {
       return httpTimeoutMillis;
     }
 
+    @Nullable
+    protected Location getLocation() {
+      return location;
+    }
+
     FlutterAdRequest build() {
       return new FlutterAdRequest(
-          keywords, contentUrl, nonPersonalizedAds, neighboringContentUrls, httpTimeoutMillis);
+          keywords,
+          contentUrl,
+          nonPersonalizedAds,
+          neighboringContentUrls,
+          httpTimeoutMillis,
+          location);
     }
   }
 
@@ -96,12 +114,14 @@ class FlutterAdRequest {
       @Nullable String contentUrl,
       @Nullable Boolean nonPersonalizedAds,
       @Nullable List<String> neighboringContentUrls,
-      @Nullable Integer httpTimeoutMillis) {
+      @Nullable Integer httpTimeoutMillis,
+      @Nullable Location location) {
     this.keywords = keywords;
     this.contentUrl = contentUrl;
     this.nonPersonalizedAds = nonPersonalizedAds;
     this.neighboringContentUrls = neighboringContentUrls;
     this.httpTimeoutMillis = httpTimeoutMillis;
+    this.location = location;
   }
 
   AdRequest asAdRequest() {
@@ -125,6 +145,9 @@ class FlutterAdRequest {
     }
     if (httpTimeoutMillis != null) {
       builder.setHttpTimeoutMillis(httpTimeoutMillis);
+    }
+    if (location != null) {
+      builder.setLocation(location);
     }
     builder.setRequestAgent(Constants.REQUEST_AGENT_PREFIX_VERSIONED);
     return builder.build();
@@ -155,6 +178,11 @@ class FlutterAdRequest {
     return httpTimeoutMillis;
   }
 
+  @Nullable
+  protected Location getLocation() {
+    return location;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -168,12 +196,18 @@ class FlutterAdRequest {
         && Objects.equals(contentUrl, request.contentUrl)
         && Objects.equals(nonPersonalizedAds, request.nonPersonalizedAds)
         && Objects.equals(neighboringContentUrls, request.neighboringContentUrls)
-        && Objects.equals(httpTimeoutMillis, request.httpTimeoutMillis);
+        && Objects.equals(httpTimeoutMillis, request.httpTimeoutMillis)
+        && Objects.equals(location, request.location);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        keywords, contentUrl, nonPersonalizedAds, neighboringContentUrls, httpTimeoutMillis);
+        keywords,
+        contentUrl,
+        nonPersonalizedAds,
+        neighboringContentUrls,
+        httpTimeoutMillis,
+        location);
   }
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdRequest.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdRequest.java
@@ -197,7 +197,13 @@ class FlutterAdRequest {
         && Objects.equals(nonPersonalizedAds, request.nonPersonalizedAds)
         && Objects.equals(neighboringContentUrls, request.neighboringContentUrls)
         && Objects.equals(httpTimeoutMillis, request.httpTimeoutMillis)
-        && Objects.equals(location, request.location);
+        && (location == null) == (request.location == null)
+        && (location == null
+            // We only care about these properties which are guaranteed by the Location API.
+            || (location.getAccuracy() == request.location.getAccuracy()
+                && location.getLongitude() == request.location.getLongitude()
+                && location.getLatitude() == request.location.getLatitude()
+                && location.getTime() == request.location.getTime()));
   }
 
   @Override

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdRequest.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdRequest.java
@@ -19,16 +19,21 @@ import androidx.annotation.Nullable;
 import com.google.ads.mediation.admob.AdMobAdapter;
 import com.google.android.gms.ads.AdRequest;
 import java.util.List;
+import java.util.Objects;
 
 class FlutterAdRequest {
-  @Nullable private List<String> keywords;
-  @Nullable private String contentUrl;
-  @Nullable private Boolean nonPersonalizedAds;
+  @Nullable private final List<String> keywords;
+  @Nullable private final String contentUrl;
+  @Nullable private final Boolean nonPersonalizedAds;
+  @Nullable private final List<String> neighboringContentUrls;
+  @Nullable private final Integer httpTimeoutMillis;
 
-  static class Builder {
+  protected static class Builder {
     @Nullable private List<String> keywords;
     @Nullable private String contentUrl;
     @Nullable private Boolean nonPersonalizedAds;
+    @Nullable private List<String> neighboringContentUrls;
+    @Nullable private Integer httpTimeoutMillis;
 
     Builder setKeywords(@Nullable List<String> keywords) {
       this.keywords = keywords;
@@ -45,16 +50,59 @@ class FlutterAdRequest {
       return this;
     }
 
+    Builder setNeighboringContentUrls(@Nullable List<String> neighboringContentUrls) {
+      this.neighboringContentUrls = neighboringContentUrls;
+      return this;
+    }
+
+    Builder setHttpTimeoutMillis(@Nullable Integer httpTimeoutMillis) {
+      this.httpTimeoutMillis = httpTimeoutMillis;
+      return this;
+    }
+
+    @Nullable
+    protected List<String> getKeywords() {
+      return keywords;
+    }
+
+    @Nullable
+    protected String getContentUrl() {
+      return contentUrl;
+    }
+
+    @Nullable
+    protected Boolean getNonPersonalizedAds() {
+      return nonPersonalizedAds;
+    }
+
+    @Nullable
+    protected List<String> getNeighboringContentUrls() {
+      return neighboringContentUrls;
+    }
+
+    @Nullable
+    protected Integer getHttpTimeoutMillis() {
+      return httpTimeoutMillis;
+    }
+
     FlutterAdRequest build() {
-      final FlutterAdRequest request = new FlutterAdRequest();
-      request.keywords = keywords;
-      request.contentUrl = contentUrl;
-      request.nonPersonalizedAds = nonPersonalizedAds;
-      return request;
+      return new FlutterAdRequest(
+          keywords, contentUrl, nonPersonalizedAds, neighboringContentUrls, httpTimeoutMillis);
     }
   }
 
-  private FlutterAdRequest() {}
+  protected FlutterAdRequest(
+      @Nullable List<String> keywords,
+      @Nullable String contentUrl,
+      @Nullable Boolean nonPersonalizedAds,
+      @Nullable List<String> neighboringContentUrls,
+      @Nullable Integer httpTimeoutMillis) {
+    this.keywords = keywords;
+    this.contentUrl = contentUrl;
+    this.nonPersonalizedAds = nonPersonalizedAds;
+    this.neighboringContentUrls = neighboringContentUrls;
+    this.httpTimeoutMillis = httpTimeoutMillis;
+  }
 
   AdRequest asAdRequest() {
     final AdRequest.Builder builder = new AdRequest.Builder();
@@ -72,22 +120,60 @@ class FlutterAdRequest {
       extras.putString("npa", "1");
       builder.addNetworkExtrasBundle(AdMobAdapter.class, extras);
     }
+    if (neighboringContentUrls != null) {
+      builder.setNeighboringContentUrls(neighboringContentUrls);
+    }
+    if (httpTimeoutMillis != null) {
+      builder.setHttpTimeoutMillis(httpTimeoutMillis);
+    }
     builder.setRequestAgent(Constants.REQUEST_AGENT_PREFIX_VERSIONED);
     return builder.build();
   }
 
   @Nullable
-  public List<String> getKeywords() {
+  protected List<String> getKeywords() {
     return keywords;
   }
 
   @Nullable
-  public String getContentUrl() {
+  protected String getContentUrl() {
     return contentUrl;
   }
 
   @Nullable
-  public Boolean getNonPersonalizedAds() {
+  protected Boolean getNonPersonalizedAds() {
     return nonPersonalizedAds;
+  }
+
+  @Nullable
+  protected List<String> getNeighboringContentUrls() {
+    return neighboringContentUrls;
+  }
+
+  @Nullable
+  protected Integer getHttpTimeoutMillis() {
+    return httpTimeoutMillis;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (!(o instanceof FlutterAdRequest)) {
+      return false;
+    }
+
+    FlutterAdRequest request = (FlutterAdRequest) o;
+    return Objects.equals(keywords, request.keywords)
+        && Objects.equals(contentUrl, request.contentUrl)
+        && Objects.equals(nonPersonalizedAds, request.nonPersonalizedAds)
+        && Objects.equals(neighboringContentUrls, request.neighboringContentUrls)
+        && Objects.equals(httpTimeoutMillis, request.httpTimeoutMillis);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        keywords, contentUrl, nonPersonalizedAds, neighboringContentUrls, httpTimeoutMillis);
   }
 }

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import android.content.Context;
+import android.location.Location;
 import com.google.android.gms.ads.AdSize;
 import io.flutter.plugins.googlemobileads.FlutterAd.FlutterAdapterResponseInfo;
 import io.flutter.plugins.googlemobileads.FlutterAd.FlutterResponseInfo;
@@ -204,23 +205,24 @@ public class AdMessageCodecTest {
 
   @Test
   public void encodeFlutterAdRequest() {
-    final ByteBuffer message =
-        codec.encodeMessage(
-            new FlutterAdRequest.Builder()
-                .setKeywords(Arrays.asList("1", "2", "3"))
-                .setContentUrl("contentUrl")
-                .setNonPersonalizedAds(false)
-                .setNeighboringContentUrls(Arrays.asList("example.com", "test.com"))
-                .setHttpTimeoutMillis(1000)
-                .build());
+    Location location = new Location("");
+    location.setAccuracy(12345);
+    location.setLongitude(1.0);
+    location.setLatitude(5.0);
+    location.setTime(54321);
+    FlutterAdRequest adRequest = new FlutterAdRequest.Builder()
+        .setKeywords(Arrays.asList("1", "2", "3"))
+        .setContentUrl("contentUrl")
+        .setNonPersonalizedAds(false)
+        .setNeighboringContentUrls(Arrays.asList("example.com", "test.com"))
+        .setHttpTimeoutMillis(1000)
+        .setLocation(location)
+        .build();
+    final ByteBuffer message = codec.encodeMessage(adRequest);
 
-    final FlutterAdRequest request =
+    final FlutterAdRequest decodedRequest =
         (FlutterAdRequest) codec.decodeMessage((ByteBuffer) message.position(0));
-    assertEquals(Arrays.asList("1", "2", "3"), request.getKeywords());
-    assertEquals("contentUrl", request.getContentUrl());
-    assertEquals(false, request.getNonPersonalizedAds());
-    assertEquals(Arrays.asList("example.com", "test.com"), request.getNeighboringContentUrls());
-    assertEquals((Integer) 1000, request.getHttpTimeoutMillis());
+    assertEquals(adRequest, decodedRequest);
   }
 
   @Test

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
@@ -16,24 +16,26 @@ package io.flutter.plugins.googlemobileads;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import android.content.Context;
 import com.google.android.gms.ads.AdSize;
+import io.flutter.plugins.googlemobileads.FlutterAd.FlutterAdapterResponseInfo;
+import io.flutter.plugins.googlemobileads.FlutterAd.FlutterResponseInfo;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
 /** Tests for {@link AdMessageCodec}. */
 public class AdMessageCodecTest {
-  AdMessageCodec testCodec;
+  AdMessageCodec codec;
   AdSize mockAdSize;
   FlutterAdSize.AdSizeFactory testAdFactory;
 
@@ -47,28 +49,28 @@ public class AdMessageCodecTest {
             return mockAdSize;
           }
         };
-    testCodec = new AdMessageCodec(null, testAdFactory);
+    codec = new AdMessageCodec(null, testAdFactory);
   }
 
   @Test
-  public void adMessageCodec_encodeAdapterInitializationState() {
+  public void encodeAdapterInitializationState() {
     final ByteBuffer message =
-        testCodec.encodeMessage(FlutterAdapterStatus.AdapterInitializationState.NOT_READY);
+        codec.encodeMessage(FlutterAdapterStatus.AdapterInitializationState.NOT_READY);
 
     assertEquals(
-        testCodec.decodeMessage((ByteBuffer) message.position(0)),
+        codec.decodeMessage((ByteBuffer) message.position(0)),
         FlutterAdapterStatus.AdapterInitializationState.NOT_READY);
   }
 
   @Test
-  public void adMessageCodec_encodeAdapterStatus() {
+  public void encodeAdapterStatus() {
     final ByteBuffer message =
-        testCodec.encodeMessage(
+        codec.encodeMessage(
             new FlutterAdapterStatus(
                 FlutterAdapterStatus.AdapterInitializationState.READY, "desc", 24));
 
     final FlutterAdapterStatus result =
-        (FlutterAdapterStatus) testCodec.decodeMessage((ByteBuffer) message.position(0));
+        (FlutterAdapterStatus) codec.decodeMessage((ByteBuffer) message.position(0));
     assertEquals(
         result,
         new FlutterAdapterStatus(
@@ -76,9 +78,9 @@ public class AdMessageCodecTest {
   }
 
   @Test
-  public void adMessageCodec_encodeInitializationStatus() {
+  public void encodeInitializationStatus() {
     final ByteBuffer message =
-        testCodec.encodeMessage(
+        codec.encodeMessage(
             new FlutterInitializationStatus(
                 Collections.singletonMap(
                     "table",
@@ -88,7 +90,7 @@ public class AdMessageCodecTest {
                         56.66))));
 
     final FlutterInitializationStatus initStatus =
-        (FlutterInitializationStatus) testCodec.decodeMessage((ByteBuffer) message.position(0));
+        (FlutterInitializationStatus) codec.decodeMessage((ByteBuffer) message.position(0));
     assertEquals(initStatus.adapterStatuses.size(), 1);
     final FlutterAdapterStatus adapterStatus = initStatus.adapterStatuses.get("table");
     assertEquals(
@@ -98,97 +100,70 @@ public class AdMessageCodecTest {
   }
 
   @Test
-  public void adMessageCodec_decodeInitializationStatus() {
-    Map<String, String> targeting = new HashMap<>();
-    targeting.put("testKey", "testValue");
-
-    Map<String, List<String>> targetingList = new HashMap<>();
-    List<String> list = new ArrayList<>();
-    list.add("testValue1");
-    list.add("testValue2");
-    targetingList.put("testKey", list);
-
-    FlutterAdManagerAdRequest flutterAdManagerAdRequest =
-        new FlutterAdManagerAdRequest.Builder()
-            .setContentUrl("test-content-url")
-            .setCustomTargeting(targeting)
-            .setCustomTargetingLists(targetingList)
-            .setKeywords(list)
-            .setNonPersonalizedAds(true)
-            .build();
-
-    ByteBuffer message = testCodec.encodeMessage(flutterAdManagerAdRequest);
-
-    FlutterAdManagerAdRequest decodedAdManagerAdRequest =
-        (FlutterAdManagerAdRequest) testCodec.decodeMessage((ByteBuffer) message.position(0));
-    assertEquals(decodedAdManagerAdRequest, flutterAdManagerAdRequest);
-  }
-
-  @Test
-  public void adMessageCodec_decodeServerSideVerificationOptions() {
+  public void decodeServerSideVerificationOptions() {
     FlutterServerSideVerificationOptions options =
         new FlutterServerSideVerificationOptions("user-id", "custom-data");
 
-    ByteBuffer message = testCodec.encodeMessage(options);
+    ByteBuffer message = codec.encodeMessage(options);
 
     FlutterServerSideVerificationOptions decodedOptions =
         (FlutterServerSideVerificationOptions)
-            testCodec.decodeMessage((ByteBuffer) message.position(0));
+            codec.decodeMessage((ByteBuffer) message.position(0));
     assertEquals(decodedOptions, options);
 
     // With userId = null.
     options = new FlutterServerSideVerificationOptions(null, "custom-data");
-    message = testCodec.encodeMessage(options);
+    message = codec.encodeMessage(options);
     decodedOptions =
         (FlutterServerSideVerificationOptions)
-            testCodec.decodeMessage((ByteBuffer) message.position(0));
+            codec.decodeMessage((ByteBuffer) message.position(0));
     assertEquals(decodedOptions, options);
 
     // With customData = null.
     options = new FlutterServerSideVerificationOptions("user-Id", null);
-    message = testCodec.encodeMessage(options);
+    message = codec.encodeMessage(options);
     decodedOptions =
         (FlutterServerSideVerificationOptions)
-            testCodec.decodeMessage((ByteBuffer) message.position(0));
+            codec.decodeMessage((ByteBuffer) message.position(0));
     assertEquals(decodedOptions, options);
 
     // With userId and customData = null.
     options = new FlutterServerSideVerificationOptions(null, null);
-    message = testCodec.encodeMessage(options);
+    message = codec.encodeMessage(options);
     decodedOptions =
         (FlutterServerSideVerificationOptions)
-            testCodec.decodeMessage((ByteBuffer) message.position(0));
+            codec.decodeMessage((ByteBuffer) message.position(0));
     assertEquals(decodedOptions, options);
   }
 
   @Test
-  public void adMessageCodec_encodeAnchoredAdaptiveBannerAdSize() {
+  public void encodeAnchoredAdaptiveBannerAdSize() {
     final FlutterAdSize.AnchoredAdaptiveBannerAdSize adaptiveAdSize =
         new FlutterAdSize.AnchoredAdaptiveBannerAdSize(null, testAdFactory, "portrait", 23);
-    final ByteBuffer data = testCodec.encodeMessage(adaptiveAdSize);
+    final ByteBuffer data = codec.encodeMessage(adaptiveAdSize);
 
     final FlutterAdSize.AnchoredAdaptiveBannerAdSize result =
         (FlutterAdSize.AnchoredAdaptiveBannerAdSize)
-            testCodec.decodeMessage((ByteBuffer) data.position(0));
+            codec.decodeMessage((ByteBuffer) data.position(0));
     assertEquals(result.size, mockAdSize);
   }
 
   @Test
-  public void adMessageCodec_encodeSmartBannerAdSize() {
-    final ByteBuffer data = testCodec.encodeMessage(new FlutterAdSize.SmartBannerAdSize());
+  public void encodeSmartBannerAdSize() {
+    final ByteBuffer data = codec.encodeMessage(new FlutterAdSize.SmartBannerAdSize());
 
     final FlutterAdSize.SmartBannerAdSize result =
-        (FlutterAdSize.SmartBannerAdSize) testCodec.decodeMessage((ByteBuffer) data.position(0));
+        (FlutterAdSize.SmartBannerAdSize) codec.decodeMessage((ByteBuffer) data.position(0));
     assertEquals(result.size, AdSize.SMART_BANNER);
   }
 
   @Test
-  public void adMessageCodec_nativeAdOptionsNull() {
+  public void nativeAdOptionsNull() {
     final ByteBuffer data =
-        testCodec.encodeMessage(new FlutterNativeAdOptions(null, null, null, null, null, null));
+        codec.encodeMessage(new FlutterNativeAdOptions(null, null, null, null, null, null));
 
     final FlutterNativeAdOptions result =
-        (FlutterNativeAdOptions) testCodec.decodeMessage((ByteBuffer) data.position(0));
+        (FlutterNativeAdOptions) codec.decodeMessage((ByteBuffer) data.position(0));
     assertNull(result.adChoicesPlacement);
     assertNull(result.mediaAspectRatio);
     assertNull(result.videoOptions);
@@ -198,14 +173,14 @@ public class AdMessageCodecTest {
   }
 
   @Test
-  public void adMessageCodec_nativeAdOptions() {
+  public void nativeAdOptions() {
     FlutterVideoOptions videoOptions = new FlutterVideoOptions(true, false, true);
 
     final ByteBuffer data =
-        testCodec.encodeMessage(new FlutterNativeAdOptions(1, 2, videoOptions, false, true, false));
+        codec.encodeMessage(new FlutterNativeAdOptions(1, 2, videoOptions, false, true, false));
 
     final FlutterNativeAdOptions result =
-        (FlutterNativeAdOptions) testCodec.decodeMessage((ByteBuffer) data.position(0));
+        (FlutterNativeAdOptions) codec.decodeMessage((ByteBuffer) data.position(0));
     assertEquals(result.adChoicesPlacement, (Integer) 1);
     assertEquals(result.mediaAspectRatio, (Integer) 2);
     assertEquals(result.videoOptions.clickToExpandRequested, true);
@@ -217,13 +192,86 @@ public class AdMessageCodecTest {
   }
 
   @Test
-  public void adMessageCodec_videoOptionsNull() {
-    final ByteBuffer data = testCodec.encodeMessage(new FlutterVideoOptions(null, null, null));
+  public void videoOptionsNull() {
+    final ByteBuffer data = codec.encodeMessage(new FlutterVideoOptions(null, null, null));
 
     final FlutterVideoOptions result =
-        (FlutterVideoOptions) testCodec.decodeMessage((ByteBuffer) data.position(0));
+        (FlutterVideoOptions) codec.decodeMessage((ByteBuffer) data.position(0));
     assertNull(result.clickToExpandRequested);
     assertNull(result.customControlsRequested);
     assertNull(result.startMuted);
+  }
+
+  @Test
+  public void encodeFlutterAdRequest() {
+    final ByteBuffer message =
+        codec.encodeMessage(
+            new FlutterAdRequest.Builder()
+                .setKeywords(Arrays.asList("1", "2", "3"))
+                .setContentUrl("contentUrl")
+                .setNonPersonalizedAds(false)
+                .setNeighboringContentUrls(Arrays.asList("example.com", "test.com"))
+                .setHttpTimeoutMillis(1000)
+                .build());
+
+    final FlutterAdRequest request =
+        (FlutterAdRequest) codec.decodeMessage((ByteBuffer) message.position(0));
+    assertEquals(Arrays.asList("1", "2", "3"), request.getKeywords());
+    assertEquals("contentUrl", request.getContentUrl());
+    assertEquals(false, request.getNonPersonalizedAds());
+    assertEquals(Arrays.asList("example.com", "test.com"), request.getNeighboringContentUrls());
+    assertEquals((Integer) 1000, request.getHttpTimeoutMillis());
+  }
+
+  @Test
+  public void encodeFlutterAdManagerAdRequest() {
+    FlutterAdManagerAdRequest.Builder builder = new FlutterAdManagerAdRequest.Builder();
+    builder.setKeywords(Arrays.asList("1", "2", "3"));
+    builder.setContentUrl("contentUrl");
+    builder.setCustomTargeting(Collections.singletonMap("apple", "banana"));
+    builder.setCustomTargetingLists(
+        Collections.singletonMap("cherry", Collections.singletonList("pie")));
+    builder.setNonPersonalizedAds(true);
+    FlutterAdManagerAdRequest flutterAdManagerAdRequest = builder.build();
+
+    final ByteBuffer message = codec.encodeMessage(flutterAdManagerAdRequest);
+
+    assertEquals(codec.decodeMessage((ByteBuffer) message.position(0)), flutterAdManagerAdRequest);
+  }
+
+  @Test
+  public void encodeFlutterAdSize() {
+    final ByteBuffer message = codec.encodeMessage(new FlutterAdSize(1, 2));
+
+    assertEquals(codec.decodeMessage((ByteBuffer) message.position(0)), new FlutterAdSize(1, 2));
+  }
+
+  @Test
+  public void encodeFlutterRewardItem() {
+    final ByteBuffer message =
+        codec.encodeMessage(new FlutterRewardedAd.FlutterRewardItem(23, "coins"));
+
+    assertEquals(
+        codec.decodeMessage((ByteBuffer) message.position(0)),
+        new FlutterRewardedAd.FlutterRewardItem(23, "coins"));
+  }
+
+  @Test
+  public void encodeFlutterLoadAdError() {
+    List<FlutterAdapterResponseInfo> adapterResponseInfos = new ArrayList<>();
+    adapterResponseInfos.add(
+        new FlutterAdapterResponseInfo("adapter-class", 9999, "description", "credentials", null));
+    FlutterResponseInfo info =
+        new FlutterResponseInfo("responseId", "className", adapterResponseInfos);
+    final ByteBuffer message =
+        codec.encodeMessage(new FlutterBannerAd.FlutterLoadAdError(1, "domain", "message", info));
+
+    final FlutterAd.FlutterLoadAdError error =
+        (FlutterAd.FlutterLoadAdError) codec.decodeMessage((ByteBuffer) message.position(0));
+    assertNotNull(error);
+    assertEquals(error.code, 1);
+    assertEquals(error.domain, "domain");
+    assertEquals(error.message, "message");
+    assertEquals(error.responseInfo, info);
   }
 }

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
@@ -33,8 +33,11 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 /** Tests for {@link AdMessageCodec}. */
+@RunWith(RobolectricTestRunner.class)
 public class AdMessageCodecTest {
   AdMessageCodec codec;
   AdSize mockAdSize;
@@ -206,18 +209,19 @@ public class AdMessageCodecTest {
   @Test
   public void encodeFlutterAdRequest() {
     Location location = new Location("");
-    location.setAccuracy(12345);
+    location.setAccuracy(12345f);
     location.setLongitude(1.0);
     location.setLatitude(5.0);
     location.setTime(54321);
-    FlutterAdRequest adRequest = new FlutterAdRequest.Builder()
-        .setKeywords(Arrays.asList("1", "2", "3"))
-        .setContentUrl("contentUrl")
-        .setNonPersonalizedAds(false)
-        .setNeighboringContentUrls(Arrays.asList("example.com", "test.com"))
-        .setHttpTimeoutMillis(1000)
-        .setLocation(location)
-        .build();
+    FlutterAdRequest adRequest =
+        new FlutterAdRequest.Builder()
+            .setKeywords(Arrays.asList("1", "2", "3"))
+            .setContentUrl("contentUrl")
+            .setNonPersonalizedAds(false)
+            .setNeighboringContentUrls(Arrays.asList("example.com", "test.com"))
+            .setHttpTimeoutMillis(1000)
+            .setLocation(location)
+            .build();
     final ByteBuffer message = codec.encodeMessage(adRequest);
 
     final FlutterAdRequest decodedRequest =
@@ -227,6 +231,11 @@ public class AdMessageCodecTest {
 
   @Test
   public void encodeFlutterAdManagerAdRequest() {
+    Location location = new Location("");
+    location.setAccuracy(12345f);
+    location.setLongitude(1.0);
+    location.setLatitude(5.0);
+    location.setTime(54321);
     FlutterAdManagerAdRequest.Builder builder = new FlutterAdManagerAdRequest.Builder();
     builder.setKeywords(Arrays.asList("1", "2", "3"));
     builder.setContentUrl("contentUrl");
@@ -234,6 +243,7 @@ public class AdMessageCodecTest {
     builder.setCustomTargetingLists(
         Collections.singletonMap("cherry", Collections.singletonList("pie")));
     builder.setNonPersonalizedAds(true);
+    builder.setLocation(location);
     FlutterAdManagerAdRequest flutterAdManagerAdRequest = builder.build();
 
     final ByteBuffer message = codec.encodeMessage(flutterAdManagerAdRequest);

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
@@ -41,12 +41,9 @@ import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.StandardMethodCodec;
-import io.flutter.plugins.googlemobileads.FlutterAd.FlutterAdapterResponseInfo;
 import io.flutter.plugins.googlemobileads.FlutterAd.FlutterResponseInfo;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -149,87 +146,6 @@ public class GoogleMobileAdsTest {
     verify(flutterNativeAd).dispose();
     assertNull(testManager.adForId(2));
     assertNull(testManager.adIdFor(flutterNativeAd));
-  }
-
-  @Test
-  public void adMessageCodec_encodeFlutterAdSize() {
-    final AdMessageCodec codec = new AdMessageCodec(null);
-    final ByteBuffer message = codec.encodeMessage(new FlutterAdSize(1, 2));
-
-    assertEquals(codec.decodeMessage((ByteBuffer) message.position(0)), new FlutterAdSize(1, 2));
-  }
-
-  @Test
-  public void adMessageCodec_encodeFlutterAdRequest() {
-    final AdMessageCodec codec = new AdMessageCodec(null);
-    final ByteBuffer message =
-        codec.encodeMessage(
-            new FlutterAdRequest.Builder()
-                .setKeywords(Arrays.asList("1", "2", "3"))
-                .setContentUrl("contentUrl")
-                .setNonPersonalizedAds(false)
-                .build());
-
-    final FlutterAdRequest request =
-        (FlutterAdRequest) codec.decodeMessage((ByteBuffer) message.position(0));
-    assertEquals(Arrays.asList("1", "2", "3"), request.getKeywords());
-    assertEquals("contentUrl", request.getContentUrl());
-    assertEquals(false, request.getNonPersonalizedAds());
-  }
-
-  @Test
-  public void adMessageCodec_encodeFlutterAdManagerAdRequest() {
-    final AdMessageCodec codec = new AdMessageCodec(null);
-    final ByteBuffer message =
-        codec.encodeMessage(
-            new FlutterAdManagerAdRequest.Builder()
-                .setKeywords(Arrays.asList("1", "2", "3"))
-                .setContentUrl("contentUrl")
-                .setCustomTargeting(Collections.singletonMap("apple", "banana"))
-                .setCustomTargetingLists(
-                    Collections.singletonMap("cherry", Collections.singletonList("pie")))
-                .build());
-
-    assertEquals(
-        codec.decodeMessage((ByteBuffer) message.position(0)),
-        new FlutterAdManagerAdRequest.Builder()
-            .setKeywords(Arrays.asList("1", "2", "3"))
-            .setContentUrl("contentUrl")
-            .setCustomTargeting(Collections.singletonMap("apple", "banana"))
-            .setCustomTargetingLists(
-                Collections.singletonMap("cherry", Collections.singletonList("pie")))
-            .build());
-  }
-
-  @Test
-  public void adMessageCodec_encodeFlutterRewardItem() {
-    final AdMessageCodec codec = new AdMessageCodec(null);
-    final ByteBuffer message =
-        codec.encodeMessage(new FlutterRewardedAd.FlutterRewardItem(23, "coins"));
-
-    assertEquals(
-        codec.decodeMessage((ByteBuffer) message.position(0)),
-        new FlutterRewardedAd.FlutterRewardItem(23, "coins"));
-  }
-
-  @Test
-  public void adMessageCodec_encodeFlutterLoadAdError() {
-    final AdMessageCodec codec = new AdMessageCodec(null);
-    List<FlutterAdapterResponseInfo> adapterResponseInfos = new ArrayList<>();
-    adapterResponseInfos.add(
-        new FlutterAdapterResponseInfo("adapter-class", 9999, "description", "credentials", null));
-    FlutterResponseInfo info =
-        new FlutterResponseInfo("responseId", "className", adapterResponseInfos);
-    final ByteBuffer message =
-        codec.encodeMessage(new FlutterBannerAd.FlutterLoadAdError(1, "domain", "message", info));
-
-    final FlutterAd.FlutterLoadAdError error =
-        (FlutterAd.FlutterLoadAdError) codec.decodeMessage((ByteBuffer) message.position(0));
-    assertNotNull(error);
-    assertEquals(error.code, 1);
-    assertEquals(error.domain, "domain");
-    assertEquals(error.message, "message");
-    assertEquals(error.responseInfo, info);
   }
 
   @Test

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
@@ -48,11 +48,25 @@
 - (instancetype _Nonnull)initWithOrientation:(NSString *_Nonnull)orientation;
 @end
 
+
+@interface FLTLocationParams : NSObject
+
+@property NSNumber *_Nullable accuracy;
+@property NSNumber *_Nullable longitude;
+@property NSNumber *_Nullable latitude;
+
+- (instancetype _Nonnull)initWithAccuracy:(NSNumber *_Nonnull)accuracy
+                                longitude: (NSNumber *_Nonnull)longitude
+                                 latitude: (NSNumber *_Nonnull)latitude;
+
+@end
+
 @interface FLTAdRequest : NSObject
 @property NSArray<NSString *> *_Nullable keywords;
 @property NSString *_Nullable contentURL;
 @property BOOL nonPersonalizedAds;
 @property NSArray<NSString *> *_Nullable neighboringContentURLs;
+@property FLTLocationParams *_Nullable location;
 - (GADRequest *_Nonnull)asGADRequest;
 @end
 

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
@@ -48,7 +48,6 @@
 - (instancetype _Nonnull)initWithOrientation:(NSString *_Nonnull)orientation;
 @end
 
-
 @interface FLTLocationParams : NSObject
 
 @property NSNumber *_Nullable accuracy;
@@ -56,8 +55,8 @@
 @property NSNumber *_Nullable latitude;
 
 - (instancetype _Nonnull)initWithAccuracy:(NSNumber *_Nonnull)accuracy
-                                longitude: (NSNumber *_Nonnull)longitude
-                                 latitude: (NSNumber *_Nonnull)latitude;
+                                longitude:(NSNumber *_Nonnull)longitude
+                                 latitude:(NSNumber *_Nonnull)latitude;
 
 @end
 

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
@@ -52,6 +52,7 @@
 @property NSArray<NSString *> *_Nullable keywords;
 @property NSString *_Nullable contentURL;
 @property BOOL nonPersonalizedAds;
+@property NSArray<NSString *> *_Nullable neighboringContentURLs;
 - (GADRequest *_Nonnull)asGADRequest;
 @end
 
@@ -99,6 +100,8 @@
 @interface FLTGAMAdRequest : FLTAdRequest
 @property NSDictionary<NSString *, NSString *> *_Nullable customTargeting;
 @property NSDictionary<NSString *, NSArray<NSString *> *> *_Nullable customTargetingLists;
+@property NSString *_Nullable pubProvidedID;
+
 - (GAMRequest *_Nonnull)asGAMRequest;
 @end
 

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
@@ -98,7 +98,7 @@
     extras.additionalParameters = @{@"npa" : @"1"};
     [request registerAdNetworkExtras:extras];
   }
-
+  request.neighboringContentURLStrings = _neighboringContentURLs;
   request.requestAgent = FLT_REQUEST_AGENT_VERSIONED;
   return request;
 }
@@ -160,6 +160,8 @@
   GAMRequest *request = [GAMRequest request];
   request.keywords = self.keywords;
   request.contentURL = self.contentURL;
+  request.neighboringContentURLStrings = self.neighboringContentURLs;
+  request.publisherProvidedID = self.pubProvidedID;
 
   NSMutableDictionary<NSString *, id> *targetingDictionary =
       [NSMutableDictionary dictionaryWithDictionary:self.customTargeting];

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
@@ -88,6 +88,22 @@
 }
 @end
 
+@implementation FLTLocationParams
+
+- (instancetype _Nonnull)initWithAccuracy:(NSNumber *_Nonnull)accuracy
+                                longitude: (NSNumber *_Nonnull)longitude
+                                 latitude: (NSNumber *_Nonnull)latitude {
+  self = [super init];
+  if (self) {
+    _accuracy = accuracy;
+    _longitude = longitude;
+    _latitude = latitude;
+  }
+  return self;
+}
+
+@end
+
 @implementation FLTAdRequest
 - (GADRequest *_Nonnull)asGADRequest {
   GADRequest *request = [GADRequest request];
@@ -100,6 +116,11 @@
   }
   request.neighboringContentURLStrings = _neighboringContentURLs;
   request.requestAgent = FLT_REQUEST_AGENT_VERSIONED;
+  if ([FLTAdUtil isNotNull:_location]) {
+    [request setLocationWithLatitude:_location.latitude.floatValue
+                           longitude:_location.longitude.floatValue
+                            accuracy:_location.accuracy.floatValue];
+  }
   return request;
 }
 @end
@@ -173,7 +194,11 @@
     extras.additionalParameters = @{@"npa" : @"1"};
     [request registerAdNetworkExtras:extras];
   }
-
+  if ([FLTAdUtil isNotNull:self.location]) {
+    [request setLocationWithLatitude:self.location.latitude.floatValue
+                           longitude:self.location.longitude.floatValue
+                            accuracy:self.location.accuracy.floatValue];
+  }
   request.requestAgent = FLT_REQUEST_AGENT_VERSIONED;
   return request;
 }

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
@@ -91,8 +91,8 @@
 @implementation FLTLocationParams
 
 - (instancetype _Nonnull)initWithAccuracy:(NSNumber *_Nonnull)accuracy
-                                longitude: (NSNumber *_Nonnull)longitude
-                                 latitude: (NSNumber *_Nonnull)latitude {
+                                longitude:(NSNumber *_Nonnull)longitude
+                                 latitude:(NSNumber *_Nonnull)latitude {
   self = [super init];
   if (self) {
     _accuracy = accuracy;

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
@@ -32,6 +32,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
   FLTAdmobFieldSmartBannerAdSize = 143,
   FLTAdmobFieldNativeAdOptions = 144,
   FLTAdmobFieldVideoOptions = 145,
+  FLTAdmobFieldLocation = 146,
 };
 
 @interface FLTGoogleMobileAdsWriter : FlutterStandardWriter
@@ -84,6 +85,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
       NSNumber *nonPersonalizedAds = [self readValueOfType:[self readByte]];
       request.nonPersonalizedAds = nonPersonalizedAds.boolValue;
       request.neighboringContentURLs = [self readValueOfType:[self readByte]];
+      request.location = [self readValueOfType:[self readByte]];
       return request;
     }
     case FLTAdMobFieldRewardItem: {
@@ -147,6 +149,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
       request.nonPersonalizedAds = nonPersonalizedAds.boolValue;
       request.neighboringContentURLs = [self readValueOfType:[self readByte]];
       request.pubProvidedID = [self readValueOfType:[self readByte]];
+      request.location = [self readValueOfType:[self readByte]];
       return request;
     }
     case FLTAdMobFieldAdapterInitializationState: {
@@ -204,6 +207,12 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
                  customControlsRequested:[self readValueOfType:[self readByte]]
                               startMuted:[self readValueOfType:[self readByte]]];
     }
+    case FLTAdmobFieldLocation: {
+      return [[FLTLocationParams alloc] initWithAccuracy:[self readValueOfType:[self readByte]]
+                                               longitude:[self readValueOfType:[self readByte]]
+                                                latitude:[self readValueOfType:[self readByte]]];
+    
+    }
   }
   return [super readValueOfType:type];
 }
@@ -241,6 +250,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     [self writeValue:@(request.nonPersonalizedAds)];
     [self writeValue:request.neighboringContentURLs];
     [self writeValue:request.pubProvidedID];
+    [self writeValue:request.location];
   } else if ([value isKindOfClass:[FLTAdRequest class]]) {
     [self writeByte:FLTAdMobFieldAdRequest];
     FLTAdRequest *request = value;
@@ -248,6 +258,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     [self writeValue:request.contentURL];
     [self writeValue:@(request.nonPersonalizedAds)];
     [self writeValue:request.neighboringContentURLs];
+    [self writeValue:request.location];
   } else if ([value isKindOfClass:[FLTRewardItem class]]) {
     [self writeByte:FLTAdMobFieldRewardItem];
     FLTRewardItem *item = value;
@@ -320,6 +331,12 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     [self writeValue:options.clickToExpandRequested];
     [self writeValue:options.customControlsRequested];
     [self writeValue:options.startMuted];
+  } else if ([value isKindOfClass:[FLTLocationParams class]]) {
+    [self writeByte:FLTAdmobFieldLocation];
+    FLTLocationParams *location = value;
+    [self writeValue:location.accuracy];
+    [self writeValue:location.longitude];
+    [self writeValue:location.latitude];
   } else {
     [super writeValue:value];
   }

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
@@ -211,7 +211,6 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
       return [[FLTLocationParams alloc] initWithAccuracy:[self readValueOfType:[self readByte]]
                                                longitude:[self readValueOfType:[self readByte]]
                                                 latitude:[self readValueOfType:[self readByte]]];
-    
     }
   }
   return [super readValueOfType:type];

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
@@ -83,7 +83,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
 
       NSNumber *nonPersonalizedAds = [self readValueOfType:[self readByte]];
       request.nonPersonalizedAds = nonPersonalizedAds.boolValue;
-
+      request.neighboringContentURLs = [self readValueOfType:[self readByte]];
       return request;
     }
     case FLTAdMobFieldRewardItem: {
@@ -145,6 +145,8 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
       request.customTargetingLists = [self readValueOfType:[self readByte]];
       NSNumber *nonPersonalizedAds = [self readValueOfType:[self readByte]];
       request.nonPersonalizedAds = nonPersonalizedAds.boolValue;
+      request.neighboringContentURLs = [self readValueOfType:[self readByte]];
+      request.pubProvidedID = [self readValueOfType:[self readByte]];
       return request;
     }
     case FLTAdMobFieldAdapterInitializationState: {
@@ -237,12 +239,15 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     [self writeValue:request.customTargeting];
     [self writeValue:request.customTargetingLists];
     [self writeValue:@(request.nonPersonalizedAds)];
+    [self writeValue:request.neighboringContentURLs];
+    [self writeValue:request.pubProvidedID];
   } else if ([value isKindOfClass:[FLTAdRequest class]]) {
     [self writeByte:FLTAdMobFieldAdRequest];
     FLTAdRequest *request = value;
     [self writeValue:request.keywords];
     [self writeValue:request.contentURL];
     [self writeValue:@(request.nonPersonalizedAds)];
+    [self writeValue:request.neighboringContentURLs];
   } else if ([value isKindOfClass:[FLTRewardItem class]]) {
     [self writeByte:FLTAdMobFieldRewardItem];
     FLTRewardItem *item = value;

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
@@ -84,6 +84,8 @@
   request.keywords = @[ @"apple" ];
   request.contentURL = @"banana";
   request.nonPersonalizedAds = YES;
+  NSArray<NSString *> *contentURLs = @[ @"url-1.com", @"url-2.com" ];
+  request.neighboringContentURLs = contentURLs;
 
   NSData *encodedMessage = [_messageCodec encode:request];
 
@@ -91,6 +93,7 @@
   XCTAssertTrue([decodedRequest.keywords isEqualToArray:@[ @"apple" ]]);
   XCTAssertEqualObjects(decodedRequest.contentURL, @"banana");
   XCTAssertTrue(decodedRequest.nonPersonalizedAds);
+  XCTAssertEqualObjects(decodedRequest.neighboringContentURLs, contentURLs);
 }
 
 - (void)testEncodeDecodeGAMAdRequest {
@@ -100,6 +103,9 @@
   request.customTargeting = @{@"table" : @"linen"};
   request.customTargetingLists = @{@"go" : @[ @"lakers" ]};
   request.nonPersonalizedAds = YES;
+  NSArray<NSString *> *contentURLs = @[ @"url-1.com", @"url-2.com" ];
+  request.neighboringContentURLs = contentURLs;
+  request.pubProvidedID = @"pub-id";
   NSData *encodedMessage = [_messageCodec encode:request];
 
   FLTGAMAdRequest *decodedRequest = [_messageCodec decode:encodedMessage];
@@ -109,6 +115,8 @@
   XCTAssertTrue(
       [decodedRequest.customTargetingLists isEqualToDictionary:@{@"go" : @[ @"lakers" ]}]);
   XCTAssertTrue(decodedRequest.nonPersonalizedAds);
+  XCTAssertEqualObjects(decodedRequest.neighboringContentURLs, contentURLs);
+  XCTAssertEqualObjects(decodedRequest.pubProvidedID, @"pub-id");
 }
 
 - (void)testEncodeDecodeRewardItem {

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
@@ -86,7 +86,10 @@
   request.nonPersonalizedAds = YES;
   NSArray<NSString *> *contentURLs = @[ @"url-1.com", @"url-2.com" ];
   request.neighboringContentURLs = contentURLs;
-
+  request.location =
+    [[FLTLocationParams alloc] initWithAccuracy:@1.5
+                                    longitude:@52
+                                     latitude:@123];
   NSData *encodedMessage = [_messageCodec encode:request];
 
   FLTAdRequest *decodedRequest = [_messageCodec decode:encodedMessage];
@@ -94,6 +97,9 @@
   XCTAssertEqualObjects(decodedRequest.contentURL, @"banana");
   XCTAssertTrue(decodedRequest.nonPersonalizedAds);
   XCTAssertEqualObjects(decodedRequest.neighboringContentURLs, contentURLs);
+  XCTAssertEqualObjects(decodedRequest.location.accuracy, @1.5);
+  XCTAssertEqualObjects(decodedRequest.location.longitude, @52);
+  XCTAssertEqualObjects(decodedRequest.location.latitude, @123);
 }
 
 - (void)testEncodeDecodeGAMAdRequest {
@@ -106,6 +112,10 @@
   NSArray<NSString *> *contentURLs = @[ @"url-1.com", @"url-2.com" ];
   request.neighboringContentURLs = contentURLs;
   request.pubProvidedID = @"pub-id";
+  request.location =
+    [[FLTLocationParams alloc] initWithAccuracy:@1.5
+                                    longitude:@52
+                                     latitude:@123];
   NSData *encodedMessage = [_messageCodec encode:request];
 
   FLTGAMAdRequest *decodedRequest = [_messageCodec decode:encodedMessage];
@@ -117,6 +127,9 @@
   XCTAssertTrue(decodedRequest.nonPersonalizedAds);
   XCTAssertEqualObjects(decodedRequest.neighboringContentURLs, contentURLs);
   XCTAssertEqualObjects(decodedRequest.pubProvidedID, @"pub-id");
+  XCTAssertEqualObjects(decodedRequest.location.accuracy, @1.5);
+  XCTAssertEqualObjects(decodedRequest.location.longitude, @52);
+  XCTAssertEqualObjects(decodedRequest.location.latitude, @123);
 }
 
 - (void)testEncodeDecodeRewardItem {

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
@@ -86,10 +86,7 @@
   request.nonPersonalizedAds = YES;
   NSArray<NSString *> *contentURLs = @[ @"url-1.com", @"url-2.com" ];
   request.neighboringContentURLs = contentURLs;
-  request.location =
-    [[FLTLocationParams alloc] initWithAccuracy:@1.5
-                                    longitude:@52
-                                     latitude:@123];
+  request.location = [[FLTLocationParams alloc] initWithAccuracy:@1.5 longitude:@52 latitude:@123];
   NSData *encodedMessage = [_messageCodec encode:request];
 
   FLTAdRequest *decodedRequest = [_messageCodec decode:encodedMessage];
@@ -112,10 +109,7 @@
   NSArray<NSString *> *contentURLs = @[ @"url-1.com", @"url-2.com" ];
   request.neighboringContentURLs = contentURLs;
   request.pubProvidedID = @"pub-id";
-  request.location =
-    [[FLTLocationParams alloc] initWithAccuracy:@1.5
-                                    longitude:@52
-                                     latitude:@123];
+  request.location = [[FLTLocationParams alloc] initWithAccuracy:@1.5 longitude:@52 latitude:@123];
   NSData *encodedMessage = [_messageCodec encode:request];
 
   FLTGAMAdRequest *decodedRequest = [_messageCodec decode:encodedMessage];

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -202,13 +202,12 @@ class AdManagerAdRequest extends AdRequest {
     int? httpTimeoutMillis,
     this.publisherProvidedId,
   }) : super(
-    keywords: keywords,
-    contentUrl: contentUrl,
-    neighboringContentUrls: neighboringContentUrls,
-    nonPersonalizedAds: nonPersonalizedAds,
-    httpTimeoutMillis: httpTimeoutMillis,
-  );
-
+          keywords: keywords,
+          contentUrl: contentUrl,
+          neighboringContentUrls: neighboringContentUrls,
+          nonPersonalizedAds: nonPersonalizedAds,
+          httpTimeoutMillis: httpTimeoutMillis,
+        );
 
   /// Key-value pairs used for custom targeting.
   final Map<String, String>? customTargeting;

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -174,6 +174,8 @@ class AdRequest {
   final bool? nonPersonalizedAds;
 
   /// A custom timeout for HTTPS calls during an ad request.
+  ///
+  /// This is only supported in Android. This value is ignored on iOS.
   final int? httpTimeoutMillis;
 
   // TODO - location
@@ -213,6 +215,8 @@ class AdManagerAdRequest extends AdRequest {
   final Map<String, String>? customTargeting;
 
   /// Key-value pairs used for custom targeting.
+  ///
+  /// Any duplicate keys from [customTargeting] will be overwritten.
   final Map<String, List<String>>? customTargetingLists;
 
   /// The identifier used for frequency capping, audience segmentation

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -142,6 +142,40 @@ class LoadAdError extends AdError {
   }
 }
 
+/// Location parameters that can be configured in an ad request.
+class LocationParams {
+  /// Location parameters that can be configured in an ad request.
+  const LocationParams({
+    required this.accuracy,
+    required this.longitude,
+    required this.latitude,
+    this.time,
+  });
+
+  /// The accuracy in meters.
+  final double accuracy;
+
+  /// The longitude in degrees.
+  final double longitude;
+
+  /// The latitude in degrees.
+  final double latitude;
+
+  /// The UTC time, in milliseconds since epoch (January 1, 1970).
+  ///
+  /// This is required on Android, and ignored on iOS.
+  final int? time;
+
+  @override
+  bool operator ==(Object other) {
+    return other is LocationParams &&
+        accuracy == other.accuracy &&
+        longitude == other.longitude &&
+        latitude == other.latitude &&
+        time == other.time;
+  }
+}
+
 /// Targeting info per the AdMob API.
 ///
 /// This class's properties mirror the native AdRequest API. See for example:
@@ -154,6 +188,7 @@ class AdRequest {
     this.neighboringContentUrls,
     this.nonPersonalizedAds,
     this.httpTimeoutMillis,
+    this.location,
   });
 
   /// Words or phrases describing the current user activity.
@@ -178,7 +213,10 @@ class AdRequest {
   /// This is only supported in Android. This value is ignored on iOS.
   final int? httpTimeoutMillis;
 
-  // TODO - location
+  /// Location data.
+  ///
+  /// Used for mediation targeting purposes.
+  final LocationParams? location;
 
   @override
   bool operator ==(Object other) {
@@ -187,7 +225,8 @@ class AdRequest {
         contentUrl == other.contentUrl &&
         nonPersonalizedAds == other.nonPersonalizedAds &&
         listEquals(neighboringContentUrls, other.neighboringContentUrls) &&
-        httpTimeoutMillis == other.httpTimeoutMillis;
+        httpTimeoutMillis == other.httpTimeoutMillis &&
+        location == other.location;
   }
 }
 
@@ -203,12 +242,14 @@ class AdManagerAdRequest extends AdRequest {
     bool? nonPersonalizedAds,
     int? httpTimeoutMillis,
     this.publisherProvidedId,
+    LocationParams? location,
   }) : super(
           keywords: keywords,
           contentUrl: contentUrl,
           neighboringContentUrls: neighboringContentUrls,
           nonPersonalizedAds: nonPersonalizedAds,
           httpTimeoutMillis: httpTimeoutMillis,
+          location: location,
         );
 
   /// Key-value pairs used for custom targeting.

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -151,7 +151,9 @@ class AdRequest {
   const AdRequest({
     this.keywords,
     this.contentUrl,
+    this.neighboringContentUrls,
     this.nonPersonalizedAds,
+    this.httpTimeoutMillis,
   });
 
   /// Words or phrases describing the current user activity.
@@ -161,6 +163,9 @@ class AdRequest {
   ///
   /// This webpage content is used for targeting and brand safety purposes.
   final String? contentUrl;
+
+  /// URLs representing web content near an ad.
+  final List<String>? neighboringContentUrls;
 
   /// Non-personalized ads are ads that are not based on a user’s past behavior.
   ///
@@ -168,33 +173,42 @@ class AdRequest {
   /// https://support.google.com/admob/answer/7676680?hl=en
   final bool? nonPersonalizedAds;
 
+  /// A custom timeout for HTTPS calls during an ad request.
+  final int? httpTimeoutMillis;
+
+  // TODO - location
+
   @override
   bool operator ==(Object other) {
     return other is AdRequest &&
         listEquals<String>(keywords, other.keywords) &&
         contentUrl == other.contentUrl &&
-        nonPersonalizedAds == other.nonPersonalizedAds;
+        nonPersonalizedAds == other.nonPersonalizedAds &&
+        listEquals(neighboringContentUrls, other.neighboringContentUrls) &&
+        httpTimeoutMillis == other.httpTimeoutMillis;
   }
 }
 
 /// Targeting info per the Ad Manager API.
-class AdManagerAdRequest {
+class AdManagerAdRequest extends AdRequest {
   /// Constructs an [AdManagerAdRequest] from optional targeting information.
   const AdManagerAdRequest({
-    this.keywords,
-    this.contentUrl,
+    List<String>? keywords,
+    String? contentUrl,
+    List<String>? neighboringContentUrls,
     this.customTargeting,
     this.customTargetingLists,
-    this.nonPersonalizedAds,
-  });
+    bool? nonPersonalizedAds,
+    int? httpTimeoutMillis,
+    this.publisherProvidedId,
+  }) : super(
+    keywords: keywords,
+    contentUrl: contentUrl,
+    neighboringContentUrls: neighboringContentUrls,
+    nonPersonalizedAds: nonPersonalizedAds,
+    httpTimeoutMillis: httpTimeoutMillis,
+  );
 
-  /// Words or phrases describing the current user activity.
-  final List<String>? keywords;
-
-  /// URL string for a webpage whose content matches the app’s primary content.
-  ///
-  /// This webpage content is used for targeting and brand safety purposes.
-  final String? contentUrl;
 
   /// Key-value pairs used for custom targeting.
   final Map<String, String>? customTargeting;
@@ -202,21 +216,19 @@ class AdManagerAdRequest {
   /// Key-value pairs used for custom targeting.
   final Map<String, List<String>>? customTargetingLists;
 
-  /// Non-personalized ads are ads that are not based on a user’s past behavior.
-  ///
-  /// For more information:
-  /// https://support.google.com/admanager/answer/9005435?hl=en
-  final bool? nonPersonalizedAds;
+  /// The identifier used for frequency capping, audience segmentation
+  /// and targeting, sequential ad rotation, and other audience-based ad
+  /// delivery controls across devices.
+  final String? publisherProvidedId;
 
   @override
   bool operator ==(Object other) {
-    return other is AdManagerAdRequest &&
-        listEquals<String>(keywords, other.keywords) &&
-        contentUrl == other.contentUrl &&
+    return super == other &&
+        other is AdManagerAdRequest &&
         mapEquals<String, String>(customTargeting, other.customTargeting) &&
         customTargetingLists.toString() ==
             other.customTargetingLists.toString() &&
-        nonPersonalizedAds == other.nonPersonalizedAds;
+        publisherProvidedId == other.publisherProvidedId;
   }
 }
 

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -747,7 +747,7 @@ class AdMessageCodec extends StandardMessageCodec {
           contentUrl: readValueOfType(buffer.getUint8(), buffer),
           nonPersonalizedAds: readValueOfType(buffer.getUint8(), buffer),
           neighboringContentUrls:
-            readValueOfType(buffer.getUint8(), buffer)?.cast<String>(),
+              readValueOfType(buffer.getUint8(), buffer)?.cast<String>(),
           httpTimeoutMillis: readValueOfType(buffer.getUint8(), buffer),
         );
       case _valueRewardItem:
@@ -792,7 +792,7 @@ class AdMessageCodec extends StandardMessageCodec {
           ),
           nonPersonalizedAds: readValueOfType(buffer.getUint8(), buffer),
           neighboringContentUrls:
-            readValueOfType(buffer.getUint8(), buffer)?.cast<String>(),
+              readValueOfType(buffer.getUint8(), buffer)?.cast<String>(),
           httpTimeoutMillis: readValueOfType(buffer.getUint8(), buffer),
           publisherProvidedId: readValueOfType(buffer.getUint8(), buffer),
         );

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -635,11 +635,23 @@ class AdMessageCodec extends StandardMessageCodec {
   void writeValue(WriteBuffer buffer, dynamic value) {
     if (value is AdSize) {
       writeAdSize(buffer, value);
+    } else if (value is AdManagerAdRequest) {
+      buffer.putUint8(_valueAdManagerAdRequest);
+      writeValue(buffer, value.keywords);
+      writeValue(buffer, value.contentUrl);
+      writeValue(buffer, value.customTargeting);
+      writeValue(buffer, value.customTargetingLists);
+      writeValue(buffer, value.nonPersonalizedAds);
+      writeValue(buffer, value.neighboringContentUrls);
+      writeValue(buffer, value.httpTimeoutMillis);
+      writeValue(buffer, value.publisherProvidedId);
     } else if (value is AdRequest) {
       buffer.putUint8(_valueAdRequest);
       writeValue(buffer, value.keywords);
       writeValue(buffer, value.contentUrl);
       writeValue(buffer, value.nonPersonalizedAds);
+      writeValue(buffer, value.neighboringContentUrls);
+      writeValue(buffer, value.httpTimeoutMillis);
     } else if (value is RewardItem) {
       buffer.putUint8(_valueRewardItem);
       writeValue(buffer, value.amount);
@@ -667,13 +679,6 @@ class AdMessageCodec extends StandardMessageCodec {
       writeValue(buffer, value.code);
       writeValue(buffer, value.domain);
       writeValue(buffer, value.message);
-    } else if (value is AdManagerAdRequest) {
-      buffer.putUint8(_valueAdManagerAdRequest);
-      writeValue(buffer, value.keywords);
-      writeValue(buffer, value.contentUrl);
-      writeValue(buffer, value.customTargeting);
-      writeValue(buffer, value.customTargetingLists);
-      writeValue(buffer, value.nonPersonalizedAds);
     } else if (value is AdapterInitializationState) {
       buffer.putUint8(_valueInitializationState);
       writeValue(buffer, describeEnum(value));
@@ -741,6 +746,9 @@ class AdMessageCodec extends StandardMessageCodec {
           keywords: readValueOfType(buffer.getUint8(), buffer)?.cast<String>(),
           contentUrl: readValueOfType(buffer.getUint8(), buffer),
           nonPersonalizedAds: readValueOfType(buffer.getUint8(), buffer),
+          neighboringContentUrls:
+            readValueOfType(buffer.getUint8(), buffer)?.cast<String>(),
+          httpTimeoutMillis: readValueOfType(buffer.getUint8(), buffer),
         );
       case _valueRewardItem:
         return RewardItem(
@@ -783,6 +791,10 @@ class AdMessageCodec extends StandardMessageCodec {
             readValueOfType(buffer.getUint8(), buffer),
           ),
           nonPersonalizedAds: readValueOfType(buffer.getUint8(), buffer),
+          neighboringContentUrls:
+            readValueOfType(buffer.getUint8(), buffer)?.cast<String>(),
+          httpTimeoutMillis: readValueOfType(buffer.getUint8(), buffer),
+          publisherProvidedId: readValueOfType(buffer.getUint8(), buffer),
         );
       case _valueInitializationState:
         switch (readValueOfType(buffer.getUint8(), buffer)) {

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -643,7 +643,9 @@ class AdMessageCodec extends StandardMessageCodec {
       writeValue(buffer, value.customTargetingLists);
       writeValue(buffer, value.nonPersonalizedAds);
       writeValue(buffer, value.neighboringContentUrls);
-      writeValue(buffer, value.httpTimeoutMillis);
+      if (defaultTargetPlatform == TargetPlatform.android) {
+        writeValue(buffer, value.httpTimeoutMillis);
+      }
       writeValue(buffer, value.publisherProvidedId);
     } else if (value is AdRequest) {
       buffer.putUint8(_valueAdRequest);
@@ -651,7 +653,9 @@ class AdMessageCodec extends StandardMessageCodec {
       writeValue(buffer, value.contentUrl);
       writeValue(buffer, value.nonPersonalizedAds);
       writeValue(buffer, value.neighboringContentUrls);
-      writeValue(buffer, value.httpTimeoutMillis);
+      if (defaultTargetPlatform == TargetPlatform.android) {
+        writeValue(buffer, value.httpTimeoutMillis);
+      }
     } else if (value is RewardItem) {
       buffer.putUint8(_valueRewardItem);
       writeValue(buffer, value.amount);
@@ -748,7 +752,9 @@ class AdMessageCodec extends StandardMessageCodec {
           nonPersonalizedAds: readValueOfType(buffer.getUint8(), buffer),
           neighboringContentUrls:
               readValueOfType(buffer.getUint8(), buffer)?.cast<String>(),
-          httpTimeoutMillis: readValueOfType(buffer.getUint8(), buffer),
+          httpTimeoutMillis: (defaultTargetPlatform == TargetPlatform.android)
+              ? readValueOfType(buffer.getUint8(), buffer)
+              : null,
         );
       case _valueRewardItem:
         return RewardItem(
@@ -793,7 +799,9 @@ class AdMessageCodec extends StandardMessageCodec {
           nonPersonalizedAds: readValueOfType(buffer.getUint8(), buffer),
           neighboringContentUrls:
               readValueOfType(buffer.getUint8(), buffer)?.cast<String>(),
-          httpTimeoutMillis: readValueOfType(buffer.getUint8(), buffer),
+          httpTimeoutMillis: (defaultTargetPlatform == TargetPlatform.android)
+              ? readValueOfType(buffer.getUint8(), buffer)
+              : null,
           publisherProvidedId: readValueOfType(buffer.getUint8(), buffer),
         );
       case _valueInitializationState:

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -630,6 +630,7 @@ class AdMessageCodec extends StandardMessageCodec {
   static const int _valueSmartBannerAdSize = 143;
   static const int _valueNativeAdOptions = 144;
   static const int _valueVideoOptions = 145;
+  static const int _valueLocationParams = 146;
 
   @override
   void writeValue(WriteBuffer buffer, dynamic value) {
@@ -647,6 +648,7 @@ class AdMessageCodec extends StandardMessageCodec {
         writeValue(buffer, value.httpTimeoutMillis);
       }
       writeValue(buffer, value.publisherProvidedId);
+      writeValue(buffer, value.location);
     } else if (value is AdRequest) {
       buffer.putUint8(_valueAdRequest);
       writeValue(buffer, value.keywords);
@@ -656,6 +658,7 @@ class AdMessageCodec extends StandardMessageCodec {
       if (defaultTargetPlatform == TargetPlatform.android) {
         writeValue(buffer, value.httpTimeoutMillis);
       }
+      writeValue(buffer, value.location);
     } else if (value is RewardItem) {
       buffer.putUint8(_valueRewardItem);
       writeValue(buffer, value.amount);
@@ -711,6 +714,14 @@ class AdMessageCodec extends StandardMessageCodec {
       writeValue(buffer, value.clickToExpandRequested);
       writeValue(buffer, value.customControlsRequested);
       writeValue(buffer, value.startMuted);
+    } else if (value is LocationParams) {
+      buffer.putUint8(_valueLocationParams);
+      writeValue(buffer, value.accuracy);
+      writeValue(buffer, value.longitude);
+      writeValue(buffer, value.latitude);
+      if (defaultTargetPlatform == TargetPlatform.android) {
+        writeValue(buffer, value.time);
+      }
     } else {
       super.writeValue(buffer, value);
     }
@@ -755,6 +766,7 @@ class AdMessageCodec extends StandardMessageCodec {
           httpTimeoutMillis: (defaultTargetPlatform == TargetPlatform.android)
               ? readValueOfType(buffer.getUint8(), buffer)
               : null,
+          location: readValueOfType(buffer.getUint8(), buffer),
         );
       case _valueRewardItem:
         return RewardItem(
@@ -803,6 +815,7 @@ class AdMessageCodec extends StandardMessageCodec {
               ? readValueOfType(buffer.getUint8(), buffer)
               : null,
           publisherProvidedId: readValueOfType(buffer.getUint8(), buffer),
+          location: readValueOfType(buffer.getUint8(), buffer),
         );
       case _valueInitializationState:
         switch (readValueOfType(buffer.getUint8(), buffer)) {
@@ -852,6 +865,15 @@ class AdMessageCodec extends StandardMessageCodec {
           clickToExpandRequested: readValueOfType(buffer.getUint8(), buffer),
           customControlsRequested: readValueOfType(buffer.getUint8(), buffer),
           startMuted: readValueOfType(buffer.getUint8(), buffer),
+        );
+      case _valueLocationParams:
+        return LocationParams(
+          accuracy: readValueOfType(buffer.getUint8(), buffer),
+          longitude: readValueOfType(buffer.getUint8(), buffer),
+          latitude: readValueOfType(buffer.getUint8(), buffer),
+          time: (defaultTargetPlatform == TargetPlatform.android)
+              ? readValueOfType(buffer.getUint8(), buffer)
+              : null,
         );
       default:
         return super.readValueOfType(type, buffer);

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -1310,7 +1310,9 @@ void main() {
       expect(codec.decodeMessage(byteData), AdSize.banner);
     });
 
-    test('encode/decode AdRequest', () async {
+    test('encode/decode AdRequest Android', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
       final AdRequest adRequest = AdRequest(
           keywords: <String>['1', '2', '3'],
           contentUrl: 'contentUrl',
@@ -1320,6 +1322,25 @@ void main() {
 
       final ByteData byteData = codec.encodeMessage(adRequest)!;
       expect(codec.decodeMessage(byteData), adRequest);
+    });
+
+    test('encode/decode AdRequest iOS', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      final AdRequest adRequest = AdRequest(
+          keywords: <String>['1', '2', '3'],
+          contentUrl: 'contentUrl',
+          nonPersonalizedAds: false,
+          neighboringContentUrls: <String>['url1.com', 'url2.com'],
+          httpTimeoutMillis: 12345);
+
+      final ByteData byteData = codec.encodeMessage(adRequest)!;
+      AdRequest decoded = codec.decodeMessage(byteData);
+      expect(decoded.httpTimeoutMillis, null);
+      expect(decoded.neighboringContentUrls, adRequest.neighboringContentUrls);
+      expect(decoded.contentUrl, adRequest.contentUrl);
+      expect(decoded.nonPersonalizedAds, adRequest.nonPersonalizedAds);
+      expect(decoded.keywords, adRequest.keywords);
     });
 
     test('encode/decode $LoadAdError', () async {
@@ -1379,7 +1400,8 @@ void main() {
       );
     });
 
-    test('encode/decode $AdManagerAdRequest', () async {
+    test('encode/decode AdManagerAdRequest Android', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
       final AdManagerAdRequest request = AdManagerAdRequest(
         keywords: <String>['who'],
         contentUrl: 'dat',
@@ -1398,6 +1420,34 @@ void main() {
         codec.decodeMessage(byteData),
         request,
       );
+    });
+
+    test('encode/decode AdManagerAdRequest iOS', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      final AdManagerAdRequest request = AdManagerAdRequest(
+        keywords: <String>['who'],
+        contentUrl: 'dat',
+        customTargeting: <String, String>{'boy': 'who'},
+        customTargetingLists: <String, List<String>>{
+          'him': <String>['is']
+        },
+        nonPersonalizedAds: true,
+        neighboringContentUrls: <String>['url1.com', 'url2.com'],
+        httpTimeoutMillis: 5000,
+        publisherProvidedId: 'test-pub-id',
+      );
+
+      final ByteData byteData = codec.encodeMessage(request)!;
+      AdManagerAdRequest decoded = codec.decodeMessage(byteData);
+      expect(decoded.httpTimeoutMillis, null);
+      expect(decoded.neighboringContentUrls, request.neighboringContentUrls);
+      expect(decoded.contentUrl, request.contentUrl);
+      expect(decoded.nonPersonalizedAds, request.nonPersonalizedAds);
+      expect(decoded.keywords, request.keywords);
+      expect(decoded.publisherProvidedId, request.publisherProvidedId);
+      expect(decoded.customTargeting, request.customTargeting);
+      expect(decoded.customTargetingLists, request.customTargetingLists);
     });
   });
 }

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -1314,7 +1314,9 @@ void main() {
       final AdRequest adRequest = AdRequest(
           keywords: <String>['1', '2', '3'],
           contentUrl: 'contentUrl',
-          nonPersonalizedAds: false);
+          nonPersonalizedAds: false,
+          neighboringContentUrls: <String>['url1.com', 'url2.com'],
+          httpTimeoutMillis: 12345);
 
       final ByteData byteData = codec.encodeMessage(adRequest)!;
       expect(codec.decodeMessage(byteData), adRequest);
@@ -1378,7 +1380,7 @@ void main() {
     });
 
     test('encode/decode $AdManagerAdRequest', () async {
-      final ByteData byteData = codec.encodeMessage(AdManagerAdRequest(
+      final AdManagerAdRequest request = AdManagerAdRequest(
         keywords: <String>['who'],
         contentUrl: 'dat',
         customTargeting: <String, String>{'boy': 'who'},
@@ -1386,19 +1388,15 @@ void main() {
           'him': <String>['is']
         },
         nonPersonalizedAds: true,
-      ))!;
+        neighboringContentUrls: <String>['url1.com', 'url2.com'],
+        httpTimeoutMillis: 5000,
+        publisherProvidedId: 'test-pub-id',
+      );
+      final ByteData byteData = codec.encodeMessage(request)!;
 
       expect(
         codec.decodeMessage(byteData),
-        AdManagerAdRequest(
-          keywords: <String>['who'],
-          contentUrl: 'dat',
-          customTargeting: <String, String>{'boy': 'who'},
-          customTargetingLists: <String, List<String>>{
-            'him': <String>['is'],
-          },
-          nonPersonalizedAds: true,
-        ),
+        request,
       );
     });
   });

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -1318,7 +1318,9 @@ void main() {
           contentUrl: 'contentUrl',
           nonPersonalizedAds: false,
           neighboringContentUrls: <String>['url1.com', 'url2.com'],
-          httpTimeoutMillis: 12345);
+          httpTimeoutMillis: 12345,
+          location: LocationParams(
+              accuracy: 1.1, longitude: 25, latitude: 38, time: 1));
 
       final ByteData byteData = codec.encodeMessage(adRequest)!;
       expect(codec.decodeMessage(byteData), adRequest);
@@ -1332,7 +1334,9 @@ void main() {
           contentUrl: 'contentUrl',
           nonPersonalizedAds: false,
           neighboringContentUrls: <String>['url1.com', 'url2.com'],
-          httpTimeoutMillis: 12345);
+          httpTimeoutMillis: 12345,
+          location: LocationParams(
+              accuracy: 1.1, longitude: 25, latitude: 38, time: 1));
 
       final ByteData byteData = codec.encodeMessage(adRequest)!;
       AdRequest decoded = codec.decodeMessage(byteData);
@@ -1341,6 +1345,9 @@ void main() {
       expect(decoded.contentUrl, adRequest.contentUrl);
       expect(decoded.nonPersonalizedAds, adRequest.nonPersonalizedAds);
       expect(decoded.keywords, adRequest.keywords);
+      expect(decoded.location!.accuracy, 1.1);
+      expect(decoded.location!.longitude, 25);
+      expect(decoded.location!.latitude, 38);
     });
 
     test('encode/decode $LoadAdError', () async {
@@ -1413,6 +1420,8 @@ void main() {
         neighboringContentUrls: <String>['url1.com', 'url2.com'],
         httpTimeoutMillis: 5000,
         publisherProvidedId: 'test-pub-id',
+        location:
+            LocationParams(accuracy: 1.1, longitude: 25, latitude: 38, time: 1),
       );
       final ByteData byteData = codec.encodeMessage(request)!;
 
@@ -1436,6 +1445,8 @@ void main() {
         neighboringContentUrls: <String>['url1.com', 'url2.com'],
         httpTimeoutMillis: 5000,
         publisherProvidedId: 'test-pub-id',
+        location:
+            LocationParams(accuracy: 1.1, longitude: 25, latitude: 38, time: 1),
       );
 
       final ByteData byteData = codec.encodeMessage(request)!;
@@ -1448,6 +1459,9 @@ void main() {
       expect(decoded.publisherProvidedId, request.publisherProvidedId);
       expect(decoded.customTargeting, request.customTargeting);
       expect(decoded.customTargetingLists, request.customTargetingLists);
+      expect(decoded.location!.accuracy, 1.1);
+      expect(decoded.location!.longitude, 25);
+      expect(decoded.location!.latitude, 38);
     });
   });
 }


### PR DESCRIPTION
## Description

Adds support for missing AdRequest.Builder APIs
- Set location
- publisher provided id
- neighboring content urls

Also adds robolectric as a dependency for android tests.

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
