### PR TITLE
Add support for current orientation AdSize in AnchoredAdaptiveBannerAdSize

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -11,7 +11,7 @@
     You can reference the [example app](https://github.com/googleads/googleads-mobile-flutter/blob/master/packages/google_mobile_ads/example/lib/fluid_example.dart) for an example of how to load and display a fluid ad.
   * Android - https://developers.google.com/ad-manager/mobile-ads-sdk/android/native/styles#fluid_size
   * iOS - https://developers.google.com/ad-manager/mobile-ads-sdk/ios/native/native-styles#fluid_size
-
+* Adds support for current orientation in AnchoredAdaptiveBannerAdSize - https://developers.google.com/android/reference/com/google/android/gms/ads/AdSize#public-static-adsize-getcurrentorientationanchoredadaptivebanneradsize-context-context,-int-width
 ## 0.13.5
 
 * Adds support for app open. 

--- a/packages/google_mobile_ads/android/build.gradle
+++ b/packages/google_mobile_ads/android/build.gradle
@@ -36,6 +36,7 @@ android {
       testImplementation 'org.hamcrest:hamcrest:2.2'
       testImplementation 'org.mockito:mockito-inline:3.9.0'
       testImplementation 'org.robolectric:robolectric:4.4'
+      testImplementation 'androidx.test:core:1.0.0'
     }
   testOptions {
     unitTests {
@@ -67,4 +68,8 @@ afterEvaluate {
             }
         }
     }
+}
+
+dependencies {
+    implementation 'androidx.test:core:1.3.0'
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdSize.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdSize.java
@@ -32,6 +32,10 @@ class FlutterAdSize {
     AdSize getLandscapeAnchoredAdaptiveBannerAdSize(Context context, int width) {
       return AdSize.getLandscapeAnchoredAdaptiveBannerAdSize(context, width);
     }
+
+    AdSize getCurrentOrientationAnchoredAdaptiveBannerAdSize(Context context, int width) {
+      return AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(context, width);
+    }
   }
 
   static class AnchoredAdaptiveBannerAdSize extends FlutterAdSize {
@@ -39,27 +43,23 @@ class FlutterAdSize {
 
     @NonNull
     private static AdSize getAdSize(
-        @NonNull Context context,
-        @NonNull AdSizeFactory factory,
-        @NonNull String orientation,
-        int width) {
+        @NonNull Context context, @NonNull AdSizeFactory factory, String orientation, int width) {
       final AdSize adSize;
-      if (orientation.equals("portrait")) {
+      if (orientation == null) {
+        adSize = factory.getCurrentOrientationAnchoredAdaptiveBannerAdSize(context, width);
+      } else if (orientation.equals("portrait")) {
         adSize = factory.getPortraitAnchoredAdaptiveBannerAdSize(context, width);
       } else if (orientation.equals("landscape")) {
         adSize = factory.getLandscapeAnchoredAdaptiveBannerAdSize(context, width);
       } else {
         throw new IllegalArgumentException(
-            "Orientation should be 'portrait' or 'landscape': " + orientation);
+            "Orientation (optional) should be 'portrait' or 'landscape': " + orientation);
       }
       return adSize;
     }
 
     AnchoredAdaptiveBannerAdSize(
-        @NonNull Context context,
-        @NonNull AdSizeFactory factory,
-        @NonNull String orientation,
-        int width) {
+        @NonNull Context context, @NonNull AdSizeFactory factory, String orientation, int width) {
       super(getAdSize(context, factory, orientation, width));
       this.orientation = orientation;
     }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -424,7 +424,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
       case "AdSize#getAnchoredAdaptiveBannerAdSize":
         final FlutterAdSize.AnchoredAdaptiveBannerAdSize size =
             new FlutterAdSize.AnchoredAdaptiveBannerAdSize(
-                activityBinding.getActivity(),
+                appContext,
                 new FlutterAdSize.AdSizeFactory(),
                 call.<String>argument("orientation"),
                 call.<Integer>argument("width"));

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
@@ -30,7 +30,9 @@ import static org.mockito.Mockito.verify;
 import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
+import androidx.test.core.app.ApplicationProvider;
 import com.google.android.gms.ads.AdError;
+import com.google.android.gms.ads.AdSize;
 import com.google.android.gms.ads.AdapterResponseInfo;
 import com.google.android.gms.ads.ResponseInfo;
 import com.google.android.gms.ads.initialization.InitializationStatus;
@@ -43,6 +45,7 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.StandardMethodCodec;
+import io.flutter.plugin.platform.PlatformViewRegistry;
 import io.flutter.plugins.googlemobileads.FlutterAd.FlutterAdapterResponseInfo;
 import io.flutter.plugins.googlemobileads.FlutterAd.FlutterResponseInfo;
 import java.nio.ByteBuffer;
@@ -677,5 +680,58 @@ public class GoogleMobileAdsTest {
     // Verify that mockMobileAds.getVersionString() was called and a value is returned.
     verify(mockMobileAds).getVersionString();
     verify(result).success("Test-SDK-Version");
+  }
+
+  @Test
+  public void testGetAnchoredAdaptiveBannerAdSize() {
+    AdInstanceManager testManagerSpy = spy(testManager);
+    FlutterMobileAdsWrapper mockMobileAds = mock(FlutterMobileAdsWrapper.class);
+    GoogleMobileAdsPlugin plugin =
+        new GoogleMobileAdsPlugin(mockFlutterPluginBinding, testManagerSpy, mockMobileAds);
+
+    BinaryMessenger mockBinaryMessenger = mock(BinaryMessenger.class);
+    FlutterPluginBinding mockActivityPluginBinding = mock(FlutterPluginBinding.class);
+    PlatformViewRegistry mockPlatformViewRegistry = mock(PlatformViewRegistry.class);
+
+    Context context = ApplicationProvider.getApplicationContext();
+
+    doReturn(context).when(mockActivityPluginBinding).getApplicationContext();
+    doReturn(mockBinaryMessenger).when(mockActivityPluginBinding).getBinaryMessenger();
+    doReturn(mockPlatformViewRegistry).when(mockActivityPluginBinding).getPlatformViewRegistry();
+
+    plugin.onAttachedToEngine(mockActivityPluginBinding);
+
+    // Test for portrait Banner AdSize.
+    HashMap<String, Object> arguments = new HashMap<>();
+    arguments.put("orientation", "portrait");
+    arguments.put("width", 23);
+
+    AdSize adSize = AdSize.getPortraitAnchoredAdaptiveBannerAdSize(context, 23);
+    MethodCall methodCall = new MethodCall("AdSize#getAnchoredAdaptiveBannerAdSize", arguments);
+    Result result = mock(Result.class);
+    plugin.onMethodCall(methodCall, result);
+
+    verify(result).success(adSize.getHeight());
+
+    // Test for landscape Banner AdSize.
+    arguments = new HashMap<>();
+    arguments.put("orientation", "landscape");
+    arguments.put("width", 23);
+
+    adSize = AdSize.getPortraitAnchoredAdaptiveBannerAdSize(context, 23);
+    methodCall = new MethodCall("AdSize#getAnchoredAdaptiveBannerAdSize", arguments);
+    plugin.onMethodCall(methodCall, result);
+
+    verify(result).success(adSize.getHeight());
+
+    // Test for current orientation (inferred) Banner AdSize.
+    arguments = new HashMap<>();
+    arguments.put("width", 23);
+
+    adSize = AdSize.getPortraitAnchoredAdaptiveBannerAdSize(context, 23);
+    methodCall = new MethodCall("AdSize#getAnchoredAdaptiveBannerAdSize", arguments);
+    plugin.onMethodCall(methodCall, result);
+
+    verify(result).success(adSize.getHeight());
   }
 }

--- a/packages/google_mobile_ads/example/lib/main.dart
+++ b/packages/google_mobile_ads/example/lib/main.dart
@@ -156,10 +156,8 @@ class _MyAppState extends State<MyApp> {
 
   Future<void> _createAnchoredBanner(BuildContext context) async {
     final AnchoredAdaptiveBannerAdSize? size =
-        await AdSize.getAnchoredAdaptiveBannerAdSize(
-      Orientation.portrait,
-      MediaQuery.of(context).size.width.truncate(),
-    );
+        await AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(
+            MediaQuery.of(context).size.width.truncate());
 
     if (size == null) {
       print('Unable to get height of anchored banner.');

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
@@ -34,6 +34,7 @@
 @interface FLTAdSizeFactory : NSObject
 - (GADAdSize)portraitAnchoredAdaptiveBannerAdSizeWithWidth:(NSNumber *_Nonnull)width;
 - (GADAdSize)landscapeAnchoredAdaptiveBannerAdSizeWithWidth:(NSNumber *_Nonnull)width;
+- (GADAdSize)currentOrientationAnchoredAdaptiveBannerAdSizeWithWidth:(NSNumber *_Nonnull)width;
 @end
 
 @interface FLTAnchoredAdaptiveBannerSize : FLTAdSize

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
@@ -41,19 +41,26 @@
 - (GADAdSize)landscapeAnchoredAdaptiveBannerAdSizeWithWidth:(NSNumber *_Nonnull)width {
   return GADLandscapeAnchoredAdaptiveBannerAdSizeWithWidth(width.doubleValue);
 }
+
+- (GADAdSize)currentOrientationAnchoredAdaptiveBannerAdSizeWithWidth:(NSNumber *_Nonnull)width {
+  return GADCurrentOrientationAnchoredAdaptiveBannerAdSizeWithWidth(width.doubleValue);
+}
 @end
 
 @implementation FLTAnchoredAdaptiveBannerSize
 - (instancetype _Nonnull)initWithFactory:(FLTAdSizeFactory *_Nonnull)factory
-                             orientation:(NSString *_Nonnull)orientation
+                             orientation:(NSString *)orientation
                                    width:(NSNumber *_Nonnull)width {
   GADAdSize size;
-  if ([orientation isEqualToString:@"portrait"]) {
+  if (!orientation || [orientation isKindOfClass:[NSNull class]]) {
+    size = [factory currentOrientationAnchoredAdaptiveBannerAdSizeWithWidth:width];
+  } else if ([orientation isEqualToString:@"portrait"]) {
     size = [factory portraitAnchoredAdaptiveBannerAdSizeWithWidth:width];
   } else if ([orientation isEqualToString:@"landscape"]) {
     size = [factory landscapeAnchoredAdaptiveBannerAdSizeWithWidth:width];
   } else {
-    NSLog(@"AdaptiveBanner orientation should be 'portrait' or 'landscape': %@", orientation);
+    NSLog(@"AdaptiveBanner orientation (optional) should be 'portrait' or 'landscape': %@",
+          orientation);
     return nil;
   }
 

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
@@ -320,4 +320,61 @@
   XCTAssertTrue(resultInvoked);
   XCTAssertEqual(returnedResult, [GADMobileAds.sharedInstance sdkVersion]);
 }
+
+- (void)testGetAnchoredAdaptiveBannerAdSize {
+  FlutterMethodCall *methodCall =
+      [FlutterMethodCall methodCallWithMethodName:@"AdSize#getAnchoredAdaptiveBannerAdSize"
+                                        arguments:@{
+                                          @"orientation" : @"portrait",
+                                          @"width" : @23,
+                                        }];
+
+  __block bool resultInvoked = false;
+  __block id _Nullable returnedResult;
+  FlutterResult result = ^(id _Nullable result) {
+    resultInvoked = true;
+    returnedResult = result;
+  };
+
+  [_fltGoogleMobileAdsPlugin handleMethodCall:methodCall result:result];
+
+  XCTAssertTrue(resultInvoked);
+  XCTAssertEqual([returnedResult doubleValue],
+                 GADPortraitAnchoredAdaptiveBannerAdSizeWithWidth(23).size.height);
+
+  methodCall = [FlutterMethodCall methodCallWithMethodName:@"AdSize#getAnchoredAdaptiveBannerAdSize"
+                                                 arguments:@{
+                                                   @"orientation" : @"landscape",
+                                                   @"width" : @34,
+                                                 }];
+
+  resultInvoked = false;
+  result = ^(id _Nullable result) {
+    resultInvoked = true;
+    returnedResult = result;
+  };
+
+  [_fltGoogleMobileAdsPlugin handleMethodCall:methodCall result:result];
+
+  XCTAssertTrue(resultInvoked);
+  XCTAssertEqual([returnedResult doubleValue],
+                 GADPortraitAnchoredAdaptiveBannerAdSizeWithWidth(34).size.height);
+
+  methodCall = [FlutterMethodCall methodCallWithMethodName:@"AdSize#getAnchoredAdaptiveBannerAdSize"
+                                                 arguments:@{
+                                                   @"width" : @45,
+                                                 }];
+
+  resultInvoked = false;
+  result = ^(id _Nullable result) {
+    resultInvoked = true;
+    returnedResult = result;
+  };
+
+  [_fltGoogleMobileAdsPlugin handleMethodCall:methodCall result:result];
+
+  XCTAssertTrue(resultInvoked);
+  XCTAssertEqual([returnedResult doubleValue],
+                 GADPortraitAnchoredAdaptiveBannerAdSizeWithWidth(45).size.height);
+}
 @end

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -239,7 +239,7 @@ class AnchoredAdaptiveBannerAdSize extends AdSize {
   }) : super(width: width, height: height);
 
   /// Orientation of the device used by the SDK to automatically find the correct height.
-  final Orientation orientation;
+  final Orientation? orientation;
 }
 
 /// Ad units that render screen-width banner ads on any screen size across different devices in either [Orientation].
@@ -308,7 +308,7 @@ class AdSize {
   ) async {
     final num? height = await instanceManager.channel.invokeMethod<num?>(
       'AdSize#getAnchoredAdaptiveBannerAdSize',
-      <String, Object>{
+      <String, Object?>{
         'orientation': describeEnum(orientation),
         'width': width,
       },
@@ -317,6 +317,28 @@ class AdSize {
     if (height == null) return null;
     return AnchoredAdaptiveBannerAdSize(
       orientation,
+      width: width,
+      height: height.truncate(),
+    );
+  }
+
+  /// Returns an AdSize with the given width and a Google-optimized height to create a banner ad.
+  /// The size returned will have an aspect ratio similar to AdSize, suitable for anchoring near the top or bottom of your app.
+  /// The height will never be larger than 15% of the device's current orientation height and never smaller than 50px.
+  /// This function always returns the same height for any width / device combination.
+  /// For more details, visit: https://developers.google.com/android/reference/com/google/android/gms/ads/AdSize#getCurrentOrientationAnchoredAdaptiveBannerAdSize(android.content.Context,%20int)
+  static Future<AnchoredAdaptiveBannerAdSize?>
+      getCurrentOrientationAnchoredAdaptiveBannerAdSize(int width) async {
+    final num? height = await instanceManager.channel.invokeMethod<num?>(
+      'AdSize#getAnchoredAdaptiveBannerAdSize',
+      <String, Object?>{
+        'width': width,
+      },
+    );
+
+    if (height == null) return null;
+    return AnchoredAdaptiveBannerAdSize(
+      null,
       width: width,
       height: height.truncate(),
     );

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -782,14 +782,18 @@ class AdMessageCodec extends StandardMessageCodec {
   dynamic readValueOfType(dynamic type, ReadBuffer buffer) {
     switch (type) {
       case _valueAnchoredAdaptiveBannerAdSize:
-        final String orientationStr =
+        final String? orientationStr =
             readValueOfType(buffer.getUint8(), buffer);
         final num width = readValueOfType(buffer.getUint8(), buffer);
-        return AnchoredAdaptiveBannerAdSize(
-          Orientation.values.firstWhere(
+        Orientation? orientation;
+        if (orientationStr != null) {
+          orientation = Orientation.values.firstWhere(
             (Orientation orientation) =>
                 describeEnum(orientation) == orientationStr,
-          ),
+          );
+        }
+        return AnchoredAdaptiveBannerAdSize(
+          orientation,
           width: width.truncate(),
           height: -1, // Unused value
         );
@@ -924,7 +928,13 @@ class AdMessageCodec extends StandardMessageCodec {
   void writeAdSize(WriteBuffer buffer, AdSize value) {
     if (value is AnchoredAdaptiveBannerAdSize) {
       buffer.putUint8(_valueAnchoredAdaptiveBannerAdSize);
-      writeValue(buffer, describeEnum(value.orientation));
+      var orientationValue;
+      if (value.orientation != null) {
+        orientationValue = describeEnum(value.orientation as Orientation);
+      } else {
+        orientationValue = null;
+      }
+      writeValue(buffer, orientationValue);
       writeValue(buffer, value.width);
     } else if (value is SmartBannerAdSize) {
       buffer.putUint8(_valueSmartBannerAdSize);

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -1347,13 +1347,32 @@ void main() {
     });
 
     test('encode/decode $AnchoredAdaptiveBannerAdSize', () async {
-      final ByteData byteData = codec.encodeMessage(
-          AnchoredAdaptiveBannerAdSize(Orientation.landscape,
+      final ByteData byteDataPortrait = codec.encodeMessage(
+          AnchoredAdaptiveBannerAdSize(Orientation.portrait,
               width: 23, height: 34))!;
 
+      final AnchoredAdaptiveBannerAdSize resultPortrait =
+          codec.decodeMessage(byteDataPortrait);
+      expect(resultPortrait.orientation, Orientation.portrait);
+      expect(resultPortrait.width, 23);
+      expect(resultPortrait.height, -1);
+
+      final ByteData byteDataLandscape = codec.encodeMessage(
+          AnchoredAdaptiveBannerAdSize(Orientation.landscape,
+              width: 34, height: 23))!;
+
+      final AnchoredAdaptiveBannerAdSize resultLandscape =
+          codec.decodeMessage(byteDataLandscape);
+      expect(resultLandscape.orientation, Orientation.landscape);
+      expect(resultLandscape.width, 34);
+      expect(resultLandscape.height, -1);
+
+      final ByteData byteData = codec.encodeMessage(
+          AnchoredAdaptiveBannerAdSize(null, width: 45, height: 34))!;
+
       final AnchoredAdaptiveBannerAdSize result = codec.decodeMessage(byteData);
-      expect(result.orientation, Orientation.landscape);
-      expect(result.width, 23);
+      expect(result.orientation, null);
+      expect(result.width, 45);
       expect(result.height, -1);
     });
 

--- a/packages/google_mobile_ads/test/mobile_ads_test.dart
+++ b/packages/google_mobile_ads/test/mobile_ads_test.dart
@@ -16,6 +16,7 @@ import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:google_mobile_ads/src/ad_instance_manager.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -54,6 +55,8 @@ void main() {
             return null;
           case 'MobileAds#getVersionString':
             return Future<String>.value('Test-SDK-Version');
+          case 'AdSize#getAnchoredAdaptiveBannerAdSize':
+            return null;
           default:
             assert(false);
             return null;
@@ -277,6 +280,35 @@ void main() {
 
       expect(log, <Matcher>[
         isMethodCall('MobileAds#getVersionString', arguments: null)
+      ]);
+    });
+
+    test('$AdSize.getAnchoredAdaptiveBannerAdSize', () async {
+      await AdSize.getAnchoredAdaptiveBannerAdSize(Orientation.portrait, 23);
+
+      expect(log, <Matcher>[
+        isMethodCall('AdSize#getAnchoredAdaptiveBannerAdSize',
+            arguments: {'orientation': 'portrait', 'width': 23})
+      ]);
+
+      await AdSize.getAnchoredAdaptiveBannerAdSize(Orientation.landscape, 34);
+
+      expect(log, <Matcher>[
+        isMethodCall('AdSize#getAnchoredAdaptiveBannerAdSize',
+            arguments: {'orientation': 'portrait', 'width': 23}),
+        isMethodCall('AdSize#getAnchoredAdaptiveBannerAdSize',
+            arguments: {'orientation': 'landscape', 'width': 34})
+      ]);
+
+      await AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(45);
+
+      expect(log, <Matcher>[
+        isMethodCall('AdSize#getAnchoredAdaptiveBannerAdSize',
+            arguments: {'orientation': 'portrait', 'width': 23}),
+        isMethodCall('AdSize#getAnchoredAdaptiveBannerAdSize',
+            arguments: {'orientation': 'landscape', 'width': 34}),
+        isMethodCall('AdSize#getAnchoredAdaptiveBannerAdSize',
+            arguments: {'width': 45})
       ]);
     });
   });


### PR DESCRIPTION
## Description

*Implement AnchoredAdaptiveBannerAdSize API for current orientation  and Test along with portrait and landscape.*

## Related Issues

*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
