### PR TITLE
Use application context to load ads - Android only

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.6
+
+* Partial fix for [#265](https://github.com/googleads/googleads-mobile-flutter/issues/265).
+
 ## 0.13.5
 
 * Adds support for app open. 

--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## 0.13.6
 
 * Partial fix for [#265](https://github.com/googleads/googleads-mobile-flutter/issues/265).
+  * The partial fix allows you to load ads from a cached flutter engine in the add to app scenario,
+    but it only works the first time the engine is attached to an activity.
+  * Support for reusing the engine in another activity after the first one is destroyed is blocked 
+    by this Flutter issue which affects all platform views: https://github.com/flutter/flutter/issues/88880.
 
 ## 0.13.5
 

--- a/packages/google_mobile_ads/android/build.gradle
+++ b/packages/google_mobile_ads/android/build.gradle
@@ -26,7 +26,6 @@ android {
 
     defaultConfig {
         minSdkVersion 19
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {
         disable 'InvalidPackage'
@@ -36,7 +35,13 @@ android {
       testImplementation 'junit:junit:4.12'
       testImplementation 'org.hamcrest:hamcrest:2.2'
       testImplementation 'org.mockito:mockito-inline:3.9.0'
+      testImplementation 'org.robolectric:robolectric:4.4'
     }
+  testOptions {
+    unitTests {
+      includeAndroidResources = true
+    }
+  }
 }
 
 afterEvaluate {

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdInstanceManager.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdInstanceManager.java
@@ -42,7 +42,7 @@ class AdInstanceManager {
 
   /**
    * Initializes the ad instance manager. We only need a method channel to start loading ads, but an
-   * activity must be present in order to attach any to the view hierarchy.
+   * activity must be present in order to attach any ads to the view hierarchy.
    */
   AdInstanceManager(@NonNull MethodChannel channel) {
     this.channel = channel;

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdInstanceManager.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdInstanceManager.java
@@ -15,13 +15,13 @@
 package io.flutter.plugins.googlemobileads;
 
 import android.app.Activity;
+import android.os.Handler;
+import android.os.Looper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.gms.ads.AdError;
 import com.google.android.gms.ads.ResponseInfo;
-import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodChannel;
-import io.flutter.plugin.common.StandardMethodCodec;
 import io.flutter.plugins.googlemobileads.FlutterAd.FlutterAdError;
 import io.flutter.plugins.googlemobileads.FlutterAd.FlutterResponseInfo;
 import java.util.HashMap;
@@ -35,21 +35,27 @@ import java.util.Map;
  * provide access until the ad is disposed.
  */
 class AdInstanceManager {
-  @NonNull Activity activity;
+  @Nullable private Activity activity;
 
   @NonNull private final Map<Integer, FlutterAd> ads;
   @NonNull private final MethodChannel channel;
 
-  AdInstanceManager(@NonNull Activity activity, @NonNull BinaryMessenger binaryMessenger) {
-    this.activity = activity;
+  /**
+   * Initializes the ad instance manager. We only need a method channel to start loading ads, but an
+   * activity must be present in order to attach any to the view hierarchy.
+   */
+  AdInstanceManager(@NonNull MethodChannel channel) {
+    this.channel = channel;
     this.ads = new HashMap<>();
-    final StandardMethodCodec methodCodec = new StandardMethodCodec(new AdMessageCodec(activity));
-    this.channel =
-        new MethodChannel(binaryMessenger, "plugins.flutter.io/google_mobile_ads", methodCodec);
   }
 
-  void setActivity(@NonNull Activity activity) {
+  void setActivity(@Nullable Activity activity) {
     this.activity = activity;
+  }
+
+  @Nullable
+  Activity getActivity() {
+    return activity;
   }
 
   @Nullable
@@ -210,12 +216,13 @@ class AdInstanceManager {
 
   /** Invoke the method channel using the UI thread. Otherwise the message gets silently dropped. */
   private void invokeOnAdEvent(final Map<Object, Object> arguments) {
-    activity.runOnUiThread(
-        new Runnable() {
-          @Override
-          public void run() {
-            channel.invokeMethod("onAdEvent", arguments);
-          }
-        });
+    new Handler(Looper.getMainLooper())
+        .post(
+            new Runnable() {
+              @Override
+              public void run() {
+                channel.invokeMethod("onAdEvent", arguments);
+              }
+            });
   }
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
@@ -50,7 +50,7 @@ class AdMessageCodec extends StandardMessageCodec {
   static final byte VALUE_NATIVE_AD_OPTIONS = (byte) 144;
   static final byte VALUE_VIDEO_OPTIONS = (byte) 145;
 
-  @NonNull final Context context;
+  @NonNull Context context;
   @NonNull final FlutterAdSize.AdSizeFactory adSizeFactory;
 
   AdMessageCodec(@NonNull Context context) {
@@ -62,6 +62,10 @@ class AdMessageCodec extends StandardMessageCodec {
   AdMessageCodec(@NonNull Context context, @NonNull FlutterAdSize.AdSizeFactory adSizeFactory) {
     this.context = context;
     this.adSizeFactory = adSizeFactory;
+  }
+
+  void setContext(@NonNull Context context) {
+    this.context = context;
   }
 
   @Override

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
@@ -17,5 +17,5 @@ package io.flutter.plugins.googlemobileads;
 /** Constants used in the plugin. */
 public class Constants {
   /** Version request agent. Should be bumped alongside plugin versions. */
-  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-0.13.5";
+  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-0.13.6";
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdLoader.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdLoader.java
@@ -36,11 +36,14 @@ import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback;
  */
 public class FlutterAdLoader {
 
-  public FlutterAdLoader() {}
+  @NonNull private final Context context;
+
+  public FlutterAdLoader(@NonNull Context context) {
+    this.context = context;
+  }
 
   /** Load an app open ad. */
   public void loadAppOpen(
-      @NonNull Context context,
       @NonNull String adUnitId,
       @NonNull AdRequest adRequest,
       int orientation,
@@ -50,7 +53,6 @@ public class FlutterAdLoader {
 
   /** Load an ad manager app open ad. */
   public void loadAdManagerAppOpen(
-      @NonNull Context context,
       @NonNull String adUnitId,
       @NonNull AdManagerAdRequest adRequest,
       int orientation,
@@ -60,7 +62,6 @@ public class FlutterAdLoader {
 
   /** Load an interstitial ad. */
   public void loadInterstitial(
-      @NonNull Context context,
       @NonNull String adUnitId,
       @NonNull AdRequest adRequest,
       @NonNull InterstitialAdLoadCallback loadCallback) {
@@ -69,7 +70,6 @@ public class FlutterAdLoader {
 
   /** Load an ad manager interstitial ad. */
   public void loadAdManagerInterstitial(
-      @NonNull Context context,
       @NonNull String adUnitId,
       @NonNull AdManagerAdRequest adRequest,
       @NonNull AdManagerInterstitialAdLoadCallback loadCallback) {
@@ -78,7 +78,6 @@ public class FlutterAdLoader {
 
   /** Load a rewarded ad. */
   public void loadRewarded(
-      @NonNull Context context,
       @NonNull String adUnitId,
       @NonNull AdRequest adRequest,
       @NonNull RewardedAdLoadCallback loadCallback) {
@@ -87,7 +86,6 @@ public class FlutterAdLoader {
 
   /** Load an ad manager rewarded ad. */
   public void loadAdManagerRewarded(
-      @NonNull Context context,
       @NonNull String adUnitId,
       @NonNull AdManagerAdRequest adRequest,
       @NonNull RewardedAdLoadCallback loadCallback) {
@@ -96,7 +94,6 @@ public class FlutterAdLoader {
 
   /** Load a native ad. */
   public void loadNativeAd(
-      @NonNull Context context,
       @NonNull String adUnitId,
       @NonNull OnNativeAdLoadedListener onNativeAdLoadedListener,
       @NonNull NativeAdOptions nativeAdOptions,
@@ -112,7 +109,6 @@ public class FlutterAdLoader {
 
   /** Load an ad manager native ad. */
   public void loadAdManagerNativeAd(
-      @NonNull Context context,
       @NonNull String adUnitId,
       @NonNull OnNativeAdLoadedListener onNativeAdLoadedListener,
       @NonNull NativeAdOptions nativeAdOptions,

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerInterstitialAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerInterstitialAd.java
@@ -58,7 +58,6 @@ class FlutterAdManagerInterstitialAd extends FlutterAd.FlutterOverlayAd {
   @Override
   void load() {
     flutterAdLoader.loadAdManagerInterstitial(
-        manager.activity,
         adUnitId,
         request.asAdManagerAdRequest(),
         new DelegatingAdManagerInterstitialAdCallbacks(this));
@@ -85,8 +84,12 @@ class FlutterAdManagerInterstitialAd extends FlutterAd.FlutterOverlayAd {
       Log.e(TAG, "The interstitial wasn't loaded yet.");
       return;
     }
+    if (manager.getActivity() == null) {
+      Log.e(TAG, "Tried to show interstitial before activity was bound to the plugin.");
+      return;
+    }
     ad.setFullScreenContentCallback(new FlutterFullScreenContentCallback(manager, adId));
-    ad.show(manager.activity);
+    ad.show(manager.getActivity());
   }
 
   @Override

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAppOpenAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAppOpenAd.java
@@ -60,14 +60,12 @@ class FlutterAppOpenAd extends FlutterAd.FlutterOverlayAd {
   void load() {
     if (request != null) {
       flutterAdLoader.loadAppOpen(
-          manager.activity,
           adUnitId,
           request.asAdRequest(),
           getOrientation(),
           new DelegatingAppOpenAdLoadCallback(this));
     } else if (adManagerAdRequest != null) {
       flutterAdLoader.loadAdManagerAppOpen(
-          manager.activity,
           adUnitId,
           adManagerAdRequest.asAdManagerAdRequest(),
           getOrientation(),
@@ -101,9 +99,12 @@ class FlutterAppOpenAd extends FlutterAd.FlutterOverlayAd {
       Log.w(TAG, "Tried to show app open ad before it was loaded");
       return;
     }
-
+    if (manager.getActivity() == null) {
+      Log.e(TAG, "Tried to show app open ad before activity was bound to the plugin.");
+      return;
+    }
     ad.setFullScreenContentCallback(new FlutterFullScreenContentCallback(manager, adId));
-    ad.show(manager.activity);
+    ad.show(manager.getActivity());
   }
 
   @Override

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterInterstitialAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterInterstitialAd.java
@@ -48,10 +48,7 @@ class FlutterInterstitialAd extends FlutterAd.FlutterOverlayAd {
   void load() {
     if (manager != null && adUnitId != null && request != null) {
       flutterAdLoader.loadInterstitial(
-          manager.activity,
-          adUnitId,
-          request.asAdRequest(),
-          new DelegatingInterstitialAdLoadCallback(this));
+          adUnitId, request.asAdRequest(), new DelegatingInterstitialAdLoadCallback(this));
     }
   }
 
@@ -76,8 +73,12 @@ class FlutterInterstitialAd extends FlutterAd.FlutterOverlayAd {
       Log.e(TAG, "Error showing interstitial - the interstitial ad wasn't loaded yet.");
       return;
     }
+    if (manager.getActivity() == null) {
+      Log.e(TAG, "Tried to show interstitial before activity was bound to the plugin.");
+      return;
+    }
     ad.setFullScreenContentCallback(new FlutterFullScreenContentCallback(manager, adId));
-    ad.show(manager.activity);
+    ad.show(manager.getActivity());
   }
 
   @Override

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterNativeAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterNativeAd.java
@@ -49,6 +49,7 @@ class FlutterNativeAd extends FlutterAd {
     @Nullable private Map<String, Object> customOptions;
     @Nullable private Integer id;
     @Nullable private FlutterNativeAdOptions nativeAdOptions;
+    @Nullable private FlutterAdLoader flutterAdLoader;
 
     public Builder setAdFactory(@NonNull NativeAdFactory adFactory) {
       this.adFactory = adFactory;
@@ -90,6 +91,11 @@ class FlutterNativeAd extends FlutterAd {
       return this;
     }
 
+    public Builder setFlutterAdLoader(@NonNull FlutterAdLoader flutterAdLoader) {
+      this.flutterAdLoader = flutterAdLoader;
+      return this;
+    }
+
     FlutterNativeAd build() {
       if (manager == null) {
         throw new IllegalStateException("AdInstanceManager cannot not be null.");
@@ -110,7 +116,7 @@ class FlutterNativeAd extends FlutterAd {
                 adUnitId,
                 adFactory,
                 adManagerRequest,
-                new FlutterAdLoader(),
+                flutterAdLoader,
                 customOptions,
                 nativeAdOptions);
       } else {
@@ -121,7 +127,7 @@ class FlutterNativeAd extends FlutterAd {
                 adUnitId,
                 adFactory,
                 request,
-                new FlutterAdLoader(),
+                flutterAdLoader,
                 customOptions,
                 nativeAdOptions);
       }
@@ -179,15 +185,10 @@ class FlutterNativeAd extends FlutterAd {
             : nativeAdOptions.asNativeAdOptions();
     if (request != null) {
       flutterAdLoader.loadNativeAd(
-          manager.activity, adUnitId, loadedListener, options, adListener, request.asAdRequest());
+          adUnitId, loadedListener, options, adListener, request.asAdRequest());
     } else if (adManagerRequest != null) {
       flutterAdLoader.loadAdManagerNativeAd(
-          manager.activity,
-          adUnitId,
-          loadedListener,
-          options,
-          adListener,
-          adManagerRequest.asAdManagerAdRequest());
+          adUnitId, loadedListener, options, adListener, adManagerRequest.asAdManagerAdRequest());
     } else {
       Log.e(TAG, "A null or invalid ad request was provided.");
     }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedAd.java
@@ -108,11 +108,10 @@ class FlutterRewardedAd extends FlutterAd.FlutterOverlayAd {
   void load() {
     final RewardedAdLoadCallback adLoadCallback = new DelegatingRewardedCallback(this);
     if (request != null) {
-      flutterAdLoader.loadRewarded(
-          manager.activity, adUnitId, request.asAdRequest(), adLoadCallback);
+      flutterAdLoader.loadRewarded(adUnitId, request.asAdRequest(), adLoadCallback);
     } else if (adManagerRequest != null) {
       flutterAdLoader.loadAdManagerRewarded(
-          manager.activity, adUnitId, adManagerRequest.asAdManagerAdRequest(), adLoadCallback);
+          adUnitId, adManagerRequest.asAdManagerAdRequest(), adLoadCallback);
     } else {
       Log.e(TAG, "A null or invalid ad request was provided.");
     }
@@ -138,10 +137,13 @@ class FlutterRewardedAd extends FlutterAd.FlutterOverlayAd {
       Log.e(TAG, "Error showing rewarded - the rewarded ad wasn't loaded yet.");
       return;
     }
-
+    if (manager.getActivity() == null) {
+      Log.e(TAG, "Tried to show rewarded ad before activity was bound to the plugin.");
+      return;
+    }
     rewardedAd.setFullScreenContentCallback(new FlutterFullScreenContentCallback(manager, adId));
     rewardedAd.setOnAdMetadataChangedListener(new DelegatingRewardedCallback(this));
-    rewardedAd.show(manager.activity, new DelegatingRewardedCallback(this));
+    rewardedAd.show(manager.getActivity(), new DelegatingRewardedCallback(this));
   }
 
   @Override

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerBannerAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerBannerAdTest.java
@@ -34,17 +34,20 @@ import com.google.android.gms.ads.ResponseInfo;
 import com.google.android.gms.ads.admanager.AdManagerAdRequest;
 import com.google.android.gms.ads.admanager.AdManagerAdView;
 import com.google.android.gms.ads.admanager.AppEventListener;
-import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.platform.PlatformView;
 import io.flutter.plugins.googlemobileads.FlutterAd.FlutterLoadAdError;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.robolectric.RobolectricTestRunner;
 
 /** Tests for {@link FlutterAdManagerBannerAd}. */
+@RunWith(RobolectricTestRunner.class)
 public class FlutterAdManagerBannerAdTest {
 
   private AdInstanceManager mockManager;
@@ -58,8 +61,8 @@ public class FlutterAdManagerBannerAdTest {
   @Before
   public void setup() {
     // Setup mock dependencies for flutterBannerAd.
-    BinaryMessenger mockMessenger = mock(BinaryMessenger.class);
-    mockManager = spy(new AdInstanceManager(mock(Activity.class), mockMessenger));
+    mockManager = spy(new AdInstanceManager(mock(MethodChannel.class)));
+    doReturn(mock(Activity.class)).when(mockManager).getActivity();
     FlutterAdManagerAdRequest mockFlutterAdRequest = mock(FlutterAdManagerAdRequest.class);
     mockAdRequest = mock(AdManagerAdRequest.class);
     FlutterAdSize mockFlutterAdSize = mock(FlutterAdSize.class);

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerInterstitialAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerInterstitialAdTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
-import android.content.Context;
 import com.google.android.gms.ads.AdError;
 import com.google.android.gms.ads.AdValue;
 import com.google.android.gms.ads.FullScreenContentCallback;
@@ -38,15 +37,18 @@ import com.google.android.gms.ads.admanager.AdManagerAdRequest;
 import com.google.android.gms.ads.admanager.AdManagerInterstitialAd;
 import com.google.android.gms.ads.admanager.AdManagerInterstitialAdLoadCallback;
 import com.google.android.gms.ads.admanager.AppEventListener;
-import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugins.googlemobileads.FlutterAd.FlutterLoadAdError;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.robolectric.RobolectricTestRunner;
 
 /** Tests for {@link FlutterAdManagerInterstitialAd}. */
+@RunWith(RobolectricTestRunner.class)
 public class FlutterAdManagerInterstitialAdTest {
 
   private AdInstanceManager mockManager;
@@ -57,7 +59,8 @@ public class FlutterAdManagerInterstitialAdTest {
 
   @Before
   public void setup() {
-    mockManager = spy(new AdInstanceManager(mock(Activity.class), mock(BinaryMessenger.class)));
+    mockManager = spy(new AdInstanceManager(mock(MethodChannel.class)));
+    doReturn(mock(Activity.class)).when(mockManager).getActivity();
     final FlutterAdManagerAdRequest mockFlutterRequest = mock(FlutterAdManagerAdRequest.class);
     mockRequest = mock(AdManagerAdRequest.class);
     mockFlutterAdLoader = mock(FlutterAdLoader.class);
@@ -78,7 +81,7 @@ public class FlutterAdManagerInterstitialAdTest {
             new Answer() {
               @Override
               public Object answer(InvocationOnMock invocation) throws Throwable {
-                AdManagerInterstitialAdLoadCallback adLoadCallback = invocation.getArgument(3);
+                AdManagerInterstitialAdLoadCallback adLoadCallback = invocation.getArgument(2);
                 // Pass back null for ad
                 adLoadCallback.onAdFailedToLoad(loadAdError);
                 return null;
@@ -86,7 +89,6 @@ public class FlutterAdManagerInterstitialAdTest {
             })
         .when(mockFlutterAdLoader)
         .loadAdManagerInterstitial(
-            any(Activity.class),
             anyString(),
             any(AdManagerAdRequest.class),
             any(AdManagerInterstitialAdLoadCallback.class));
@@ -95,10 +97,7 @@ public class FlutterAdManagerInterstitialAdTest {
 
     verify(mockFlutterAdLoader)
         .loadAdManagerInterstitial(
-            eq(mockManager.activity),
-            eq("testId"),
-            eq(mockRequest),
-            any(AdManagerInterstitialAdLoadCallback.class));
+            eq("testId"), eq(mockRequest), any(AdManagerInterstitialAdLoadCallback.class));
 
     FlutterLoadAdError flutterLoadAdError = new FlutterLoadAdError(loadAdError);
     verify(mockManager).onAdFailedToLoad(eq(1), eq(flutterLoadAdError));
@@ -111,7 +110,7 @@ public class FlutterAdManagerInterstitialAdTest {
             new Answer() {
               @Override
               public Object answer(InvocationOnMock invocation) throws Throwable {
-                AdManagerInterstitialAdLoadCallback adLoadCallback = invocation.getArgument(3);
+                AdManagerInterstitialAdLoadCallback adLoadCallback = invocation.getArgument(2);
                 // Pass back null for ad
                 adLoadCallback.onAdLoaded(mockAdManagerAd);
                 return null;
@@ -119,7 +118,6 @@ public class FlutterAdManagerInterstitialAdTest {
             })
         .when(mockFlutterAdLoader)
         .loadAdManagerInterstitial(
-            any(Context.class),
             anyString(),
             any(AdManagerAdRequest.class),
             any(AdManagerInterstitialAdLoadCallback.class));
@@ -147,10 +145,7 @@ public class FlutterAdManagerInterstitialAdTest {
 
     verify(mockFlutterAdLoader)
         .loadAdManagerInterstitial(
-            eq(mockManager.activity),
-            eq("testId"),
-            eq(mockRequest),
-            any(AdManagerInterstitialAdLoadCallback.class));
+            eq("testId"), eq(mockRequest), any(AdManagerInterstitialAdLoadCallback.class));
 
     verify(mockManager).onAdLoaded(1, responseInfo);
     verify(mockAdManagerAd).setOnPaidEventListener(any(FlutterPaidEventListener.class));
@@ -177,7 +172,7 @@ public class FlutterAdManagerInterstitialAdTest {
 
     flutterAdManagerInterstitialAd.show();
     verify(mockAdManagerAd).setFullScreenContentCallback(any(FullScreenContentCallback.class));
-    verify(mockAdManagerAd).show(mockManager.activity);
+    verify(mockAdManagerAd).show(mockManager.getActivity());
     verify(mockAdManagerAd).setAppEventListener(any(AppEventListener.class));
     verify(mockManager).onAdShowedFullScreenContent(eq(1));
     verify(mockManager).onAdImpression(eq(1));
@@ -192,7 +187,7 @@ public class FlutterAdManagerInterstitialAdTest {
             new Answer() {
               @Override
               public Object answer(InvocationOnMock invocation) throws Throwable {
-                AdManagerInterstitialAdLoadCallback adLoadCallback = invocation.getArgument(3);
+                AdManagerInterstitialAdLoadCallback adLoadCallback = invocation.getArgument(2);
                 adLoadCallback.onAdLoaded(mockAdManagerAd);
                 // Pass back null for ad
                 return null;
@@ -200,7 +195,6 @@ public class FlutterAdManagerInterstitialAdTest {
             })
         .when(mockFlutterAdLoader)
         .loadAdManagerInterstitial(
-            any(Context.class),
             anyString(),
             any(AdManagerAdRequest.class),
             any(AdManagerInterstitialAdLoadCallback.class));
@@ -217,7 +211,7 @@ public class FlutterAdManagerInterstitialAdTest {
             new Answer() {
               @Override
               public Object answer(InvocationOnMock invocation) throws Throwable {
-                AdManagerInterstitialAdLoadCallback adLoadCallback = invocation.getArgument(3);
+                AdManagerInterstitialAdLoadCallback adLoadCallback = invocation.getArgument(2);
                 // Pass back null for ad
                 adLoadCallback.onAdLoaded(mockAdManagerAd);
                 return null;
@@ -225,7 +219,6 @@ public class FlutterAdManagerInterstitialAdTest {
             })
         .when(mockFlutterAdLoader)
         .loadAdManagerInterstitial(
-            any(Context.class),
             anyString(),
             any(AdManagerAdRequest.class),
             any(AdManagerInterstitialAdLoadCallback.class));
@@ -255,7 +248,7 @@ public class FlutterAdManagerInterstitialAdTest {
             new Answer() {
               @Override
               public Object answer(InvocationOnMock invocation) throws Throwable {
-                AdManagerInterstitialAdLoadCallback adLoadCallback = invocation.getArgument(3);
+                AdManagerInterstitialAdLoadCallback adLoadCallback = invocation.getArgument(2);
                 // Pass back null for ad
                 adLoadCallback.onAdLoaded(mockAdManagerAd);
                 return null;
@@ -263,7 +256,6 @@ public class FlutterAdManagerInterstitialAdTest {
             })
         .when(mockFlutterAdLoader)
         .loadAdManagerInterstitial(
-            any(Context.class),
             anyString(),
             any(AdManagerAdRequest.class),
             any(AdManagerInterstitialAdLoadCallback.class));

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAppOpenAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAppOpenAdTest.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
-import android.content.Context;
 import com.google.android.gms.ads.AdError;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.AdValue;
@@ -39,15 +38,18 @@ import com.google.android.gms.ads.ResponseInfo;
 import com.google.android.gms.ads.admanager.AdManagerAdRequest;
 import com.google.android.gms.ads.appopen.AppOpenAd;
 import com.google.android.gms.ads.appopen.AppOpenAd.AppOpenAdLoadCallback;
-import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugins.googlemobileads.FlutterAd.FlutterLoadAdError;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.robolectric.RobolectricTestRunner;
 
 /** Tests for {@link FlutterAppOpenAd}. */
+@RunWith(RobolectricTestRunner.class)
 public class FlutterAppOpenAdTest {
 
   private FlutterAdLoader mockFlutterAdLoader;
@@ -61,7 +63,8 @@ public class FlutterAppOpenAdTest {
 
   @Before
   public void setup() {
-    mockManager = spy(new AdInstanceManager(mock(Activity.class), mock(BinaryMessenger.class)));
+    mockManager = spy(new AdInstanceManager(mock(MethodChannel.class)));
+    doReturn(mock(Activity.class)).when(mockManager).getActivity();
     mockFlutterAdLoader = mock(FlutterAdLoader.class);
     mockAd = mock(AppOpenAd.class);
   }
@@ -96,7 +99,7 @@ public class FlutterAppOpenAdTest {
             new Answer() {
               @Override
               public Object answer(InvocationOnMock invocation) throws Throwable {
-                AppOpenAdLoadCallback adLoadCallback = invocation.getArgument(4);
+                AppOpenAdLoadCallback adLoadCallback = invocation.getArgument(3);
                 // Pass back null for ad
                 adLoadCallback.onAdFailedToLoad(loadAdError);
                 return null;
@@ -104,21 +107,13 @@ public class FlutterAppOpenAdTest {
             })
         .when(mockFlutterAdLoader)
         .loadAdManagerAppOpen(
-            any(Context.class),
-            anyString(),
-            any(AdManagerAdRequest.class),
-            anyInt(),
-            any(AppOpenAdLoadCallback.class));
+            anyString(), any(AdManagerAdRequest.class), anyInt(), any(AppOpenAdLoadCallback.class));
 
     flutterAppOpenAd.load();
 
     verify(mockFlutterAdLoader)
         .loadAdManagerAppOpen(
-            eq(mockManager.activity),
-            eq("testId"),
-            eq(mockAdManagerAdRequest),
-            eq(2),
-            any(AppOpenAdLoadCallback.class));
+            eq("testId"), eq(mockAdManagerAdRequest), eq(2), any(AppOpenAdLoadCallback.class));
 
     FlutterLoadAdError expectedError = new FlutterLoadAdError(loadAdError);
     verify(mockManager).onAdFailedToLoad(eq(1), eq(expectedError));
@@ -136,29 +131,19 @@ public class FlutterAppOpenAdTest {
             new Answer() {
               @Override
               public Object answer(InvocationOnMock invocation) throws Throwable {
-                AppOpenAdLoadCallback adLoadCallback = invocation.getArgument(4);
+                AppOpenAdLoadCallback adLoadCallback = invocation.getArgument(3);
                 // Pass back null for ad
                 adLoadCallback.onAdFailedToLoad(loadAdError);
                 return null;
               }
             })
         .when(mockFlutterAdLoader)
-        .loadAppOpen(
-            any(Context.class),
-            anyString(),
-            any(AdRequest.class),
-            anyInt(),
-            any(AppOpenAdLoadCallback.class));
+        .loadAppOpen(anyString(), any(AdRequest.class), anyInt(), any(AppOpenAdLoadCallback.class));
 
     flutterAppOpenAd.load();
 
     verify(mockFlutterAdLoader)
-        .loadAppOpen(
-            eq(mockManager.activity),
-            eq("testId"),
-            eq(mockAdRequest),
-            eq(2),
-            any(AppOpenAdLoadCallback.class));
+        .loadAppOpen(eq("testId"), eq(mockAdRequest), eq(2), any(AppOpenAdLoadCallback.class));
 
     FlutterLoadAdError expectedError = new FlutterLoadAdError(loadAdError);
     verify(mockManager).onAdFailedToLoad(eq(1), eq(expectedError));
@@ -174,7 +159,7 @@ public class FlutterAppOpenAdTest {
             new Answer() {
               @Override
               public Object answer(InvocationOnMock invocation) throws Throwable {
-                AppOpenAdLoadCallback adLoadCallback = invocation.getArgument(4);
+                AppOpenAdLoadCallback adLoadCallback = invocation.getArgument(3);
                 // Pass back null for ad
                 adLoadCallback.onAdLoaded(mockAd);
                 return null;
@@ -182,11 +167,7 @@ public class FlutterAppOpenAdTest {
             })
         .when(mockFlutterAdLoader)
         .loadAdManagerAppOpen(
-            any(Context.class),
-            anyString(),
-            any(AdManagerAdRequest.class),
-            anyInt(),
-            any(AppOpenAdLoadCallback.class));
+            anyString(), any(AdManagerAdRequest.class), anyInt(), any(AppOpenAdLoadCallback.class));
     final ResponseInfo responseInfo = mock(ResponseInfo.class);
     doReturn(responseInfo).when(mockAd).getResponseInfo();
 
@@ -211,11 +192,7 @@ public class FlutterAppOpenAdTest {
 
     verify(mockFlutterAdLoader)
         .loadAdManagerAppOpen(
-            eq(mockManager.activity),
-            eq("testId"),
-            eq(mockAdManagerAdRequest),
-            eq(2),
-            any(AppOpenAdLoadCallback.class));
+            eq("testId"), eq(mockAdManagerAdRequest), eq(2), any(AppOpenAdLoadCallback.class));
 
     verify(mockManager).onAdLoaded(eq(1), eq(responseInfo));
     verify(mockAd).setOnPaidEventListener(any(FlutterPaidEventListener.class));
@@ -236,19 +213,14 @@ public class FlutterAppOpenAdTest {
             new Answer() {
               @Override
               public Object answer(InvocationOnMock invocation) throws Throwable {
-                AppOpenAdLoadCallback adLoadCallback = invocation.getArgument(4);
+                AppOpenAdLoadCallback adLoadCallback = invocation.getArgument(3);
                 // Pass back null for ad
                 adLoadCallback.onAdLoaded(mockAd);
                 return null;
               }
             })
         .when(mockFlutterAdLoader)
-        .loadAppOpen(
-            any(Context.class),
-            anyString(),
-            any(AdRequest.class),
-            anyInt(),
-            any(AppOpenAdLoadCallback.class));
+        .loadAppOpen(anyString(), any(AdRequest.class), anyInt(), any(AppOpenAdLoadCallback.class));
     final ResponseInfo responseInfo = mock(ResponseInfo.class);
     doReturn(responseInfo).when(mockAd).getResponseInfo();
 
@@ -272,12 +244,7 @@ public class FlutterAppOpenAdTest {
     flutterAppOpenAd.load();
 
     verify(mockFlutterAdLoader)
-        .loadAppOpen(
-            eq(mockManager.activity),
-            eq("testId"),
-            eq(mockAdRequest),
-            eq(2),
-            any(AppOpenAdLoadCallback.class));
+        .loadAppOpen(eq("testId"), eq(mockAdRequest), eq(2), any(AppOpenAdLoadCallback.class));
 
     verify(mockManager).onAdLoaded(eq(1), eq(responseInfo));
     verify(mockAd).setOnPaidEventListener(any(FlutterPaidEventListener.class));
@@ -295,7 +262,7 @@ public class FlutterAppOpenAdTest {
             new Answer() {
               @Override
               public Object answer(InvocationOnMock invocation) throws Throwable {
-                AppOpenAdLoadCallback adLoadCallback = invocation.getArgument(4);
+                AppOpenAdLoadCallback adLoadCallback = invocation.getArgument(3);
                 // Pass back null for ad
                 adLoadCallback.onAdLoaded(mockAd);
                 return null;
@@ -303,11 +270,7 @@ public class FlutterAppOpenAdTest {
             })
         .when(mockFlutterAdLoader)
         .loadAdManagerAppOpen(
-            any(Context.class),
-            anyString(),
-            any(AdManagerAdRequest.class),
-            anyInt(),
-            any(AppOpenAdLoadCallback.class));
+            anyString(), any(AdManagerAdRequest.class), anyInt(), any(AppOpenAdLoadCallback.class));
     final ResponseInfo responseInfo = mock(ResponseInfo.class);
     doReturn(responseInfo).when(mockAd).getResponseInfo();
 
@@ -324,19 +287,14 @@ public class FlutterAppOpenAdTest {
             new Answer() {
               @Override
               public Object answer(InvocationOnMock invocation) throws Throwable {
-                AppOpenAdLoadCallback adLoadCallback = invocation.getArgument(4);
+                AppOpenAdLoadCallback adLoadCallback = invocation.getArgument(3);
                 // Pass back null for ad
                 adLoadCallback.onAdLoaded(mockAd);
                 return null;
               }
             })
         .when(mockFlutterAdLoader)
-        .loadAppOpen(
-            any(Context.class),
-            anyString(),
-            any(AdRequest.class),
-            anyInt(),
-            any(AppOpenAdLoadCallback.class));
+        .loadAppOpen(anyString(), any(AdRequest.class), anyInt(), any(AppOpenAdLoadCallback.class));
     final ResponseInfo responseInfo = mock(ResponseInfo.class);
     doReturn(responseInfo).when(mockAd).getResponseInfo();
 
@@ -378,7 +336,7 @@ public class FlutterAppOpenAdTest {
     // Show the ad and verify callbacks are set up properly.
     flutterAppOpenAd.show();
     verify(mockAd).setFullScreenContentCallback(any(FullScreenContentCallback.class));
-    verify(mockAd).show(eq(mockManager.activity));
+    verify(mockAd).show(eq(mockManager.getActivity()));
 
     verify(mockManager).onAdShowedFullScreenContent(eq(1));
     verify(mockManager).onAdImpression(eq(1));
@@ -421,7 +379,7 @@ public class FlutterAppOpenAdTest {
     // Show the ad and verify callbacks are set up properly.
     flutterAppOpenAd.show();
     verify(mockAd).setFullScreenContentCallback(any(FullScreenContentCallback.class));
-    verify(mockAd).show(eq(mockManager.activity));
+    verify(mockAd).show(eq(mockManager.getActivity()));
 
     verify(mockManager).onAdShowedFullScreenContent(eq(1));
     verify(mockManager).onAdImpression(eq(1));
@@ -484,19 +442,14 @@ public class FlutterAppOpenAdTest {
             new Answer() {
               @Override
               public Object answer(InvocationOnMock invocation) throws Throwable {
-                AppOpenAdLoadCallback adLoadCallback = invocation.getArgument(4);
+                AppOpenAdLoadCallback adLoadCallback = invocation.getArgument(3);
                 adLoadCallback.onAdLoaded(mockAd);
                 // Pass back null for ad
                 return null;
               }
             })
         .when(mockFlutterAdLoader)
-        .loadAppOpen(
-            any(Context.class),
-            anyString(),
-            any(AdRequest.class),
-            anyInt(),
-            any(AppOpenAdLoadCallback.class));
+        .loadAppOpen(anyString(), any(AdRequest.class), anyInt(), any(AppOpenAdLoadCallback.class));
     flutterAppOpenAd.load();
     flutterAppOpenAd.setImmersiveMode(false);
     verify(mockAd).setImmersiveMode(eq(false));

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterBannerAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterBannerAdTest.java
@@ -35,16 +35,19 @@ import com.google.android.gms.ads.AdValue;
 import com.google.android.gms.ads.AdView;
 import com.google.android.gms.ads.LoadAdError;
 import com.google.android.gms.ads.ResponseInfo;
-import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.platform.PlatformView;
 import io.flutter.plugins.googlemobileads.FlutterAd.FlutterLoadAdError;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.robolectric.RobolectricTestRunner;
 
 /** Tests for {@link FlutterBannerAd}. */
+@RunWith(RobolectricTestRunner.class)
 public class FlutterBannerAdTest {
 
   private AdInstanceManager mockManager;
@@ -57,7 +60,8 @@ public class FlutterBannerAdTest {
 
   @Before
   public void setup() {
-    mockManager = spy(new AdInstanceManager(mock(Activity.class), mock(BinaryMessenger.class)));
+    mockManager = spy(new AdInstanceManager(mock(MethodChannel.class)));
+    doReturn(mock(Activity.class)).when(mockManager).getActivity();
     final FlutterAdRequest mockFlutterRequest = mock(FlutterAdRequest.class);
     mockAdRequest = mock(AdRequest.class);
     final FlutterAdSize mockFlutterAdSize = mock(FlutterAdSize.class);

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterInterstitialAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterInterstitialAdTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
-import android.content.Context;
 import com.google.android.gms.ads.AdError;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.AdValue;
@@ -37,15 +36,18 @@ import com.google.android.gms.ads.LoadAdError;
 import com.google.android.gms.ads.ResponseInfo;
 import com.google.android.gms.ads.interstitial.InterstitialAd;
 import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback;
-import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugins.googlemobileads.FlutterAd.FlutterLoadAdError;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.robolectric.RobolectricTestRunner;
 
 /** Tests for {@link FlutterInterstitialAd}. */
+@RunWith(RobolectricTestRunner.class)
 public class FlutterInterstitialAdTest {
 
   private AdInstanceManager mockManager;
@@ -57,7 +59,8 @@ public class FlutterInterstitialAdTest {
 
   @Before
   public void setup() {
-    mockManager = spy(new AdInstanceManager(mock(Activity.class), mock(BinaryMessenger.class)));
+    mockManager = spy(new AdInstanceManager(mock(MethodChannel.class)));
+    doReturn(mock(Activity.class)).when(mockManager).getActivity();
     final FlutterAdRequest mockFlutterRequest = mock(FlutterAdRequest.class);
     mockAdRequest = mock(AdRequest.class);
     mockFlutterAdLoader = mock(FlutterAdLoader.class);
@@ -82,27 +85,19 @@ public class FlutterInterstitialAdTest {
             new Answer() {
               @Override
               public Object answer(InvocationOnMock invocation) throws Throwable {
-                InterstitialAdLoadCallback adLoadCallback = invocation.getArgument(3);
+                InterstitialAdLoadCallback adLoadCallback = invocation.getArgument(2);
                 // Pass back null for ad
                 adLoadCallback.onAdFailedToLoad(loadAdError);
                 return null;
               }
             })
         .when(mockFlutterAdLoader)
-        .loadInterstitial(
-            any(Activity.class),
-            anyString(),
-            any(AdRequest.class),
-            any(InterstitialAdLoadCallback.class));
+        .loadInterstitial(anyString(), any(AdRequest.class), any(InterstitialAdLoadCallback.class));
 
     flutterInterstitialAd.load();
 
     verify(mockFlutterAdLoader)
-        .loadInterstitial(
-            eq(mockManager.activity),
-            eq("testId"),
-            eq(mockAdRequest),
-            any(InterstitialAdLoadCallback.class));
+        .loadInterstitial(eq("testId"), eq(mockAdRequest), any(InterstitialAdLoadCallback.class));
 
     FlutterLoadAdError expectedError = new FlutterLoadAdError(loadAdError);
     verify(mockManager).onAdFailedToLoad(eq(1), eq(expectedError));
@@ -115,18 +110,14 @@ public class FlutterInterstitialAdTest {
             new Answer() {
               @Override
               public Object answer(InvocationOnMock invocation) throws Throwable {
-                InterstitialAdLoadCallback adLoadCallback = invocation.getArgument(3);
+                InterstitialAdLoadCallback adLoadCallback = invocation.getArgument(2);
                 // Pass back null for ad
                 adLoadCallback.onAdLoaded(mockAd);
                 return null;
               }
             })
         .when(mockFlutterAdLoader)
-        .loadInterstitial(
-            any(Context.class),
-            anyString(),
-            any(AdRequest.class),
-            any(InterstitialAdLoadCallback.class));
+        .loadInterstitial(anyString(), any(AdRequest.class), any(InterstitialAdLoadCallback.class));
     final ResponseInfo responseInfo = mock(ResponseInfo.class);
     doReturn(responseInfo).when(mockAd).getResponseInfo();
     final AdValue adValue = mock(AdValue.class);
@@ -148,11 +139,7 @@ public class FlutterInterstitialAdTest {
     flutterInterstitialAd.load();
 
     verify(mockFlutterAdLoader)
-        .loadInterstitial(
-            eq(mockManager.activity),
-            eq("testId"),
-            eq(mockAdRequest),
-            any(InterstitialAdLoadCallback.class));
+        .loadInterstitial(eq("testId"), eq(mockAdRequest), any(InterstitialAdLoadCallback.class));
 
     verify(mockManager).onAdLoaded(eq(1), eq(responseInfo));
     verify(mockAd).setOnPaidEventListener(any(FlutterPaidEventListener.class));
@@ -180,7 +167,7 @@ public class FlutterInterstitialAdTest {
 
     flutterInterstitialAd.show();
     verify(mockAd).setFullScreenContentCallback(any(FullScreenContentCallback.class));
-    verify(mockAd).show(eq(mockManager.activity));
+    verify(mockAd).show(eq(mockManager.getActivity()));
     verify(mockManager).onAdShowedFullScreenContent(eq(1));
     verify(mockManager).onAdDismissedFullScreenContent(eq(1));
     verify(mockManager).onAdImpression(eq(1));
@@ -194,18 +181,14 @@ public class FlutterInterstitialAdTest {
             new Answer() {
               @Override
               public Object answer(InvocationOnMock invocation) throws Throwable {
-                InterstitialAdLoadCallback adLoadCallback = invocation.getArgument(3);
+                InterstitialAdLoadCallback adLoadCallback = invocation.getArgument(2);
                 // Pass back null for ad
                 adLoadCallback.onAdLoaded(mockAd);
                 return null;
               }
             })
         .when(mockFlutterAdLoader)
-        .loadInterstitial(
-            any(Context.class),
-            anyString(),
-            any(AdRequest.class),
-            any(InterstitialAdLoadCallback.class));
+        .loadInterstitial(anyString(), any(AdRequest.class), any(InterstitialAdLoadCallback.class));
     doReturn(mock(ResponseInfo.class)).when(mockAd).getResponseInfo();
     flutterInterstitialAd.load();
     final AdError adError = new AdError(1, "2", "3");
@@ -233,18 +216,14 @@ public class FlutterInterstitialAdTest {
             new Answer() {
               @Override
               public Object answer(InvocationOnMock invocation) throws Throwable {
-                InterstitialAdLoadCallback adLoadCallback = invocation.getArgument(3);
+                InterstitialAdLoadCallback adLoadCallback = invocation.getArgument(2);
                 adLoadCallback.onAdLoaded(mockAd);
                 // Pass back null for ad
                 return null;
               }
             })
         .when(mockFlutterAdLoader)
-        .loadInterstitial(
-            any(Context.class),
-            anyString(),
-            any(AdRequest.class),
-            any(InterstitialAdLoadCallback.class));
+        .loadInterstitial(anyString(), any(AdRequest.class), any(InterstitialAdLoadCallback.class));
     flutterInterstitialAd.load();
     flutterInterstitialAd.setImmersiveMode(false);
     verify(mockAd).setImmersiveMode(eq(false));

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterNativeAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterNativeAdTest.java
@@ -38,18 +38,21 @@ import com.google.android.gms.ads.nativead.NativeAd;
 import com.google.android.gms.ads.nativead.NativeAd.OnNativeAdLoadedListener;
 import com.google.android.gms.ads.nativead.NativeAdOptions;
 import com.google.android.gms.ads.nativead.NativeAdView;
-import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.platform.PlatformView;
 import io.flutter.plugins.googlemobileads.FlutterAd.FlutterLoadAdError;
 import io.flutter.plugins.googlemobileads.GoogleMobileAdsPlugin.NativeAdFactory;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.robolectric.RobolectricTestRunner;
 
 /** Tests for {@link FlutterNativeAd}. */
+@RunWith(RobolectricTestRunner.class)
 public class FlutterNativeAdTest {
 
   private AdInstanceManager testManager;
@@ -57,7 +60,8 @@ public class FlutterNativeAdTest {
 
   @Before
   public void setup() {
-    testManager = spy(new AdInstanceManager(mock(Activity.class), mock(BinaryMessenger.class)));
+    testManager = spy(new AdInstanceManager(mock(MethodChannel.class)));
+    doReturn(mock(Activity.class)).when(testManager).getActivity();
   }
 
   @Test
@@ -95,10 +99,10 @@ public class FlutterNativeAdTest {
             new Answer() {
               @Override
               public Object answer(InvocationOnMock invocation) {
-                OnNativeAdLoadedListener adLoadCallback = invocation.getArgument(2);
+                OnNativeAdLoadedListener adLoadCallback = invocation.getArgument(1);
                 adLoadCallback.onNativeAdLoaded(mockNativeAd);
 
-                AdListener listener = invocation.getArgument(4);
+                AdListener listener = invocation.getArgument(3);
                 listener.onAdOpened();
                 listener.onAdClosed();
                 listener.onAdClicked();
@@ -110,7 +114,6 @@ public class FlutterNativeAdTest {
             })
         .when(mockLoader)
         .loadAdManagerNativeAd(
-            eq(testManager.activity),
             eq("testId"),
             any(OnNativeAdLoadedListener.class),
             any(NativeAdOptions.class),
@@ -136,7 +139,6 @@ public class FlutterNativeAdTest {
     nativeAd.load();
     verify(mockLoader)
         .loadAdManagerNativeAd(
-            eq(testManager.activity),
             eq("testId"),
             any(OnNativeAdLoadedListener.class),
             eq(mockNativeAdOptions),
@@ -200,10 +202,10 @@ public class FlutterNativeAdTest {
             new Answer() {
               @Override
               public Object answer(InvocationOnMock invocation) throws Throwable {
-                OnNativeAdLoadedListener adLoadCallback = invocation.getArgument(2);
+                OnNativeAdLoadedListener adLoadCallback = invocation.getArgument(1);
                 adLoadCallback.onNativeAdLoaded(mockNativeAd);
 
-                AdListener listener = invocation.getArgument(4);
+                AdListener listener = invocation.getArgument(3);
                 listener.onAdOpened();
                 listener.onAdClosed();
                 listener.onAdClicked();
@@ -215,7 +217,6 @@ public class FlutterNativeAdTest {
             })
         .when(mockLoader)
         .loadNativeAd(
-            eq(testManager.activity),
             eq("testId"),
             any(OnNativeAdLoadedListener.class),
             any(NativeAdOptions.class),
@@ -225,7 +226,6 @@ public class FlutterNativeAdTest {
     nativeAd.load();
     verify(mockLoader)
         .loadNativeAd(
-            eq(testManager.activity),
             eq("testId"),
             any(OnNativeAdLoadedListener.class),
             eq(mockNativeAdOptions),

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterRewardedAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterRewardedAdTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
-import android.content.Context;
 import androidx.annotation.Nullable;
 import com.google.android.gms.ads.AdError;
 import com.google.android.gms.ads.AdRequest;
@@ -43,18 +42,21 @@ import com.google.android.gms.ads.rewarded.RewardItem;
 import com.google.android.gms.ads.rewarded.RewardedAd;
 import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback;
 import com.google.android.gms.ads.rewarded.ServerSideVerificationOptions;
-import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugins.googlemobileads.FlutterAd.FlutterLoadAdError;
 import io.flutter.plugins.googlemobileads.FlutterRewardedAd.FlutterRewardItem;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 import org.mockito.ArgumentMatchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.robolectric.RobolectricTestRunner;
 
 /** Tests for {@link FlutterRewardedAd}. */
+@RunWith(RobolectricTestRunner.class)
 public class FlutterRewardedAdTest {
 
   private FlutterAdLoader mockFlutterAdLoader;
@@ -67,7 +69,8 @@ public class FlutterRewardedAdTest {
 
   @Before
   public void setup() {
-    mockManager = spy(new AdInstanceManager(mock(Activity.class), mock(BinaryMessenger.class)));
+    mockManager = spy(new AdInstanceManager(mock(MethodChannel.class)));
+    doReturn(mock(Activity.class)).when(mockManager).getActivity();
     mockFlutterAdLoader = mock(FlutterAdLoader.class);
   }
 
@@ -101,7 +104,7 @@ public class FlutterRewardedAdTest {
             new Answer() {
               @Override
               public Object answer(InvocationOnMock invocation) throws Throwable {
-                RewardedAdLoadCallback adLoadCallback = invocation.getArgument(3);
+                RewardedAdLoadCallback adLoadCallback = invocation.getArgument(2);
                 // Pass back null for ad
                 adLoadCallback.onAdFailedToLoad(loadAdError);
                 return null;
@@ -109,19 +112,13 @@ public class FlutterRewardedAdTest {
             })
         .when(mockFlutterAdLoader)
         .loadAdManagerRewarded(
-            any(Context.class),
-            anyString(),
-            any(AdManagerAdRequest.class),
-            any(RewardedAdLoadCallback.class));
+            anyString(), any(AdManagerAdRequest.class), any(RewardedAdLoadCallback.class));
 
     flutterRewardedAd.load();
 
     verify(mockFlutterAdLoader)
         .loadAdManagerRewarded(
-            eq(mockManager.activity),
-            eq("testId"),
-            eq(mockAdManagerAdRequest),
-            any(RewardedAdLoadCallback.class));
+            eq("testId"), eq(mockAdManagerAdRequest), any(RewardedAdLoadCallback.class));
 
     FlutterLoadAdError expectedError = new FlutterLoadAdError(loadAdError);
     verify(mockManager).onAdFailedToLoad(eq(1), eq(expectedError));
@@ -138,7 +135,7 @@ public class FlutterRewardedAdTest {
             new Answer() {
               @Override
               public Object answer(InvocationOnMock invocation) throws Throwable {
-                RewardedAdLoadCallback adLoadCallback = invocation.getArgument(3);
+                RewardedAdLoadCallback adLoadCallback = invocation.getArgument(2);
                 // Pass back null for ad
                 adLoadCallback.onAdLoaded(mockAd);
                 return null;
@@ -146,10 +143,7 @@ public class FlutterRewardedAdTest {
             })
         .when(mockFlutterAdLoader)
         .loadAdManagerRewarded(
-            any(Context.class),
-            anyString(),
-            any(AdManagerAdRequest.class),
-            any(RewardedAdLoadCallback.class));
+            anyString(), any(AdManagerAdRequest.class), any(RewardedAdLoadCallback.class));
     final ResponseInfo responseInfo = mock(ResponseInfo.class);
     doReturn(responseInfo).when(mockAd).getResponseInfo();
 
@@ -173,10 +167,7 @@ public class FlutterRewardedAdTest {
 
     verify(mockFlutterAdLoader)
         .loadAdManagerRewarded(
-            eq(mockManager.activity),
-            eq("testId"),
-            eq(mockAdManagerAdRequest),
-            any(RewardedAdLoadCallback.class));
+            eq("testId"), eq(mockAdManagerAdRequest), any(RewardedAdLoadCallback.class));
 
     verify(mockManager).onAdLoaded(eq(1), eq(responseInfo));
     verify(mockAd).setOnPaidEventListener(any(FlutterPaidEventListener.class));
@@ -230,7 +221,7 @@ public class FlutterRewardedAdTest {
 
     flutterRewardedAd.show();
     verify(mockAd).setFullScreenContentCallback(any(FullScreenContentCallback.class));
-    verify(mockAd).show(eq(mockManager.activity), any(OnUserEarnedRewardListener.class));
+    verify(mockAd).show(eq(mockManager.getActivity()), any(OnUserEarnedRewardListener.class));
     verify(mockAd).setOnAdMetadataChangedListener(any(OnAdMetadataChangedListener.class));
     ArgumentMatcher<ServerSideVerificationOptions> serverSideVerificationOptionsArgumentMatcher =
         new ArgumentMatcher<ServerSideVerificationOptions>() {
@@ -265,7 +256,7 @@ public class FlutterRewardedAdTest {
             new Answer() {
               @Override
               public Object answer(InvocationOnMock invocation) throws Throwable {
-                RewardedAdLoadCallback adLoadCallback = invocation.getArgument(3);
+                RewardedAdLoadCallback adLoadCallback = invocation.getArgument(2);
                 // Pass back null for ad
                 adLoadCallback.onAdLoaded(mockAd);
                 return null;
@@ -273,10 +264,7 @@ public class FlutterRewardedAdTest {
             })
         .when(mockFlutterAdLoader)
         .loadAdManagerRewarded(
-            any(Context.class),
-            anyString(),
-            any(AdManagerAdRequest.class),
-            any(RewardedAdLoadCallback.class));
+            anyString(), any(AdManagerAdRequest.class), any(RewardedAdLoadCallback.class));
     final ResponseInfo responseInfo = mock(ResponseInfo.class);
     doReturn(responseInfo).when(mockAd).getResponseInfo();
 
@@ -284,10 +272,7 @@ public class FlutterRewardedAdTest {
 
     verify(mockFlutterAdLoader)
         .loadAdManagerRewarded(
-            eq(mockManager.activity),
-            eq("testId"),
-            eq(mockAdManagerAdRequest),
-            any(RewardedAdLoadCallback.class));
+            eq("testId"), eq(mockAdManagerAdRequest), any(RewardedAdLoadCallback.class));
 
     verify(mockManager).onAdLoaded(eq(1), eq(responseInfo));
 
@@ -305,7 +290,7 @@ public class FlutterRewardedAdTest {
 
     mockFlutterAd.show();
     verify(mockAd).setFullScreenContentCallback(any(FullScreenContentCallback.class));
-    verify(mockAd).show(eq(mockManager.activity), any(OnUserEarnedRewardListener.class));
+    verify(mockAd).show(eq(mockManager.getActivity()), any(OnUserEarnedRewardListener.class));
     verify(mockAd).setOnAdMetadataChangedListener(any(OnAdMetadataChangedListener.class));
     ArgumentMatcher<ServerSideVerificationOptions> serverSideVerificationOptionsArgumentMatcher =
         new ArgumentMatcher<ServerSideVerificationOptions>() {
@@ -328,28 +313,20 @@ public class FlutterRewardedAdTest {
             new Answer() {
               @Override
               public Object answer(InvocationOnMock invocation) throws Throwable {
-                RewardedAdLoadCallback adLoadCallback = invocation.getArgument(3);
+                RewardedAdLoadCallback adLoadCallback = invocation.getArgument(2);
                 // Pass back null for ad
                 adLoadCallback.onAdLoaded(mockRewardedAd);
                 return null;
               }
             })
         .when(mockFlutterAdLoader)
-        .loadRewarded(
-            any(Activity.class),
-            anyString(),
-            any(AdRequest.class),
-            any(RewardedAdLoadCallback.class));
+        .loadRewarded(anyString(), any(AdRequest.class), any(RewardedAdLoadCallback.class));
     final ResponseInfo responseInfo = mock(ResponseInfo.class);
     doReturn(responseInfo).when(mockRewardedAd).getResponseInfo();
     flutterRewardedAd.load();
 
     verify(mockFlutterAdLoader)
-        .loadRewarded(
-            eq(mockManager.activity),
-            eq("testId"),
-            eq(mockAdRequest),
-            any(RewardedAdLoadCallback.class));
+        .loadRewarded(eq("testId"), eq(mockAdRequest), any(RewardedAdLoadCallback.class));
 
     verify(mockManager).onAdLoaded(eq(1), eq(responseInfo));
     final AdError adError = new AdError(0, "ad", "error");
@@ -379,18 +356,14 @@ public class FlutterRewardedAdTest {
             new Answer() {
               @Override
               public Object answer(InvocationOnMock invocation) throws Throwable {
-                RewardedAdLoadCallback adLoadCallback = invocation.getArgument(3);
+                RewardedAdLoadCallback adLoadCallback = invocation.getArgument(2);
                 adLoadCallback.onAdLoaded(mockRewardedAd);
                 // Pass back null for ad
                 return null;
               }
             })
         .when(mockFlutterAdLoader)
-        .loadRewarded(
-            any(Activity.class),
-            anyString(),
-            any(AdRequest.class),
-            any(RewardedAdLoadCallback.class));
+        .loadRewarded(anyString(), any(AdRequest.class), any(RewardedAdLoadCallback.class));
 
     flutterRewardedAd.load();
     flutterRewardedAd.setImmersiveMode(true);

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
@@ -37,8 +37,10 @@ import com.google.android.gms.ads.initialization.InitializationStatus;
 import com.google.android.gms.ads.initialization.OnInitializationCompleteListener;
 import com.google.android.gms.ads.nativead.NativeAd;
 import com.google.android.gms.ads.nativead.NativeAdView;
+import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.StandardMethodCodec;
 import io.flutter.plugins.googlemobileads.FlutterAd.FlutterAdapterResponseInfo;
@@ -53,19 +55,26 @@ import java.util.Map;
 import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
 
 /** Tests {@link AdInstanceManager}. */
+@RunWith(RobolectricTestRunner.class)
 public class GoogleMobileAdsTest {
   private AdInstanceManager testManager;
   private final FlutterAdRequest request = new FlutterAdRequest.Builder().build();
   private Activity mockActivity;
+  private Context mockContext;
+  private FlutterPluginBinding mockFlutterPluginBinding;
   private static BinaryMessenger mockMessenger;
 
   private static MethodCall getLastMethodCall() {
+    Robolectric.flushForegroundThreadScheduler();
     final ArgumentCaptor<ByteBuffer> byteBufferCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
     verify(mockMessenger)
         .send(
@@ -92,7 +101,16 @@ public class GoogleMobileAdsTest {
             })
         .when(mockActivity)
         .runOnUiThread(ArgumentMatchers.any(Runnable.class));
-    testManager = new AdInstanceManager(mockActivity, mockMessenger);
+    MethodChannel methodChannel =
+        new MethodChannel(
+            mockMessenger,
+            "plugins.flutter.io/google_mobile_ads",
+            new StandardMethodCodec(new AdMessageCodec(mockActivity)));
+    testManager = new AdInstanceManager(methodChannel);
+    testManager.setActivity(mockActivity);
+    mockContext = mock(Context.class);
+    mockFlutterPluginBinding = mock(FlutterPluginBinding.class);
+    doReturn(mockContext).when(mockFlutterPluginBinding).getApplicationContext();
   }
 
   @Test
@@ -104,7 +122,7 @@ public class GoogleMobileAdsTest {
             "testId",
             request,
             new FlutterAdSize(1, 2),
-            new BannerAdCreator(testManager.activity));
+            mock(BannerAdCreator.class));
     testManager.trackAd(bannerAd, 0);
 
     assertNotNull(testManager.adForId(0));
@@ -241,7 +259,7 @@ public class GoogleMobileAdsTest {
             "testId",
             request,
             new FlutterAdSize(1, 2),
-            new BannerAdCreator(testManager.activity));
+            mock(BannerAdCreator.class));
     testManager.trackAd(bannerAd, 0);
 
     AdError adError = mock(AdError.class);
@@ -296,7 +314,7 @@ public class GoogleMobileAdsTest {
             "testId",
             request,
             new FlutterAdSize(1, 2),
-            new BannerAdCreator(testManager.activity));
+            mock(BannerAdCreator.class));
     testManager.trackAd(bannerAd, 0);
 
     testManager.onAdLoaded(0, null);
@@ -319,7 +337,7 @@ public class GoogleMobileAdsTest {
             "testId",
             request,
             new FlutterAdSize(1, 2),
-            new BannerAdCreator(testManager.activity));
+            mock(BannerAdCreator.class));
     testManager.trackAd(bannerAd, 0);
 
     testManager.onAdFailedToLoad(0, new FlutterAd.FlutterLoadAdError(1, "hi", "friend", null));
@@ -346,7 +364,7 @@ public class GoogleMobileAdsTest {
             "testId",
             request,
             new FlutterAdSize(1, 2),
-            new BannerAdCreator(testManager.activity));
+            mock(BannerAdCreator.class));
     testManager.trackAd(bannerAd, 0);
 
     testManager.onAppEvent(0, "color", "red");
@@ -372,7 +390,7 @@ public class GoogleMobileAdsTest {
             "testId",
             request,
             new FlutterAdSize(1, 2),
-            new BannerAdCreator(testManager.activity));
+            mock(BannerAdCreator.class));
     testManager.trackAd(bannerAd, 0);
 
     testManager.onAdOpened(0);
@@ -452,7 +470,7 @@ public class GoogleMobileAdsTest {
             "testId",
             request,
             new FlutterAdSize(1, 2),
-            new BannerAdCreator(testManager.activity));
+            mock(BannerAdCreator.class));
     testManager.trackAd(bannerAd, 0);
 
     testManager.onAdClosed(0);
@@ -504,7 +522,8 @@ public class GoogleMobileAdsTest {
     // Check that ads are removed and disposed when "_init" is called.
     AdInstanceManager testManagerSpy = spy(testManager);
     GoogleMobileAdsPlugin plugin =
-        new GoogleMobileAdsPlugin(null, testManagerSpy, new FlutterMobileAdsWrapper());
+        new GoogleMobileAdsPlugin(
+            mockFlutterPluginBinding, testManagerSpy, new FlutterMobileAdsWrapper());
     Result result = mock(Result.class);
     MethodCall methodCall = new MethodCall("_init", null);
     plugin.onMethodCall(methodCall, result);
@@ -523,7 +542,8 @@ public class GoogleMobileAdsTest {
   public void initializeCallbackInvokedTwice() {
     AdInstanceManager testManagerSpy = spy(testManager);
     FlutterMobileAdsWrapper mockMobileAds = mock(FlutterMobileAdsWrapper.class);
-    GoogleMobileAdsPlugin plugin = new GoogleMobileAdsPlugin(null, testManagerSpy, mockMobileAds);
+    GoogleMobileAdsPlugin plugin =
+        new GoogleMobileAdsPlugin(mockFlutterPluginBinding, testManagerSpy, mockMobileAds);
     final InitializationStatus mockInitStatus = mock(InitializationStatus.class);
     doAnswer(
             new Answer() {
@@ -576,7 +596,8 @@ public class GoogleMobileAdsTest {
   public void testSetAppMuted() {
     AdInstanceManager testManagerSpy = spy(testManager);
     FlutterMobileAdsWrapper mockMobileAds = mock(FlutterMobileAdsWrapper.class);
-    GoogleMobileAdsPlugin plugin = new GoogleMobileAdsPlugin(null, testManagerSpy, mockMobileAds);
+    GoogleMobileAdsPlugin plugin =
+        new GoogleMobileAdsPlugin(mockFlutterPluginBinding, testManagerSpy, mockMobileAds);
 
     // Create a map for passing arguments to the MethodCall
     HashMap<String, Boolean> trueArguments = new HashMap<>();
@@ -607,7 +628,8 @@ public class GoogleMobileAdsTest {
   public void testSetAppVolume() {
     AdInstanceManager testManagerSpy = spy(testManager);
     FlutterMobileAdsWrapper mockMobileAds = mock(FlutterMobileAdsWrapper.class);
-    GoogleMobileAdsPlugin plugin = new GoogleMobileAdsPlugin(null, testManagerSpy, mockMobileAds);
+    GoogleMobileAdsPlugin plugin =
+        new GoogleMobileAdsPlugin(mockFlutterPluginBinding, testManagerSpy, mockMobileAds);
 
     // Create a map for passing arguments to the MethodCall.
     HashMap<String, Float> fullVolumeArguments = new HashMap<>();
@@ -626,13 +648,14 @@ public class GoogleMobileAdsTest {
   public void testDisableMediationInitialization() {
     AdInstanceManager testManagerSpy = spy(testManager);
     FlutterMobileAdsWrapper mockMobileAds = mock(FlutterMobileAdsWrapper.class);
-    GoogleMobileAdsPlugin plugin = new GoogleMobileAdsPlugin(null, testManagerSpy, mockMobileAds);
-
+    GoogleMobileAdsPlugin plugin =
+        new GoogleMobileAdsPlugin(mockFlutterPluginBinding, testManagerSpy, mockMobileAds);
     // Invoke the disableMediationInitialization method.
     MethodCall methodCall = new MethodCall("MobileAds#disableMediationInitialization", null);
     Result result = mock(Result.class);
     plugin.onMethodCall(methodCall, result);
 
+    Robolectric.flushForegroundThreadScheduler();
     // Verify that mockMobileAds.disableMediationInitialization() was called.
     verify(mockMobileAds).disableMediationInitialization(ArgumentMatchers.any(Context.class));
   }
@@ -641,8 +664,8 @@ public class GoogleMobileAdsTest {
   public void testGetVersionString() {
     AdInstanceManager testManagerSpy = spy(testManager);
     FlutterMobileAdsWrapper mockMobileAds = mock(FlutterMobileAdsWrapper.class);
-    GoogleMobileAdsPlugin plugin = new GoogleMobileAdsPlugin(null, testManagerSpy, mockMobileAds);
-
+    GoogleMobileAdsPlugin plugin =
+        new GoogleMobileAdsPlugin(mockFlutterPluginBinding, testManagerSpy, mockMobileAds);
     // Stub getVersionString() to return a value.
     doReturn("Test-SDK-Version").when(mockMobileAds).getVersionString();
 

--- a/packages/google_mobile_ads/ios/Classes/FLTConstants.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTConstants.h
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /** Versioned request agent string. */
-#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-0.13.5"
+#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-0.13.6"

--- a/packages/google_mobile_ads/pubspec.yaml
+++ b/packages/google_mobile_ads/pubspec.yaml
@@ -16,7 +16,7 @@ name: google_mobile_ads
 description: Flutter plugin for Google Mobile Ads, supporting
   banner, interstitial (full-screen),  rewarded and native ads
 homepage: https://github.com/googleads/googleads-mobile-flutter/tree/master/packages/google_mobile_ads
-version: 0.13.5
+version: 0.13.6
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description
This is a partial fix for https://github.com/googleads/googleads-mobile-flutter/issues/265. This allows you to load ads from a cached flutter engine in the add to app scenario. Note this does not allow for reusing the cached flutter engine after dismissing its flutter activity, since redisplaying platform views is currently not supported.

- Moves most of `GoogleMobileAdsPlugin` initialization from `onAttachedToActivity` to `onAttachedToEngine`.
- The application context is used to load ads, which allows ads to be loaded from a cached flutter engine that has not been attached to an activity.
- The activity is still required to show ads.
- Adds roboletric to unit tests.

## Related Issues

https://github.com/googleads/googleads-mobile-flutter/issues/265

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/googleads/googleads-mobile-flutter/issues). Indicate, which of these issues are resolved or fixed by this PR.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
