### PR TITLE
Mediation network extras apis

### DIFF
--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
@@ -59,6 +59,7 @@ class AdMessageCodec extends StandardMessageCodec {
 
   @NonNull Context context;
   @NonNull final FlutterAdSize.AdSizeFactory adSizeFactory;
+  @Nullable private MediationNetworkExtrasProvider mediationNetworkExtrasProvider;
 
   AdMessageCodec(@NonNull Context context) {
     this.context = context;
@@ -73,6 +74,11 @@ class AdMessageCodec extends StandardMessageCodec {
 
   void setContext(@NonNull Context context) {
     this.context = context;
+  }
+
+  void setMediationNetworkExtrasProvider(
+      @NonNull MediationNetworkExtrasProvider mediationNetworkExtrasProvider) {
+    this.mediationNetworkExtrasProvider = mediationNetworkExtrasProvider;
   }
 
   @Override
@@ -91,6 +97,7 @@ class AdMessageCodec extends StandardMessageCodec {
       writeValue(stream, request.getHttpTimeoutMillis());
       writeValue(stream, request.getPublisherProvidedId());
       writeValue(stream, request.getLocation());
+      writeValue(stream, request.getMediationExtrasIdentifier());
     } else if (value instanceof FlutterAdRequest) {
       stream.write(VALUE_AD_REQUEST);
       final FlutterAdRequest request = (FlutterAdRequest) value;
@@ -100,6 +107,7 @@ class AdMessageCodec extends StandardMessageCodec {
       writeValue(stream, request.getNeighboringContentUrls());
       writeValue(stream, request.getHttpTimeoutMillis());
       writeValue(stream, request.getLocation());
+      writeValue(stream, request.getMediationExtrasIdentifier());
     } else if (value instanceof FlutterRewardedAd.FlutterRewardItem) {
       stream.write(VALUE_REWARD_ITEM);
       final FlutterRewardedAd.FlutterRewardItem item = (FlutterRewardedAd.FlutterRewardItem) value;
@@ -228,6 +236,8 @@ class AdMessageCodec extends StandardMessageCodec {
             .setNeighboringContentUrls((List<String>) readValueOfType(buffer.get(), buffer))
             .setHttpTimeoutMillis((Integer) readValueOfType(buffer.get(), buffer))
             .setLocation((Location) readValueOfType(buffer.get(), buffer))
+            .setMediationNetworkExtrasIdentifier((String) readValueOfType(buffer.get(), buffer))
+            .setMediationNetworkExtrasProvider(mediationNetworkExtrasProvider)
             .build();
       case VALUE_REWARD_ITEM:
         return new FlutterRewardedAd.FlutterRewardItem(
@@ -268,6 +278,8 @@ class AdMessageCodec extends StandardMessageCodec {
         builder.setHttpTimeoutMillis((Integer) readValueOfType(buffer.get(), buffer));
         builder.setPublisherProvidedId((String) readValueOfType(buffer.get(), buffer));
         builder.setLocation((Location) readValueOfType(buffer.get(), buffer));
+        builder.setMediationNetworkExtrasIdentifier((String) readValueOfType(buffer.get(), buffer));
+        builder.setMediationNetworkExtrasProvider(mediationNetworkExtrasProvider);
         return builder.build();
       case VALUE_INITIALIZATION_STATE:
         final String state = (String) readValueOfType(buffer.get(), buffer);

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
@@ -77,7 +77,7 @@ class AdMessageCodec extends StandardMessageCodec {
   }
 
   void setMediationNetworkExtrasProvider(
-      @NonNull MediationNetworkExtrasProvider mediationNetworkExtrasProvider) {
+      @Nullable MediationNetworkExtrasProvider mediationNetworkExtrasProvider) {
     this.mediationNetworkExtrasProvider = mediationNetworkExtrasProvider;
   }
 

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequest.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequest.java
@@ -15,9 +15,7 @@
 package io.flutter.plugins.googlemobileads;
 
 import android.location.Location;
-import android.os.Bundle;
 import androidx.annotation.Nullable;
-import com.google.ads.mediation.admob.AdMobAdapter;
 import com.google.android.gms.ads.admanager.AdManagerAdRequest;
 import java.util.List;
 import java.util.Map;

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequest.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequest.java
@@ -29,9 +29,9 @@ import java.util.Objects;
  */
 class FlutterAdManagerAdRequest extends FlutterAdRequest {
 
-  @Nullable private Map<String, String> customTargeting;
-  @Nullable private Map<String, List<String>> customTargetingLists;
-  @Nullable private String publisherProvidedId;
+  @Nullable private final Map<String, String> customTargeting;
+  @Nullable private final Map<String, List<String>> customTargetingLists;
+  @Nullable private final String publisherProvidedId;
 
   static class Builder extends FlutterAdRequest.Builder {
 
@@ -65,7 +65,9 @@ class FlutterAdManagerAdRequest extends FlutterAdRequest {
           getNeighboringContentUrls(),
           getHttpTimeoutMillis(),
           getLocation(),
-          publisherProvidedId);
+          publisherProvidedId,
+          getMediationExtrasIdentifier(),
+          getMediationNetworkExtrasProvider());
     }
   }
 
@@ -78,30 +80,27 @@ class FlutterAdManagerAdRequest extends FlutterAdRequest {
       @Nullable List<String> neighboringContentUrls,
       @Nullable Integer httpTimeoutMillis,
       @Nullable Location location,
-      @Nullable String publisherProvidedId) {
+      @Nullable String publisherProvidedId,
+      @Nullable String mediationExtrasIdentifier,
+      @Nullable MediationNetworkExtrasProvider mediationNetworkExtrasProvider) {
     super(
         keywords,
         contentUrl,
         nonPersonalizedAds,
         neighboringContentUrls,
         httpTimeoutMillis,
-        location);
+        location,
+        mediationExtrasIdentifier,
+        mediationNetworkExtrasProvider);
     this.customTargeting = customTargeting;
     this.customTargetingLists = customTargetingLists;
     this.publisherProvidedId = publisherProvidedId;
   }
 
-  AdManagerAdRequest asAdManagerAdRequest() {
+  AdManagerAdRequest asAdManagerAdRequest(String adUnitId) {
     final AdManagerAdRequest.Builder builder = new AdManagerAdRequest.Builder();
-    if (getKeywords() != null) {
-      for (final String keyword : getKeywords()) {
-        builder.addKeyword(keyword);
-      }
-    }
+    updateAdRequestBuilder(builder, adUnitId);
 
-    if (getContentUrl() != null) {
-      builder.setContentUrl(getContentUrl());
-    }
     if (customTargeting != null) {
       for (final Map.Entry<String, String> entry : customTargeting.entrySet()) {
         builder.addCustomTargeting(entry.getKey(), entry.getValue());
@@ -112,18 +111,9 @@ class FlutterAdManagerAdRequest extends FlutterAdRequest {
         builder.addCustomTargeting(entry.getKey(), entry.getValue());
       }
     }
-    if (getNonPersonalizedAds() != null && getNonPersonalizedAds()) {
-      final Bundle extras = new Bundle();
-      extras.putString("npa", "1");
-      builder.addNetworkExtrasBundle(AdMobAdapter.class, extras);
-    }
     if (publisherProvidedId != null) {
       builder.setPublisherProvidedId(publisherProvidedId);
     }
-    if (getLocation() != null) {
-      builder.setLocation(getLocation());
-    }
-    builder.setRequestAgent(Constants.REQUEST_AGENT_PREFIX_VERSIONED);
     return builder.build();
   }
 

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerBannerAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerBannerAd.java
@@ -86,7 +86,7 @@ class FlutterAdManagerBannerAd extends FlutterAd implements FlutterAdLoadedListe
     }
     adView.setAdSizes(allSizes);
     adView.setAdListener(new FlutterBannerAdListener(adId, manager, this));
-    adView.loadAd(request.asAdManagerAdRequest());
+    adView.loadAd(request.asAdManagerAdRequest(adUnitId));
   }
 
   @Override

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerInterstitialAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerInterstitialAd.java
@@ -59,7 +59,7 @@ class FlutterAdManagerInterstitialAd extends FlutterAd.FlutterOverlayAd {
   void load() {
     flutterAdLoader.loadAdManagerInterstitial(
         adUnitId,
-        request.asAdManagerAdRequest(),
+        request.asAdManagerAdRequest(adUnitId),
         new DelegatingAdManagerInterstitialAdCallbacks(this));
   }
 

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdRequest.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdRequest.java
@@ -19,7 +19,9 @@ import android.os.Bundle;
 import androidx.annotation.Nullable;
 import com.google.ads.mediation.admob.AdMobAdapter;
 import com.google.android.gms.ads.AdRequest;
+import com.google.android.gms.ads.mediation.MediationExtrasReceiver;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 class FlutterAdRequest {
@@ -29,6 +31,8 @@ class FlutterAdRequest {
   @Nullable private final List<String> neighboringContentUrls;
   @Nullable private final Integer httpTimeoutMillis;
   @Nullable private final Location location;
+  @Nullable private final String mediationExtrasIdentifier;
+  @Nullable private final MediationNetworkExtrasProvider mediationNetworkExtrasProvider;
 
   protected static class Builder {
     @Nullable private List<String> keywords;
@@ -37,6 +41,8 @@ class FlutterAdRequest {
     @Nullable private List<String> neighboringContentUrls;
     @Nullable private Integer httpTimeoutMillis;
     @Nullable private Location location;
+    @Nullable private String mediationExtrasIdentifier;
+    @Nullable private MediationNetworkExtrasProvider mediationNetworkExtrasProvider;
 
     Builder setKeywords(@Nullable List<String> keywords) {
       this.keywords = keywords;
@@ -65,6 +71,17 @@ class FlutterAdRequest {
 
     Builder setLocation(@Nullable Location location) {
       this.location = location;
+      return this;
+    }
+
+    Builder setMediationNetworkExtrasIdentifier(@Nullable String mediationExtrasIdentifier) {
+      this.mediationExtrasIdentifier = mediationExtrasIdentifier;
+      return this;
+    }
+
+    Builder setMediationNetworkExtrasProvider(
+        @Nullable MediationNetworkExtrasProvider mediationNetworkExtrasProvider) {
+      this.mediationNetworkExtrasProvider = mediationNetworkExtrasProvider;
       return this;
     }
 
@@ -98,6 +115,16 @@ class FlutterAdRequest {
       return location;
     }
 
+    @Nullable
+    protected String getMediationExtrasIdentifier() {
+      return mediationExtrasIdentifier;
+    }
+
+    @Nullable
+    protected MediationNetworkExtrasProvider getMediationNetworkExtrasProvider() {
+      return mediationNetworkExtrasProvider;
+    }
+
     FlutterAdRequest build() {
       return new FlutterAdRequest(
           keywords,
@@ -105,7 +132,9 @@ class FlutterAdRequest {
           nonPersonalizedAds,
           neighboringContentUrls,
           httpTimeoutMillis,
-          location);
+          location,
+          mediationExtrasIdentifier,
+          mediationNetworkExtrasProvider);
     }
   }
 
@@ -115,18 +144,23 @@ class FlutterAdRequest {
       @Nullable Boolean nonPersonalizedAds,
       @Nullable List<String> neighboringContentUrls,
       @Nullable Integer httpTimeoutMillis,
-      @Nullable Location location) {
+      @Nullable Location location,
+      @Nullable String mediationExtrasIdentifier,
+      @Nullable MediationNetworkExtrasProvider mediationNetworkExtrasProvider) {
     this.keywords = keywords;
     this.contentUrl = contentUrl;
     this.nonPersonalizedAds = nonPersonalizedAds;
     this.neighboringContentUrls = neighboringContentUrls;
     this.httpTimeoutMillis = httpTimeoutMillis;
     this.location = location;
+    this.mediationExtrasIdentifier = mediationExtrasIdentifier;
+    this.mediationNetworkExtrasProvider = mediationNetworkExtrasProvider;
   }
 
-  AdRequest asAdRequest() {
-    final AdRequest.Builder builder = new AdRequest.Builder();
-
+  /**
+   * Updates the {@link AdRequest.Builder} with the properties in this {@link FlutterAdRequest}.
+   */
+  protected AdRequest.Builder updateAdRequestBuilder(AdRequest.Builder builder, String adUnitId) {
     if (keywords != null) {
       for (final String keyword : keywords) {
         builder.addKeyword(keyword);
@@ -135,7 +169,23 @@ class FlutterAdRequest {
     if (contentUrl != null) {
       builder.setContentUrl(contentUrl);
     }
-    if (nonPersonalizedAds != null && nonPersonalizedAds) {
+    if (mediationNetworkExtrasProvider != null && mediationExtrasIdentifier != null) {
+      Map<Class<? extends MediationExtrasReceiver>, Bundle> mediationNetworkExtras =
+          mediationNetworkExtrasProvider.getMediationExtras(adUnitId, mediationExtrasIdentifier);
+      // Handle npa here so we don't override any admob extras.
+      if (nonPersonalizedAds != null && nonPersonalizedAds) {
+        Bundle extras = mediationNetworkExtras.get(AdMobAdapter.class);
+        if (extras == null) {
+          extras = new Bundle();
+        }
+        extras.putString("npa", "1");
+        mediationNetworkExtras.put(AdMobAdapter.class, extras);
+      }
+      for (Map.Entry<Class<? extends MediationExtrasReceiver>, Bundle> entry
+          : mediationNetworkExtras.entrySet()) {
+        builder.addNetworkExtrasBundle(entry.getKey(), entry.getValue());
+      }
+    } else if (nonPersonalizedAds != null && nonPersonalizedAds) {
       final Bundle extras = new Bundle();
       extras.putString("npa", "1");
       builder.addNetworkExtrasBundle(AdMobAdapter.class, extras);
@@ -150,7 +200,11 @@ class FlutterAdRequest {
       builder.setLocation(location);
     }
     builder.setRequestAgent(Constants.REQUEST_AGENT_PREFIX_VERSIONED);
-    return builder.build();
+    return builder;
+  }
+
+  AdRequest asAdRequest(String adUnitId) {
+    return updateAdRequestBuilder(new AdRequest.Builder(), adUnitId).build();
   }
 
   @Nullable
@@ -183,6 +237,11 @@ class FlutterAdRequest {
     return location;
   }
 
+  @Nullable
+  protected String getMediationExtrasIdentifier() {
+    return mediationExtrasIdentifier;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -203,7 +262,9 @@ class FlutterAdRequest {
             || (location.getAccuracy() == request.location.getAccuracy()
                 && location.getLongitude() == request.location.getLongitude()
                 && location.getLatitude() == request.location.getLatitude()
-                && location.getTime() == request.location.getTime()));
+                && location.getTime() == request.location.getTime()))
+        && Objects.equals(mediationExtrasIdentifier, request.mediationExtrasIdentifier)
+        && Objects.equals(mediationNetworkExtrasProvider, request.mediationNetworkExtrasProvider);
   }
 
   @Override
@@ -214,6 +275,8 @@ class FlutterAdRequest {
         nonPersonalizedAds,
         neighboringContentUrls,
         httpTimeoutMillis,
-        location);
+        location,
+        mediationExtrasIdentifier,
+        mediationNetworkExtrasProvider);
   }
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdRequest.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdRequest.java
@@ -20,6 +20,7 @@ import androidx.annotation.Nullable;
 import com.google.ads.mediation.admob.AdMobAdapter;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.mediation.MediationExtrasReceiver;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -174,17 +175,19 @@ class FlutterAdRequest {
             : mediationNetworkExtrasProvider.getMediationExtras(
                 adUnitId, mediationExtrasIdentifier);
     if (mediationNetworkExtras != null) {
+      Map<Class<? extends MediationExtrasReceiver>, Bundle> mediationNetworkExtrasCopy =
+          new HashMap<>(mediationNetworkExtras);
       // Handle npa here so we don't override any admob extras.
       if (nonPersonalizedAds != null && nonPersonalizedAds) {
-        Bundle extras = mediationNetworkExtras.get(AdMobAdapter.class);
+        Bundle extras = mediationNetworkExtrasCopy.get(AdMobAdapter.class);
         if (extras == null) {
           extras = new Bundle();
         }
         extras.putString("npa", "1");
-        mediationNetworkExtras.put(AdMobAdapter.class, extras);
+        mediationNetworkExtrasCopy.put(AdMobAdapter.class, extras);
       }
       for (Map.Entry<Class<? extends MediationExtrasReceiver>, Bundle> entry :
-          mediationNetworkExtras.entrySet()) {
+          mediationNetworkExtrasCopy.entrySet()) {
         builder.addNetworkExtrasBundle(entry.getKey(), entry.getValue());
       }
     } else if (nonPersonalizedAds != null && nonPersonalizedAds) {

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdRequest.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdRequest.java
@@ -157,9 +157,7 @@ class FlutterAdRequest {
     this.mediationNetworkExtrasProvider = mediationNetworkExtrasProvider;
   }
 
-  /**
-   * Updates the {@link AdRequest.Builder} with the properties in this {@link FlutterAdRequest}.
-   */
+  /** Updates the {@link AdRequest.Builder} with the properties in this {@link FlutterAdRequest}. */
   protected AdRequest.Builder updateAdRequestBuilder(AdRequest.Builder builder, String adUnitId) {
     if (keywords != null) {
       for (final String keyword : keywords) {
@@ -169,9 +167,13 @@ class FlutterAdRequest {
     if (contentUrl != null) {
       builder.setContentUrl(contentUrl);
     }
-    if (mediationNetworkExtrasProvider != null && mediationExtrasIdentifier != null) {
-      Map<Class<? extends MediationExtrasReceiver>, Bundle> mediationNetworkExtras =
-          mediationNetworkExtrasProvider.getMediationExtras(adUnitId, mediationExtrasIdentifier);
+
+    Map<Class<? extends MediationExtrasReceiver>, Bundle> mediationNetworkExtras =
+        mediationNetworkExtrasProvider == null
+            ? null
+            : mediationNetworkExtrasProvider.getMediationExtras(
+                adUnitId, mediationExtrasIdentifier);
+    if (mediationNetworkExtras != null) {
       // Handle npa here so we don't override any admob extras.
       if (nonPersonalizedAds != null && nonPersonalizedAds) {
         Bundle extras = mediationNetworkExtras.get(AdMobAdapter.class);
@@ -181,8 +183,8 @@ class FlutterAdRequest {
         extras.putString("npa", "1");
         mediationNetworkExtras.put(AdMobAdapter.class, extras);
       }
-      for (Map.Entry<Class<? extends MediationExtrasReceiver>, Bundle> entry
-          : mediationNetworkExtras.entrySet()) {
+      for (Map.Entry<Class<? extends MediationExtrasReceiver>, Bundle> entry :
+          mediationNetworkExtras.entrySet()) {
         builder.addNetworkExtrasBundle(entry.getKey(), entry.getValue());
       }
     } else if (nonPersonalizedAds != null && nonPersonalizedAds) {

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAppOpenAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAppOpenAd.java
@@ -61,13 +61,13 @@ class FlutterAppOpenAd extends FlutterAd.FlutterOverlayAd {
     if (request != null) {
       flutterAdLoader.loadAppOpen(
           adUnitId,
-          request.asAdRequest(),
+          request.asAdRequest(adUnitId),
           getOrientation(),
           new DelegatingAppOpenAdLoadCallback(this));
     } else if (adManagerAdRequest != null) {
       flutterAdLoader.loadAdManagerAppOpen(
           adUnitId,
-          adManagerAdRequest.asAdManagerAdRequest(),
+          adManagerAdRequest.asAdManagerAdRequest(adUnitId),
           getOrientation(),
           new DelegatingAppOpenAdLoadCallback(this));
     }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterBannerAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterBannerAd.java
@@ -64,7 +64,7 @@ class FlutterBannerAd extends FlutterAd implements FlutterAdLoadedListener {
     adView.setAdSize(size.getAdSize());
     adView.setOnPaidEventListener(new FlutterPaidEventListener(manager, this));
     adView.setAdListener(new FlutterBannerAdListener(adId, manager, this));
-    adView.loadAd(request.asAdRequest());
+    adView.loadAd(request.asAdRequest(adUnitId));
   }
 
   @Nullable

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterInterstitialAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterInterstitialAd.java
@@ -48,9 +48,7 @@ class FlutterInterstitialAd extends FlutterAd.FlutterOverlayAd {
   void load() {
     if (manager != null && adUnitId != null && request != null) {
       flutterAdLoader.loadInterstitial(
-          adUnitId,
-          request.asAdRequest(adUnitId),
-          new DelegatingInterstitialAdLoadCallback(this));
+          adUnitId, request.asAdRequest(adUnitId), new DelegatingInterstitialAdLoadCallback(this));
     }
   }
 

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterInterstitialAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterInterstitialAd.java
@@ -48,7 +48,9 @@ class FlutterInterstitialAd extends FlutterAd.FlutterOverlayAd {
   void load() {
     if (manager != null && adUnitId != null && request != null) {
       flutterAdLoader.loadInterstitial(
-          adUnitId, request.asAdRequest(), new DelegatingInterstitialAdLoadCallback(this));
+          adUnitId,
+          request.asAdRequest(adUnitId),
+          new DelegatingInterstitialAdLoadCallback(this));
     }
   }
 

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterNativeAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterNativeAd.java
@@ -18,6 +18,7 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.gms.ads.AdListener;
+import com.google.android.gms.ads.admanager.AdManagerAdRequest;
 import com.google.android.gms.ads.nativead.NativeAd;
 import com.google.android.gms.ads.nativead.NativeAd.OnNativeAdLoadedListener;
 import com.google.android.gms.ads.nativead.NativeAdOptions;
@@ -185,10 +186,11 @@ class FlutterNativeAd extends FlutterAd {
             : nativeAdOptions.asNativeAdOptions();
     if (request != null) {
       flutterAdLoader.loadNativeAd(
-          adUnitId, loadedListener, options, adListener, request.asAdRequest());
+          adUnitId, loadedListener, options, adListener, request.asAdRequest(adUnitId));
     } else if (adManagerRequest != null) {
+      AdManagerAdRequest adManagerAdRequest = adManagerRequest.asAdManagerAdRequest(adUnitId);
       flutterAdLoader.loadAdManagerNativeAd(
-          adUnitId, loadedListener, options, adListener, adManagerRequest.asAdManagerAdRequest());
+          adUnitId, loadedListener, options, adListener, adManagerAdRequest);
     } else {
       Log.e(TAG, "A null or invalid ad request was provided.");
     }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedAd.java
@@ -108,10 +108,10 @@ class FlutterRewardedAd extends FlutterAd.FlutterOverlayAd {
   void load() {
     final RewardedAdLoadCallback adLoadCallback = new DelegatingRewardedCallback(this);
     if (request != null) {
-      flutterAdLoader.loadRewarded(adUnitId, request.asAdRequest(), adLoadCallback);
+      flutterAdLoader.loadRewarded(adUnitId, request.asAdRequest(adUnitId), adLoadCallback);
     } else if (adManagerRequest != null) {
       flutterAdLoader.loadAdManagerRewarded(
-          adUnitId, adManagerRequest.asAdManagerAdRequest(), adLoadCallback);
+          adUnitId, adManagerRequest.asAdManagerAdRequest(adUnitId), adLoadCallback);
     } else {
       Log.e(TAG, "A null or invalid ad request was provided.");
     }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -99,7 +99,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
      * @param customOptions Used to pass additional custom options to create the {@link
      *     com.google.android.gms.ads.nativead.NativeAdView}. Nullable.
      * @return a {@link com.google.android.gms.ads.nativead.NativeAdView} that is overlaid on top of
-     *     the FlutterView.
+     *     the FlutterView
      */
     NativeAdView createNativeAd(NativeAd nativeAd, Map<String, Object> customOptions);
   }
@@ -109,12 +109,12 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
    * used to create {@link com.google.android.gms.ads.nativead.NativeAdView}s from a Native Ad
    * created in Dart.
    *
-   * @param engine maintains access to a GoogleMobileAdsPlugin instance.
+   * @param engine maintains access to a GoogleMobileAdsPlugin instance
    * @param factoryId a unique identifier for the ad factory. The Native Ad created in Dart includes
    *     a parameter that refers to this.
    * @param nativeAdFactory creates {@link com.google.android.gms.ads.nativead.NativeAdView}s when
-   *     Flutter NativeAds are created.
-   * @return whether the factoryId is unique and the nativeAdFactory was successfully added.
+   *     Flutter NativeAds are created
+   * @return whether the factoryId is unique and the nativeAdFactory was successfully added
    */
   public static boolean registerNativeAdFactory(
       FlutterEngine engine, String factoryId, NativeAdFactory nativeAdFactory) {
@@ -127,11 +127,11 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
    * Registers a {@link MediationNetworkExtrasProvider} used to provide network extras to the plugin
    * when it creates ad requests.
    *
-   * @param engine The {@link FlutterEngine} which should have an attached instance of this plugin.
+   * @param engine The {@link FlutterEngine} which should have an attached instance of this plugin
    * @param mediationNetworkExtrasProvider The {@link MediationNetworkExtrasProvider} which will be
-   *     used to provide network extras when ad requests are created.
+   *     used to provide network extras when ad requests are created
    * @return whether {@code mediationNetworkExtrasProvider} was registered to a {@code
-   *     GoogleMobileAdsPlugin} associated with {@code engine}.
+   *     GoogleMobileAdsPlugin} associated with {@code engine}
    */
   public static boolean registerMediationNetworkExtrasProvider(
       FlutterEngine engine, MediationNetworkExtrasProvider mediationNetworkExtrasProvider) {
@@ -151,7 +151,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
    * Unregisters any {@link MediationNetworkExtrasProvider} that have been previously registered
    * with the plugin using {@code unregisterMediationNetworkExtrasProvider}.
    *
-   * @param engine The {@link FlutterEngine} which should have an attached instance of this plugin.
+   * @param engine The {@link FlutterEngine} which should have an attached instance of this plugin
    */
   public static void unregisterMediationNetworkExtrasProvider(FlutterEngine engine) {
     final GoogleMobileAdsPlugin gmaPlugin =
@@ -184,12 +184,12 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
    * used to create {@link com.google.android.gms.ads.nativead.NativeAdView}s from a Native Ad
    * created in Dart.
    *
-   * @param engine maintains access to a GoogleMobileAdsPlugin instance.
+   * @param engine maintains access to a GoogleMobileAdsPlugin instance
    * @param factoryId a unique identifier for the ad factory. The Native ad created in Dart includes
-   *     a parameter that refers to this.
+   *     a parameter that refers to this
    * @return the previous {@link
    *     io.flutter.plugins.googlemobileads.GoogleMobileAdsPlugin.NativeAdFactory} associated with
-   *     this factoryId, or null if there was none for this factoryId.
+   *     this factoryId, or null if there was none for this factoryId
    */
   public static NativeAdFactory unregisterNativeAdFactory(FlutterEngine engine, String factoryId) {
     final FlutterPlugin gmaPlugin = engine.getPlugins().get(GoogleMobileAdsPlugin.class);

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -130,8 +130,8 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
    * @param engine The {@link FlutterEngine} which should have an attached instance of this plugin.
    * @param mediationNetworkExtrasProvider The {@link MediationNetworkExtrasProvider} which will be
    *     used to provide network extras when ad requests are created.
-   * @return whether {@code mediationNetworkExtrasProvider} was registered to a
-   *    {@code GoogleMobileAdsPlugin} associated with {@code engine}.
+   * @return whether {@code mediationNetworkExtrasProvider} was registered to a {@code
+   *     GoogleMobileAdsPlugin} associated with {@code engine}.
    */
   public static boolean registerMediationNetworkExtrasProvider(
       FlutterEngine engine, MediationNetworkExtrasProvider mediationNetworkExtrasProvider) {

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -123,10 +123,18 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
     return registerNativeAdFactory(gmaPlugin, factoryId, nativeAdFactory);
   }
 
-  /** TODO. */
+  /**
+   * Registers a {@link MediationNetworkExtrasProvider} used to provide network extras to the plugin
+   * when it creates ad requests.
+   *
+   * @param engine The {@link FlutterEngine} which should have an attached instance of this plugin.
+   * @param mediationNetworkExtrasProvider The {@link MediationNetworkExtrasProvider} which will be
+   *     used to provide network extras when ad requests are created.
+   * @return whether {@code mediationNetworkExtrasProvider} was registered to a
+   *    {@code GoogleMobileAdsPlugin} associated with {@code engine}.
+   */
   public static boolean registerMediationNetworkExtrasProvider(
-      FlutterEngine engine,
-      MediationNetworkExtrasProvider mediationNetworkExtrasProvider) {
+      FlutterEngine engine, MediationNetworkExtrasProvider mediationNetworkExtrasProvider) {
     final GoogleMobileAdsPlugin gmaPlugin =
         (GoogleMobileAdsPlugin) engine.getPlugins().get(GoogleMobileAdsPlugin.class);
     if (gmaPlugin == null) {
@@ -137,6 +145,25 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
       gmaPlugin.adMessageCodec.setMediationNetworkExtrasProvider(mediationNetworkExtrasProvider);
     }
     return true;
+  }
+
+  /**
+   * Unregisters any {@link MediationNetworkExtrasProvider} that have been previously registered
+   * with the plugin using {@code unregisterMediationNetworkExtrasProvider}.
+   *
+   * @param engine The {@link FlutterEngine} which should have an attached instance of this plugin.
+   */
+  public static void unregisterMediationNetworkExtrasProvider(FlutterEngine engine) {
+    final GoogleMobileAdsPlugin gmaPlugin =
+        (GoogleMobileAdsPlugin) engine.getPlugins().get(GoogleMobileAdsPlugin.class);
+    if (gmaPlugin == null) {
+      return;
+    }
+
+    if (gmaPlugin.adMessageCodec != null) {
+      gmaPlugin.adMessageCodec.setMediationNetworkExtrasProvider(null);
+    }
+    gmaPlugin.mediationNetworkExtrasProvider = null;
   }
 
   private static boolean registerNativeAdFactory(

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -62,6 +62,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
   @Nullable private ActivityPluginBinding activityBinding;
   @Nullable private AdMessageCodec adMessageCodec;
   private final Map<String, NativeAdFactory> nativeAdFactories = new HashMap<>();
+  @Nullable private MediationNetworkExtrasProvider mediationNetworkExtrasProvider;
   private final FlutterMobileAdsWrapper flutterMobileAds;
   /**
    * Public constructor for the plugin. Dependency initialization is handled in lifecycle methods
@@ -122,6 +123,22 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
     return registerNativeAdFactory(gmaPlugin, factoryId, nativeAdFactory);
   }
 
+  /** TODO. */
+  public static boolean registerMediationNetworkExtrasProvider(
+      FlutterEngine engine,
+      MediationNetworkExtrasProvider mediationNetworkExtrasProvider) {
+    final GoogleMobileAdsPlugin gmaPlugin =
+        (GoogleMobileAdsPlugin) engine.getPlugins().get(GoogleMobileAdsPlugin.class);
+    if (gmaPlugin == null) {
+      return false;
+    }
+    gmaPlugin.mediationNetworkExtrasProvider = mediationNetworkExtrasProvider;
+    if (gmaPlugin.adMessageCodec != null) {
+      gmaPlugin.adMessageCodec.setMediationNetworkExtrasProvider(mediationNetworkExtrasProvider);
+    }
+    return true;
+  }
+
   private static boolean registerNativeAdFactory(
       GoogleMobileAdsPlugin plugin, String factoryId, NativeAdFactory nativeAdFactory) {
     if (plugin == null) {
@@ -177,6 +194,9 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
   public void onAttachedToEngine(FlutterPluginBinding binding) {
     pluginBinding = binding;
     adMessageCodec = new AdMessageCodec(binding.getApplicationContext());
+    if (mediationNetworkExtrasProvider != null) {
+      adMessageCodec.setMediationNetworkExtrasProvider(mediationNetworkExtrasProvider);
+    }
     final MethodChannel channel =
         new MethodChannel(
             binding.getBinaryMessenger(),

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/MediationNetworkExtrasProvider.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/MediationNetworkExtrasProvider.java
@@ -23,7 +23,7 @@ import java.util.Map;
 /**
  * Provides network specific parameters when constructing an ad request.
  *
- * After you register a {@code MediationNetworkExtrasProvider} using {@link
+ * <p>After you register a {@code MediationNetworkExtrasProvider} using {@link
  * GoogleMobileAdsPlugin#registerMediationNetworkExtrasProvider(FlutterEngine,
  * MediationNetworkExtrasProvider)}, the plugin will use it to pass extras when constructing ad
  * requests.
@@ -32,8 +32,8 @@ public interface MediationNetworkExtrasProvider {
 
   /**
    * Gets mediation extras that should be included for an ad request with the {@code adUnitId} and
-   * {@code identifier}, as a map from adapter classes to their corresponding extras bundle.
-   * You can refer to each network's <a
+   * {@code identifier}, as a map from adapter classes to their corresponding extras bundle. You can
+   * refer to each network's <a
    * href="https://developers.google.com/admob/android/mediation/applovin#network-specific_parameters">documentation</a>
    * to see how to find the corresponding adapter class and create its extras. This will be called
    * whenever the plugin creates an ad request.

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/MediationNetworkExtrasProvider.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/MediationNetworkExtrasProvider.java
@@ -1,0 +1,32 @@
+package io.flutter.plugins.googlemobileads;
+
+import android.os.Bundle;
+import androidx.annotation.Nullable;
+import com.google.android.gms.ads.mediation.MediationExtrasReceiver;
+import io.flutter.embedding.engine.FlutterEngine;
+import java.util.Map;
+
+/**
+ * Provides mediation extras for ad requests.
+ * TODO - reword this
+ * If you wish to provide mediation extras, implement
+ * this interface and provide an instance to
+ * {@link GoogleMobileAdsPlugin#registerMediationNetworkExtrasProvider(FlutterEngine,
+ * MediationNetworkExtrasProvider)}.
+ */
+public interface MediationNetworkExtrasProvider {
+
+  /**
+   * Gets mediation extras that should be included for an ad request for the {@code adUnitId}
+   * and {@code identifier}.
+   *
+   * @param adUnitId The ad unit for the associated ad request.
+   * @param identifier An optional identifier that comes from the associated ad request. This value
+   *                   can be provided when creating the dart ad request object, if you want to
+   *                   additional customization of mediation extras. TODO - reword this.
+   *
+   */
+  Map<Class<? extends MediationExtrasReceiver>, Bundle> getMediationExtras(
+      String adUnitId,
+      @Nullable String identifier);
+}

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/MediationNetworkExtrasProvider.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/MediationNetworkExtrasProvider.java
@@ -7,26 +7,31 @@ import io.flutter.embedding.engine.FlutterEngine;
 import java.util.Map;
 
 /**
- * Provides mediation extras for ad requests.
- * TODO - reword this
- * If you wish to provide mediation extras, implement
- * this interface and provide an instance to
- * {@link GoogleMobileAdsPlugin#registerMediationNetworkExtrasProvider(FlutterEngine,
- * MediationNetworkExtrasProvider)}.
+ * Provides network specific parameters when constructing an ad request.
+ *
+ * After you register a {@code MediationNetworkExtrasProvider} using {@link
+ * GoogleMobileAdsPlugin#registerMediationNetworkExtrasProvider(FlutterEngine,
+ * MediationNetworkExtrasProvider)}, the plugin will use it to pass extras when constructing ad
+ * requests.
  */
 public interface MediationNetworkExtrasProvider {
 
   /**
-   * Gets mediation extras that should be included for an ad request for the {@code adUnitId}
-   * and {@code identifier}.
+   * Gets mediation extras that should be included for an ad request with the {@code adUnitId} and
+   * {@code identifier}, as a map from adapter classes to their corresponding extras bundle.
+   * You can refer to each network's <a
+   * href="https://developers.google.com/admob/android/mediation/applovin#network-specific_parameters">documentation</a>
+   * to see how to find the corresponding adapter class and create its extras. This will be called
+   * whenever the plugin creates an ad request.
    *
    * @param adUnitId The ad unit for the associated ad request.
-   * @param identifier An optional identifier that comes from the associated ad request. This value
-   *                   can be provided when creating the dart ad request object, if you want to
-   *                   additional customization of mediation extras. TODO - reword this.
-   *
+   * @param identifier An optional identifier that comes from the associated dart ad request object.
+   *     This allows for additional control of which extras to include for an ad request, beyond
+   *     just the ad unit.
+   * @return A map of mediation adapter classes to their extras that should be included in the ad
+   *     request. If {@code null} is returned then no extras are added.
    */
+  @Nullable
   Map<Class<? extends MediationExtrasReceiver>, Bundle> getMediationExtras(
-      String adUnitId,
-      @Nullable String identifier);
+      String adUnitId, @Nullable String identifier);
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/MediationNetworkExtrasProvider.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/MediationNetworkExtrasProvider.java
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package io.flutter.plugins.googlemobileads;
 
 import android.os.Bundle;

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
@@ -258,6 +258,7 @@ public class AdMessageCodecTest {
             .setNeighboringContentUrls(Arrays.asList("example.com", "test.com"))
             .setHttpTimeoutMillis(1000)
             .setLocation(location)
+            .setMediationNetworkExtrasIdentifier("identifier")
             .build();
     final ByteBuffer message = codec.encodeMessage(adRequest);
 
@@ -282,6 +283,7 @@ public class AdMessageCodecTest {
     builder.setNonPersonalizedAds(true);
     builder.setPublisherProvidedId("pub-provided-id");
     builder.setLocation(location);
+    builder.setMediationNetworkExtrasIdentifier("identifier");
     FlutterAdManagerAdRequest flutterAdManagerAdRequest = builder.build();
 
     final ByteBuffer message = codec.encodeMessage(flutterAdManagerAdRequest);

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FluidAdManagerBannerAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FluidAdManagerBannerAdTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -65,7 +66,7 @@ public class FluidAdManagerBannerAdTest {
     mockManager = spy(new AdInstanceManager(mock(MethodChannel.class)));
     FlutterAdManagerAdRequest mockFlutterAdRequest = mock(FlutterAdManagerAdRequest.class);
     mockAdRequest = mock(AdManagerAdRequest.class);
-    when(mockFlutterAdRequest.asAdManagerAdRequest()).thenReturn(mockAdRequest);
+    when(mockFlutterAdRequest.asAdManagerAdRequest(anyString())).thenReturn(mockAdRequest);
     BannerAdCreator bannerAdCreator = mock(BannerAdCreator.class);
     mockAdView = mock(AdManagerAdView.class);
     doReturn(mockAdView).when(bannerAdCreator).createAdManagerAdView();

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequestTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequestTest.java
@@ -1,0 +1,124 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.flutter.plugins.googlemobileads;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import android.location.Location;
+import android.os.Bundle;
+import com.google.ads.mediation.admob.AdMobAdapter;
+import com.google.android.gms.ads.admanager.AdManagerAdRequest;
+import io.flutter.plugins.googlemobileads.FlutterAdManagerAdRequest.Builder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/** Tests for {@link FlutterAdManagerAdRequest}. */
+@RunWith(RobolectricTestRunner.class)
+public class FlutterAdManagerAdRequestTest {
+
+  @Test
+  public void testAsAdRequest_noParams() {
+    FlutterAdManagerAdRequest flutterAdRequest = new Builder().build();
+    AdManagerAdRequest adRequest = flutterAdRequest.asAdManagerAdRequest("test-ad-unit");
+    assertNull(adRequest.getContentUrl());
+    assertTrue(adRequest.getNeighboringContentUrls().isEmpty());
+    assertTrue(adRequest.getKeywords().isEmpty());
+    assertTrue(adRequest.getCustomTargeting().isEmpty());
+    assertNull(adRequest.getLocation());
+    assertNull(adRequest.getPublisherProvidedId());
+    assertNull(adRequest.getNetworkExtrasBundle(AdMobAdapter.class));
+  }
+
+  @Test
+  public void testAsAdRequest_allParams() {
+    Location location = new Location("");
+    location.setAccuracy(1);
+    location.setLongitude(2);
+    location.setLatitude(3);
+    location.setTime(12345);
+
+    MediationNetworkExtrasProvider provider = mock(MediationNetworkExtrasProvider.class);
+    Bundle bundle = new Bundle();
+    bundle.putString("npa", "0");
+    doReturn(Collections.singletonMap(AdMobAdapter.class, bundle))
+        .when(provider)
+        .getMediationExtras(eq("test-ad-unit"), eq("identifier"));
+
+    Builder builder = new Builder();
+    builder.setLocation(location);
+    builder.setKeywords(Collections.singletonList("keyword"));
+    builder.setContentUrl("content-url");
+    builder.setNeighboringContentUrls(Collections.singletonList("neighbor"));
+    builder.setHttpTimeoutMillis(100);
+    builder.setNonPersonalizedAds(true);
+    builder.setMediationNetworkExtrasIdentifier("identifier");
+    builder.setMediationNetworkExtrasProvider(provider);
+    builder.setCustomTargeting(Collections.singletonMap("targetingKey", "targetingValue"));
+    List<String> targetingList = new ArrayList<>();
+    targetingList.add("targetingValue1");
+    targetingList.add("targetingValue2");
+
+    builder.setCustomTargetingLists(Collections.singletonMap("targetingKey", targetingList));
+    builder.setPublisherProvidedId("pubProvidedId");
+    builder.build();
+
+    AdManagerAdRequest adRequest = builder.build().asAdManagerAdRequest("test-ad-unit");
+
+    assertEquals(adRequest.getKeywords(), Collections.singleton("keyword"));
+    assertEquals(adRequest.getContentUrl(), "content-url");
+    assertEquals(adRequest.getNeighboringContentUrls(), Collections.singletonList("neighbor"));
+    assertEquals(adRequest.getLocation().getAccuracy(), 1, 0);
+    assertEquals(adRequest.getLocation().getLongitude(), 2, 0);
+    assertEquals(adRequest.getLocation().getLatitude(), 3, 0);
+    assertEquals(adRequest.getLocation().getTime(), 12345);
+    // Previous value of "npa" should get overridden.
+    assertEquals(adRequest.getNetworkExtrasBundle(AdMobAdapter.class).get("npa"), "1");
+    assertEquals(adRequest.getPublisherProvidedId(), "pubProvidedId");
+    assertFalse(adRequest.getCustomTargeting().isEmpty());
+    // If custom targeting keys match, the values are overwritten.
+    assertEquals(
+        adRequest.getCustomTargeting().get("targetingKey"), "targetingValue1,targetingValue2");
+  }
+
+  @Test
+  public void testAsAdRequestMediationNetworkExtras() {
+    MediationNetworkExtrasProvider provider = mock(MediationNetworkExtrasProvider.class);
+    Bundle bundle = new Bundle();
+    bundle.putString("key", "value");
+    doReturn(Collections.singletonMap(AdMobAdapter.class, bundle))
+        .when(provider)
+        .getMediationExtras(eq("test-ad-unit"), eq("identifier"));
+
+    Builder builder = new Builder();
+    builder
+        .setMediationNetworkExtrasIdentifier("identifier")
+        .setMediationNetworkExtrasProvider(provider)
+        .setNonPersonalizedAds(true);
+
+    AdManagerAdRequest adRequest = builder.build().asAdManagerAdRequest("test-ad-unit");
+    assertEquals(adRequest.getNetworkExtrasBundle(AdMobAdapter.class).get("key"), "value");
+    assertEquals(adRequest.getNetworkExtrasBundle(AdMobAdapter.class).get("npa"), "1");
+  }
+}

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerBannerAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerBannerAdTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -67,7 +68,7 @@ public class FlutterAdManagerBannerAdTest {
     mockAdRequest = mock(AdManagerAdRequest.class);
     FlutterAdSize mockFlutterAdSize = mock(FlutterAdSize.class);
     adSize = new AdSize(1, 2);
-    when(mockFlutterAdRequest.asAdManagerAdRequest()).thenReturn(mockAdRequest);
+    when(mockFlutterAdRequest.asAdManagerAdRequest(anyString())).thenReturn(mockAdRequest);
     when(mockFlutterAdSize.getAdSize()).thenReturn(adSize);
     List<FlutterAdSize> sizes = new ArrayList<>();
     sizes.add(mockFlutterAdSize);

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerInterstitialAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerInterstitialAdTest.java
@@ -64,7 +64,7 @@ public class FlutterAdManagerInterstitialAdTest {
     final FlutterAdManagerAdRequest mockFlutterRequest = mock(FlutterAdManagerAdRequest.class);
     mockRequest = mock(AdManagerAdRequest.class);
     mockFlutterAdLoader = mock(FlutterAdLoader.class);
-    when(mockFlutterRequest.asAdManagerAdRequest()).thenReturn(mockRequest);
+    when(mockFlutterRequest.asAdManagerAdRequest(anyString())).thenReturn(mockRequest);
     flutterAdManagerInterstitialAd =
         new FlutterAdManagerInterstitialAd(
             1, mockManager, "testId", mockFlutterRequest, mockFlutterAdLoader);

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdRequestTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdRequestTest.java
@@ -1,0 +1,109 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.flutter.plugins.googlemobileads;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import android.location.Location;
+import android.os.Bundle;
+import com.google.ads.mediation.admob.AdMobAdapter;
+import com.google.android.gms.ads.AdRequest;
+import io.flutter.plugins.googlemobileads.FlutterAdRequest.Builder;
+import java.util.Collections;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/** Tests for {@link FlutterAdRequest}. */
+@RunWith(RobolectricTestRunner.class)
+public class FlutterAdRequestTest {
+
+  @Test
+  public void testAsAdRequest_noParams() {
+    FlutterAdRequest flutterAdRequest = new Builder().build();
+    AdRequest adRequest = flutterAdRequest.asAdRequest("test-ad-unit");
+    assertNull(adRequest.getContentUrl());
+    assertTrue(adRequest.getNeighboringContentUrls().isEmpty());
+    assertTrue(adRequest.getKeywords().isEmpty());
+    assertNull(adRequest.getLocation());
+    assertNull(adRequest.getNetworkExtrasBundle(AdMobAdapter.class));
+  }
+
+  @Test
+  public void testAsAdRequest_allParams() {
+    Location location = new Location("");
+    location.setAccuracy(1);
+    location.setLongitude(2);
+    location.setLatitude(3);
+    location.setTime(12345);
+
+    MediationNetworkExtrasProvider provider = mock(MediationNetworkExtrasProvider.class);
+    Bundle bundle = new Bundle();
+    bundle.putString("npa", "0");
+    doReturn(Collections.singletonMap(AdMobAdapter.class, bundle))
+        .when(provider)
+        .getMediationExtras(eq("test-ad-unit"), eq("identifier"));
+
+    FlutterAdRequest flutterAdRequest =
+        new Builder()
+            .setLocation(location)
+            .setKeywords(Collections.singletonList("keyword"))
+            .setContentUrl("content-url")
+            .setNeighboringContentUrls(Collections.singletonList("neighbor"))
+            .setHttpTimeoutMillis(100)
+            .setNonPersonalizedAds(true)
+            .setMediationNetworkExtrasIdentifier("identifier")
+            .setMediationNetworkExtrasProvider(provider)
+            .build();
+
+    AdRequest adRequest = flutterAdRequest.asAdRequest("test-ad-unit");
+
+    assertEquals(adRequest.getKeywords(), Collections.singleton("keyword"));
+    assertEquals(adRequest.getContentUrl(), "content-url");
+    assertEquals(adRequest.getNeighboringContentUrls(), Collections.singletonList("neighbor"));
+    assertEquals(adRequest.getLocation().getAccuracy(), 1, 0);
+    assertEquals(adRequest.getLocation().getLongitude(), 2, 0);
+    assertEquals(adRequest.getLocation().getLatitude(), 3, 0);
+    assertEquals(adRequest.getLocation().getTime(), 12345);
+    // Previous value of "npa" should get overridden.
+    assertEquals(adRequest.getNetworkExtrasBundle(AdMobAdapter.class).get("npa"), "1");
+  }
+
+  @Test
+  public void testAsAdRequestMediationNetworkExtras() {
+    MediationNetworkExtrasProvider provider = mock(MediationNetworkExtrasProvider.class);
+    Bundle bundle = new Bundle();
+    bundle.putString("key", "value");
+    doReturn(Collections.singletonMap(AdMobAdapter.class, bundle))
+        .when(provider)
+        .getMediationExtras(eq("test-ad-unit"), eq("identifier"));
+
+    FlutterAdRequest flutterAdRequest =
+        new Builder()
+            .setMediationNetworkExtrasIdentifier("identifier")
+            .setMediationNetworkExtrasProvider(provider)
+            .setNonPersonalizedAds(true)
+            .build();
+
+    AdRequest adRequest = flutterAdRequest.asAdRequest("test-ad-unit");
+    assertEquals(adRequest.getNetworkExtrasBundle(AdMobAdapter.class).get("key"), "value");
+    assertEquals(adRequest.getNetworkExtrasBundle(AdMobAdapter.class).get("npa"), "1");
+  }
+}

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAppOpenAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAppOpenAdTest.java
@@ -72,7 +72,7 @@ public class FlutterAppOpenAdTest {
   private void setupAdmobMocks() {
     FlutterAdRequest mockFlutterAdRequest = mock(FlutterAdRequest.class);
     mockAdRequest = mock(AdRequest.class);
-    when(mockFlutterAdRequest.asAdRequest()).thenReturn(mockAdRequest);
+    when(mockFlutterAdRequest.asAdRequest(anyString())).thenReturn(mockAdRequest);
     flutterAppOpenAd =
         new FlutterAppOpenAd(
             1, 2, mockManager, "testId", mockFlutterAdRequest, null, mockFlutterAdLoader);
@@ -81,7 +81,8 @@ public class FlutterAppOpenAdTest {
   private void setupAdManagerMocks() {
     FlutterAdManagerAdRequest mockAdManagerFlutterRequest = mock(FlutterAdManagerAdRequest.class);
     mockAdManagerAdRequest = mock(AdManagerAdRequest.class);
-    when(mockAdManagerFlutterRequest.asAdManagerAdRequest()).thenReturn(mockAdManagerAdRequest);
+    when(mockAdManagerFlutterRequest.asAdManagerAdRequest(anyString()))
+        .thenReturn(mockAdManagerAdRequest);
     flutterAppOpenAd =
         new FlutterAppOpenAd(
             1, 2, mockManager, "testId", null, mockAdManagerFlutterRequest, mockFlutterAdLoader);

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterBannerAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterBannerAdTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -66,7 +67,7 @@ public class FlutterBannerAdTest {
     mockAdRequest = mock(AdRequest.class);
     final FlutterAdSize mockFlutterAdSize = mock(FlutterAdSize.class);
     adSize = new AdSize(1, 2);
-    when(mockFlutterRequest.asAdRequest()).thenReturn(mockAdRequest);
+    when(mockFlutterRequest.asAdRequest(anyString())).thenReturn(mockAdRequest);
     when(mockFlutterAdSize.getAdSize()).thenReturn(adSize);
     BannerAdCreator bannerAdCreator = mock(BannerAdCreator.class);
     mockAdView = mock(AdView.class);

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterInterstitialAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterInterstitialAdTest.java
@@ -64,7 +64,7 @@ public class FlutterInterstitialAdTest {
     final FlutterAdRequest mockFlutterRequest = mock(FlutterAdRequest.class);
     mockAdRequest = mock(AdRequest.class);
     mockFlutterAdLoader = mock(FlutterAdLoader.class);
-    when(mockFlutterRequest.asAdRequest()).thenReturn(mockAdRequest);
+    when(mockFlutterRequest.asAdRequest(anyString())).thenReturn(mockAdRequest);
 
     flutterInterstitialAd =
         new FlutterInterstitialAd(

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterNativeAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterNativeAdTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -68,7 +69,7 @@ public class FlutterNativeAdTest {
   public void loadNativeAdWithAdManagerAdRequest() {
     final FlutterAdManagerAdRequest mockFlutterRequest = mock(FlutterAdManagerAdRequest.class);
     final AdManagerAdRequest mockRequest = mock(AdManagerAdRequest.class);
-    when(mockFlutterRequest.asAdManagerAdRequest()).thenReturn(mockRequest);
+    when(mockFlutterRequest.asAdManagerAdRequest(anyString())).thenReturn(mockRequest);
     FlutterAdLoader mockLoader = mock(FlutterAdLoader.class);
     NativeAdFactory mockNativeAdFactory = mock(NativeAdFactory.class);
     @SuppressWarnings("unchecked")
@@ -166,7 +167,7 @@ public class FlutterNativeAdTest {
   public void loadNativeAdWithAdRequest() {
     final FlutterAdRequest mockFlutterRequest = mock(FlutterAdRequest.class);
     final AdRequest mockRequest = mock(AdRequest.class);
-    when(mockFlutterRequest.asAdRequest()).thenReturn(mockRequest);
+    when(mockFlutterRequest.asAdRequest(anyString())).thenReturn(mockRequest);
     FlutterAdLoader mockLoader = mock(FlutterAdLoader.class);
     NativeAdFactory mockNativeAdFactory = mock(GoogleMobileAdsPlugin.NativeAdFactory.class);
     NativeAdView mockNativeAdView = mock(NativeAdView.class);

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterRewardedAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterRewardedAdTest.java
@@ -77,7 +77,7 @@ public class FlutterRewardedAdTest {
   private void setupAdmobMocks(@Nullable FlutterServerSideVerificationOptions options) {
     FlutterAdRequest mockFlutterAdRequest = mock(FlutterAdRequest.class);
     mockAdRequest = mock(AdRequest.class);
-    when(mockFlutterAdRequest.asAdRequest()).thenReturn(mockAdRequest);
+    when(mockFlutterAdRequest.asAdRequest(anyString())).thenReturn(mockAdRequest);
     flutterRewardedAd =
         new FlutterRewardedAd(
             1, mockManager, "testId", mockFlutterAdRequest, options, mockFlutterAdLoader);
@@ -86,7 +86,8 @@ public class FlutterRewardedAdTest {
   private void setupAdManagerMocks(@Nullable FlutterServerSideVerificationOptions options) {
     FlutterAdManagerAdRequest mockAdManagerFlutterRequest = mock(FlutterAdManagerAdRequest.class);
     mockAdManagerAdRequest = mock(AdManagerAdRequest.class);
-    when(mockAdManagerFlutterRequest.asAdManagerAdRequest()).thenReturn(mockAdManagerAdRequest);
+    when(mockAdManagerFlutterRequest.asAdManagerAdRequest(anyString()))
+        .thenReturn(mockAdManagerAdRequest);
     flutterRewardedAd =
         new FlutterRewardedAd(
             1, mockManager, "testId", mockAdManagerFlutterRequest, options, mockFlutterAdLoader);

--- a/packages/google_mobile_ads/example/ios/Podfile
+++ b/packages/google_mobile_ads/example/ios/Podfile
@@ -39,5 +39,5 @@ end
 
 # Add test dependency matching google_mobile_ads.podspec.
 target 'google_mobile_ads_exampleTests' do
-  pod 'OCMock','3.5'
+  pod 'OCMock','3.6'
 end

--- a/packages/google_mobile_ads/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/google_mobile_ads/example/ios/Runner.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		9E4163BA26CCE99300220C78 /* FLTAppOpenAdTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FLTAppOpenAdTest.m; path = ../../../ios/Tests/FLTAppOpenAdTest.m; sourceTree = "<group>"; };
 		9E5A534726AA235D00B9438D /* FLTAdUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FLTAdUtil.h; path = ../../ios/Classes/FLTAdUtil.h; sourceTree = "<group>"; };
 		9E5A534826AA235D00B9438D /* FLTAdUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FLTAdUtil.m; path = ../../ios/Classes/FLTAdUtil.m; sourceTree = "<group>"; };
+		9E79682A271D415600E06158 /* FLTMediationNetworkExtrasProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FLTMediationNetworkExtrasProvider.h; path = ../../ios/Classes/FLTMediationNetworkExtrasProvider.h; sourceTree = "<group>"; };
 		9EA7213525BB6464008D57E3 /* GoogleMobileAds.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GoogleMobileAds.xcframework; path = "Pods/Google-Mobile-Ads-SDK/Frameworks/GoogleMobileAdsFramework-Current/GoogleMobileAds.xcframework"; sourceTree = "<group>"; };
 		9EA7474C2637CD6800E0B0E4 /* FLTBannerAdTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FLTBannerAdTest.m; path = ../../../ios/Tests/FLTBannerAdTest.m; sourceTree = "<group>"; };
 		9EA7474D2637CD6800E0B0E4 /* FLTGAMBannerAdTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FLTGAMBannerAdTest.m; path = ../../../ios/Tests/FLTGAMBannerAdTest.m; sourceTree = "<group>"; };
@@ -200,6 +201,7 @@
 		97C146E51CF9000F007C117D = {
 			isa = PBXGroup;
 			children = (
+				9E79682A271D415600E06158 /* FLTMediationNetworkExtrasProvider.h */,
 				9E5A534726AA235D00B9438D /* FLTAdUtil.h */,
 				9E5A534826AA235D00B9438D /* FLTAdUtil.m */,
 				9EF4E6FB26392B230007E4FE /* FLTAd_Internal.h */,

--- a/packages/google_mobile_ads/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/google_mobile_ads/example/ios/Runner.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		9E4163BB26CCE99400220C78 /* FLTAppOpenAdTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E4163BA26CCE99300220C78 /* FLTAppOpenAdTest.m */; };
 		9E5A534926AA235D00B9438D /* FLTAdUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E5A534826AA235D00B9438D /* FLTAdUtil.m */; };
+		9E79684A271FF40900E06158 /* FLTAdRequestTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E796848271FF40900E06158 /* FLTAdRequestTest.m */; };
+		9E79684B271FF40900E06158 /* FLTGAMAdRequestTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E796849271FF40900E06158 /* FLTGAMAdRequestTest.m */; };
 		9EA7213725BB6517008D57E3 /* GoogleMobileAds.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EA7213525BB6464008D57E3 /* GoogleMobileAds.xcframework */; };
 		9EA7213825BB6530008D57E3 /* GoogleMobileAds.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EA7213525BB6464008D57E3 /* GoogleMobileAds.xcframework */; };
 		9EA7474E2637CD6800E0B0E4 /* FLTBannerAdTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EA7474C2637CD6800E0B0E4 /* FLTBannerAdTest.m */; };
@@ -44,7 +46,7 @@
 		9EF4E70C26392B230007E4FE /* FLTMobileAds_Internal.h in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4E6FF26392B230007E4FE /* FLTMobileAds_Internal.h */; };
 		9EF4E7102639410D0007E4FE /* FLTRewardedAdTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4E70F2639410D0007E4FE /* FLTRewardedAdTest.m */; };
 		9EF4E7142639D4B30007E4FE /* FLTNativeAdTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4E7132639D4B30007E4FE /* FLTNativeAdTest.m */; };
-		D2CF0978BD94BAEAD9E443C4 /* libPods-google_mobile_ads_exampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F8AB4520D15662F521C33C38 /* libPods-google_mobile_ads_exampleTests.a */; };
+		C4247E08A145B7C14603446E /* libPods-google_mobile_ads_exampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BDCE5C673B60CB3659CEFE9 /* libPods-google_mobile_ads_exampleTests.a */; };
 		FBE669D215209F1F44CEEB21 /* libPods-Runner.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F369F228D3A43519CEE308 /* libPods-Runner.a */; };
 /* End PBXBuildFile section */
 
@@ -74,7 +76,9 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		185186B2D682FC21FE7F9077 /* Pods-google_mobile_ads_exampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-google_mobile_ads_exampleTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-google_mobile_ads_exampleTests/Pods-google_mobile_ads_exampleTests.release.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		6BDCE5C673B60CB3659CEFE9 /* libPods-google_mobile_ads_exampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-google_mobile_ads_exampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		7AFFD8ED1D35381100E5BB4D /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		7AFFD8EE1D35381100E5BB4D /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -96,6 +100,8 @@
 		9E5A534726AA235D00B9438D /* FLTAdUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FLTAdUtil.h; path = ../../ios/Classes/FLTAdUtil.h; sourceTree = "<group>"; };
 		9E5A534826AA235D00B9438D /* FLTAdUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FLTAdUtil.m; path = ../../ios/Classes/FLTAdUtil.m; sourceTree = "<group>"; };
 		9E79682A271D415600E06158 /* FLTMediationNetworkExtrasProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FLTMediationNetworkExtrasProvider.h; path = ../../ios/Classes/FLTMediationNetworkExtrasProvider.h; sourceTree = "<group>"; };
+		9E796848271FF40900E06158 /* FLTAdRequestTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FLTAdRequestTest.m; path = ../../../ios/Tests/FLTAdRequestTest.m; sourceTree = "<group>"; };
+		9E796849271FF40900E06158 /* FLTGAMAdRequestTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FLTGAMAdRequestTest.m; path = ../../../ios/Tests/FLTGAMAdRequestTest.m; sourceTree = "<group>"; };
 		9EA7213525BB6464008D57E3 /* GoogleMobileAds.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GoogleMobileAds.xcframework; path = "Pods/Google-Mobile-Ads-SDK/Frameworks/GoogleMobileAdsFramework-Current/GoogleMobileAds.xcframework"; sourceTree = "<group>"; };
 		9EA7474C2637CD6800E0B0E4 /* FLTBannerAdTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FLTBannerAdTest.m; path = ../../../ios/Tests/FLTBannerAdTest.m; sourceTree = "<group>"; };
 		9EA7474D2637CD6800E0B0E4 /* FLTGAMBannerAdTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FLTGAMBannerAdTest.m; path = ../../../ios/Tests/FLTGAMBannerAdTest.m; sourceTree = "<group>"; };
@@ -118,11 +124,9 @@
 		9EF4E6FF26392B230007E4FE /* FLTMobileAds_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FLTMobileAds_Internal.h; path = ../../ios/Classes/FLTMobileAds_Internal.h; sourceTree = "<group>"; };
 		9EF4E70F2639410D0007E4FE /* FLTRewardedAdTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FLTRewardedAdTest.m; path = ../../../ios/Tests/FLTRewardedAdTest.m; sourceTree = "<group>"; };
 		9EF4E7132639D4B30007E4FE /* FLTNativeAdTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FLTNativeAdTest.m; path = ../../../ios/Tests/FLTNativeAdTest.m; sourceTree = "<group>"; };
-		BC01F2AA74ECDC9497A31EF6 /* Pods-google_mobile_ads_exampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-google_mobile_ads_exampleTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-google_mobile_ads_exampleTests/Pods-google_mobile_ads_exampleTests.release.xcconfig"; sourceTree = "<group>"; };
 		CE82265EF05E2A9632B25E60 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		E7E26991231DD855BEEE69EB /* Pods-google_mobile_ads_exampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-google_mobile_ads_exampleTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-google_mobile_ads_exampleTests/Pods-google_mobile_ads_exampleTests.debug.xcconfig"; sourceTree = "<group>"; };
 		F74051031B69F8124E38352E /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
-		F8AB4520D15662F521C33C38 /* libPods-google_mobile_ads_exampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-google_mobile_ads_exampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FC33B87979513A77136D4557 /* Pods-google_mobile_ads_exampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-google_mobile_ads_exampleTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-google_mobile_ads_exampleTests/Pods-google_mobile_ads_exampleTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -131,7 +135,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9EA7213725BB6517008D57E3 /* GoogleMobileAds.xcframework in Frameworks */,
-				D2CF0978BD94BAEAD9E443C4 /* libPods-google_mobile_ads_exampleTests.a in Frameworks */,
+				C4247E08A145B7C14603446E /* libPods-google_mobile_ads_exampleTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -152,8 +156,8 @@
 			children = (
 				CE82265EF05E2A9632B25E60 /* Pods-Runner.debug.xcconfig */,
 				F74051031B69F8124E38352E /* Pods-Runner.release.xcconfig */,
-				FC33B87979513A77136D4557 /* Pods-google_mobile_ads_exampleTests.debug.xcconfig */,
-				BC01F2AA74ECDC9497A31EF6 /* Pods-google_mobile_ads_exampleTests.release.xcconfig */,
+				E7E26991231DD855BEEE69EB /* Pods-google_mobile_ads_exampleTests.debug.xcconfig */,
+				185186B2D682FC21FE7F9077 /* Pods-google_mobile_ads_exampleTests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -163,7 +167,7 @@
 			children = (
 				9EA7213525BB6464008D57E3 /* GoogleMobileAds.xcframework */,
 				83F369F228D3A43519CEE308 /* libPods-Runner.a */,
-				F8AB4520D15662F521C33C38 /* libPods-google_mobile_ads_exampleTests.a */,
+				6BDCE5C673B60CB3659CEFE9 /* libPods-google_mobile_ads_exampleTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -171,6 +175,8 @@
 		8FB13CD3248F07B80011A72F /* google_mobile_ads_exampleTests */ = {
 			isa = PBXGroup;
 			children = (
+				9E796848271FF40900E06158 /* FLTAdRequestTest.m */,
+				9E796849271FF40900E06158 /* FLTGAMAdRequestTest.m */,
 				9EDE65D526F9300000783049 /* FLTFluidGAMBannerAdTest.m */,
 				9E4163BA26CCE99300220C78 /* FLTAppOpenAdTest.m */,
 				9EF4E7132639D4B30007E4FE /* FLTNativeAdTest.m */,
@@ -267,7 +273,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8FB13CDB248F07B80011A72F /* Build configuration list for PBXNativeTarget "google_mobile_ads_exampleTests" */;
 			buildPhases = (
-				58394F97FF6A7510BAED57E1 /* [CP] Check Pods Manifest.lock */,
+				2A2457F6E7000417AF1E283D /* [CP] Check Pods Manifest.lock */,
 				8FB13CCE248F07B80011A72F /* Sources */,
 				8FB13CCF248F07B80011A72F /* Frameworks */,
 				8FB13CD0248F07B80011A72F /* Resources */,
@@ -368,6 +374,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		2A2457F6E7000417AF1E283D /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-google_mobile_ads_exampleTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		2C1A4E9A6849F7CC6B679EA5 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -399,28 +427,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed\n/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" thin\n";
-		};
-		58394F97FF6A7510BAED57E1 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-google_mobile_ads_exampleTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -460,6 +466,8 @@
 				9EDE65D626F9300000783049 /* FLTFluidGAMBannerAdTest.m in Sources */,
 				9EF4E70B26392B230007E4FE /* FLTGoogleMobileAdsCollection_Internal.m in Sources */,
 				9EF4E70C26392B230007E4FE /* FLTMobileAds_Internal.h in Sources */,
+				9E79684B271FF40900E06158 /* FLTGAMAdRequestTest.m in Sources */,
+				9E79684A271FF40900E06158 /* FLTAdRequestTest.m in Sources */,
 				9EA7474F2637CD6800E0B0E4 /* FLTGAMBannerAdTest.m in Sources */,
 				8FB13CDD248F07D90011A72F /* FLTGoogleMobileAdsTest.m in Sources */,
 				9EF4E7142639D4B30007E4FE /* FLTNativeAdTest.m in Sources */,
@@ -513,7 +521,7 @@
 /* Begin XCBuildConfiguration section */
 		8FB13CD9248F07B80011A72F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FC33B87979513A77136D4557 /* Pods-google_mobile_ads_exampleTests.debug.xcconfig */;
+			baseConfigurationReference = E7E26991231DD855BEEE69EB /* Pods-google_mobile_ads_exampleTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -550,7 +558,7 @@
 		};
 		8FB13CDA248F07B80011A72F /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BC01F2AA74ECDC9497A31EF6 /* Pods-google_mobile_ads_exampleTests.release.xcconfig */;
+			baseConfigurationReference = 185186B2D682FC21FE7F9077 /* Pods-google_mobile_ads_exampleTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;

--- a/packages/google_mobile_ads/example/ios/Runner/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/packages/google_mobile_ads/example/ios/Runner/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,116 +1,121 @@
 {
   "images" : [
     {
-      "size" : "20x20",
-      "idiom" : "iphone",
       "filename" : "Icon-App-20x20@2x.png",
-      "scale" : "2x"
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
-      "size" : "20x20",
-      "idiom" : "iphone",
       "filename" : "Icon-App-20x20@3x.png",
-      "scale" : "3x"
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
     },
     {
-      "size" : "29x29",
-      "idiom" : "iphone",
       "filename" : "Icon-App-29x29@1x.png",
-      "scale" : "1x"
+      "idiom" : "iphone",
+      "scale" : "1x",
+      "size" : "29x29"
     },
     {
-      "size" : "29x29",
-      "idiom" : "iphone",
       "filename" : "Icon-App-29x29@2x.png",
-      "scale" : "2x"
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
     },
     {
-      "size" : "29x29",
-      "idiom" : "iphone",
       "filename" : "Icon-App-29x29@3x.png",
-      "scale" : "3x"
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
     },
     {
-      "size" : "40x40",
-      "idiom" : "iphone",
       "filename" : "Icon-App-40x40@2x.png",
-      "scale" : "2x"
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
     },
     {
-      "size" : "40x40",
-      "idiom" : "iphone",
       "filename" : "Icon-App-40x40@3x.png",
-      "scale" : "3x"
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
     },
     {
-      "size" : "60x60",
-      "idiom" : "iphone",
       "filename" : "Icon-App-60x60@2x.png",
-      "scale" : "2x"
-    },
-    {
-      "size" : "60x60",
       "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
       "filename" : "Icon-App-60x60@3x.png",
-      "scale" : "3x"
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
     },
     {
-      "size" : "20x20",
-      "idiom" : "ipad",
       "filename" : "Icon-App-20x20@1x.png",
-      "scale" : "1x"
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
     },
     {
-      "size" : "20x20",
-      "idiom" : "ipad",
       "filename" : "Icon-App-20x20@2x.png",
-      "scale" : "2x"
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
-      "size" : "29x29",
-      "idiom" : "ipad",
       "filename" : "Icon-App-29x29@1x.png",
-      "scale" : "1x"
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
     },
     {
-      "size" : "29x29",
-      "idiom" : "ipad",
       "filename" : "Icon-App-29x29@2x.png",
-      "scale" : "2x"
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
     },
     {
-      "size" : "40x40",
-      "idiom" : "ipad",
       "filename" : "Icon-App-40x40@1x.png",
-      "scale" : "1x"
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
     },
     {
-      "size" : "40x40",
-      "idiom" : "ipad",
       "filename" : "Icon-App-40x40@2x.png",
-      "scale" : "2x"
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
     },
     {
-      "size" : "76x76",
-      "idiom" : "ipad",
       "filename" : "Icon-App-76x76@1x.png",
-      "scale" : "1x"
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
     },
     {
-      "size" : "76x76",
-      "idiom" : "ipad",
       "filename" : "Icon-App-76x76@2x.png",
-      "scale" : "2x"
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
     },
     {
-      "size" : "83.5x83.5",
-      "idiom" : "ipad",
       "filename" : "Icon-App-83.5x83.5@2x.png",
-      "scale" : "2x"
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
@@ -88,7 +88,7 @@
 @property NSString *_Nullable mediationExtrasIdentifier;
 @property id<FLTMediationNetworkExtrasProvider> _Nullable mediationNetworkExtrasProvider;
 
-- (GADRequest *_Nonnull)asGADRequest;
+- (GADRequest *_Nonnull)asGADRequest:(NSString *_Nonnull)adUnitId;
 @end
 
 /**
@@ -137,7 +137,7 @@
 @property NSDictionary<NSString *, NSArray<NSString *> *> *_Nullable customTargetingLists;
 @property NSString *_Nullable pubProvidedID;
 
-- (GAMRequest *_Nonnull)asGAMRequest;
+- (GAMRequest *_Nonnull)asGAMRequest:(NSString *_Nonnull)adUnitId;
 @end
 
 @protocol FLTAd <NSObject>

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
@@ -15,6 +15,7 @@
 #import <GoogleMobileAds/GoogleMobileAds.h>
 #import "FLTAdInstanceManager_Internal.h"
 #import "FLTGoogleMobileAdsPlugin.h"
+#import "FLTMediationNetworkExtrasProvider.h"
 #import "FLTMobileAds_Internal.h"
 
 @class FLTAdInstanceManager;
@@ -84,6 +85,9 @@
 @property BOOL nonPersonalizedAds;
 @property NSArray<NSString *> *_Nullable neighboringContentURLs;
 @property FLTLocationParams *_Nullable location;
+@property NSString *_Nullable mediationExtrasIdentifier;
+@property id<FLTMediationNetworkExtrasProvider> _Nullable mediationNetworkExtrasProvider;
+
 - (GADRequest *_Nonnull)asGADRequest;
 @end
 

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
@@ -166,6 +166,7 @@
     extras.additionalParameters = @{@"npa" : @"1"};
     [request registerAdNetworkExtras:extras];
   }
+  
   request.neighboringContentURLStrings = _neighboringContentURLs;
   request.requestAgent = FLT_REQUEST_AGENT_VERSIONED;
   if ([FLTAdUtil isNotNull:_location]) {

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.h
@@ -56,7 +56,7 @@
  *
  * @param mediationNetworkExtrasProvider the FLTMediationNetworkExtrasProvider which will be used to
  * get extras when ad requests are created.
- * @param registry the FlutterPluginRegistry associated with the
+ * @param registry the associated FlutterPluginRegistry the plugin will be attached to
  * @return whether mediationNetworkExtrasProvider was successfuly registered to a
  * FLTGoogleMobileAdsPlugin in the registry.
  */

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.h
@@ -51,11 +51,24 @@
 @interface FLTGoogleMobileAdsPlugin : NSObject <FlutterPlugin>
 
 /**
- * TODO - this.
+ * Registers a FLTMediationNetworkExtrasProvider used to provide mediation extras when the plugin
+ * creates ad requests.
+ *
+ * @param mediationNetworkExtrasProvider the FLTMediationNetworkExtrasProvider which will be used to
+ * get extras when ad requests are created.
+ * @param registry the FlutterPluginRegistry associated with the
+ * @return whether mediationNetworkExtrasProvider was successfuly registered to a
+ * FLTGoogleMobileAdsPlugin in the registry.
  */
-+ (BOOL)registerMediationNetworkExtrasProvider:(id<FLTMediationNetworkExtrasProvider> _Nonnull)mediationNetworkExtrasProvider
++ (BOOL)registerMediationNetworkExtrasProvider:
+            (id<FLTMediationNetworkExtrasProvider> _Nonnull)mediationNetworkExtrasProvider
                                      registery:(id<FlutterPluginRegistry> _Nonnull)registry;
 
+/*
+ * Unregisters any FLTMediationNetworkExtrasProvider that was associated with the
+ * FLTGoogleMobileAdsPlugin in registry.
+ */
++ (void)unregisterMediationNetworkExtrasProvider:(id<FlutterPluginRegistry> _Nonnull)registry;
 
 /**
  * Adds a `FLTNativeAdFactory` used to create a `GADNativeAdView`s from a Native Ad created

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.h
@@ -57,12 +57,12 @@
  * @param mediationNetworkExtrasProvider the FLTMediationNetworkExtrasProvider which will be used to
  * get extras when ad requests are created.
  * @param registry the associated FlutterPluginRegistry the plugin will be attached to
- * @return whether mediationNetworkExtrasProvider was successfuly registered to a
+ * @return whether mediationNetworkExtrasProvider was successfully registered to a
  * FLTGoogleMobileAdsPlugin in the registry.
  */
 + (BOOL)registerMediationNetworkExtrasProvider:
             (id<FLTMediationNetworkExtrasProvider> _Nonnull)mediationNetworkExtrasProvider
-                                     registery:(id<FlutterPluginRegistry> _Nonnull)registry;
+                                      registry:(id<FlutterPluginRegistry> _Nonnull)registry;
 
 /*
  * Unregisters any FLTMediationNetworkExtrasProvider that was associated with the

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.h
@@ -18,6 +18,7 @@
 
 #import "FLTAdInstanceManager_Internal.h"
 #import "FLTAd_Internal.h"
+#import "FLTMediationNetworkExtrasProvider.h"
 #import "FLTMobileAds_Internal.h"
 
 #define FLTLogWarning(format, ...) \
@@ -48,6 +49,14 @@
  * Flutter plugin providing access to the Google Mobile Ads API.
  */
 @interface FLTGoogleMobileAdsPlugin : NSObject <FlutterPlugin>
+
+/**
+ * TODO - this.
+ */
++ (BOOL)registerMediationNetworkExtrasProvider:(id<FLTMediationNetworkExtrasProvider> _Nonnull)mediationNetworkExtrasProvider
+                                     registery:(id<FlutterPluginRegistry> _Nonnull)registry;
+
+
 /**
  * Adds a `FLTNativeAdFactory` used to create a `GADNativeAdView`s from a Native Ad created
  * in Dart.

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
@@ -52,6 +52,8 @@
 @implementation FLTGoogleMobileAdsPlugin {
   NSMutableDictionary<NSString *, id<FLTNativeAdFactory>> *_nativeAdFactories;
   FLTAdInstanceManager *_manager;
+  id<FLTMediationNetworkExtrasProvider> _mediationNetworkExtrasProvider;
+  FLTGoogleMobileAdsReaderWriter *_readerWriter;
 }
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
@@ -60,6 +62,8 @@
   [registrar publish:instance];
 
   FLTGoogleMobileAdsReaderWriter *readerWriter = [[FLTGoogleMobileAdsReaderWriter alloc] init];
+  instance->_readerWriter = readerWriter;
+  
   NSObject<FlutterMethodCodec> *codec =
       [FlutterStandardMethodCodec codecWithReaderWriter:readerWriter];
 
@@ -89,6 +93,24 @@
 
   return self;
 }
+
++ (BOOL)registerMediationNetworkExtrasProvider:(id<FLTMediationNetworkExtrasProvider> _Nonnull)mediationNetworkExtrasProvider
+                                     registery:(id<FlutterPluginRegistry> _Nonnull)registry {
+  NSString *pluginClassName = NSStringFromClass([FLTGoogleMobileAdsPlugin class]);
+  FLTGoogleMobileAdsPlugin *adMobPlugin =
+      (FLTGoogleMobileAdsPlugin *)[registry valuePublishedByPlugin:pluginClassName];
+  if (!adMobPlugin) {
+    NSLog(@"Could not find a %@ instance registering mediation extras provider. The plugin may have not been registered.",
+          pluginClassName);
+    return NO;
+  }
+
+  adMobPlugin->_mediationNetworkExtrasProvider = mediationNetworkExtrasProvider;
+  adMobPlugin->_readerWriter.mediationNetworkExtrasProvider = mediationNetworkExtrasProvider;
+  
+  return YES;
+}
+
 
 + (BOOL)registerNativeAdFactory:(id<FlutterPluginRegistry>)registry
                       factoryId:(NSString *)factoryId

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
@@ -63,7 +63,7 @@
 
   FLTGoogleMobileAdsReaderWriter *readerWriter = [[FLTGoogleMobileAdsReaderWriter alloc] init];
   instance->_readerWriter = readerWriter;
-  
+
   NSObject<FlutterMethodCodec> *codec =
       [FlutterStandardMethodCodec codecWithReaderWriter:readerWriter];
 
@@ -94,23 +94,39 @@
   return self;
 }
 
-+ (BOOL)registerMediationNetworkExtrasProvider:(id<FLTMediationNetworkExtrasProvider> _Nonnull)mediationNetworkExtrasProvider
++ (BOOL)registerMediationNetworkExtrasProvider:
+            (id<FLTMediationNetworkExtrasProvider> _Nonnull)mediationNetworkExtrasProvider
                                      registery:(id<FlutterPluginRegistry> _Nonnull)registry {
   NSString *pluginClassName = NSStringFromClass([FLTGoogleMobileAdsPlugin class]);
   FLTGoogleMobileAdsPlugin *adMobPlugin =
       (FLTGoogleMobileAdsPlugin *)[registry valuePublishedByPlugin:pluginClassName];
   if (!adMobPlugin) {
-    NSLog(@"Could not find a %@ instance registering mediation extras provider. The plugin may have not been registered.",
+    NSLog(@"Could not find a %@ instance registering mediation extras provider. The plugin may "
+          @"have not been registered.",
           pluginClassName);
     return NO;
   }
 
   adMobPlugin->_mediationNetworkExtrasProvider = mediationNetworkExtrasProvider;
   adMobPlugin->_readerWriter.mediationNetworkExtrasProvider = mediationNetworkExtrasProvider;
-  
+
   return YES;
 }
 
++ (void)unregisterMediationNetworkExtrasProvider:(id<FlutterPluginRegistry> _Nonnull)registry {
+  NSString *pluginClassName = NSStringFromClass([FLTGoogleMobileAdsPlugin class]);
+  FLTGoogleMobileAdsPlugin *adMobPlugin =
+      (FLTGoogleMobileAdsPlugin *)[registry valuePublishedByPlugin:pluginClassName];
+  if (!adMobPlugin) {
+    NSLog(@"Could not find a %@ instance deregistering mediation extras provider. The plugin may "
+          @"have not been registered.",
+          pluginClassName);
+    return;
+  }
+
+  adMobPlugin->_mediationNetworkExtrasProvider = nil;
+  adMobPlugin->_readerWriter.mediationNetworkExtrasProvider = nil;
+}
 
 + (BOOL)registerNativeAdFactory:(id<FlutterPluginRegistry>)registry
                       factoryId:(NSString *)factoryId

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
@@ -97,7 +97,7 @@
 
 + (BOOL)registerMediationNetworkExtrasProvider:
             (id<FLTMediationNetworkExtrasProvider> _Nonnull)mediationNetworkExtrasProvider
-                                     registery:(id<FlutterPluginRegistry> _Nonnull)registry {
+                                      registry:(id<FlutterPluginRegistry> _Nonnull)registry {
   NSString *pluginClassName = NSStringFromClass([FLTGoogleMobileAdsPlugin class]);
   FLTGoogleMobileAdsPlugin *adMobPlugin =
       (FLTGoogleMobileAdsPlugin *)[registry valuePublishedByPlugin:pluginClassName];

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.h
@@ -14,16 +14,21 @@
 
 #import <Flutter/Flutter.h>
 #import "FLTAd_Internal.h"
+#import "FLTMediationNetworkExtrasProvider.h"
 
 @class FLTAdSizeFactory;
 
 @interface FLTGoogleMobileAdsReaderWriter : FlutterStandardReaderWriter
 @property(readonly) FLTAdSizeFactory *_Nonnull adSizeFactory;
+@property id<FLTMediationNetworkExtrasProvider> _Nullable mediationNetworkExtrasProvider;
+
 - (instancetype _Nonnull)initWithFactory:(FLTAdSizeFactory *_Nonnull)adSizeFactory;
 @end
 
 @interface FLTGoogleMobileAdsReader : FlutterStandardReader
 @property(readonly) FLTAdSizeFactory *_Nonnull adSizeFactory;
+@property id<FLTMediationNetworkExtrasProvider> _Nullable mediationNetworkExtrasProvider;
+
 - (instancetype _Nonnull)initWithFactory:(FLTAdSizeFactory *_Nonnull)adSizeFactory
                                     data:(NSData *_Nonnull)data;
 @end

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
@@ -56,7 +56,10 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
 }
 
 - (FlutterStandardReader *_Nonnull)readerWithData:(NSData *_Nonnull)data {
-  return [[FLTGoogleMobileAdsReader alloc] initWithFactory:_adSizeFactory data:data];
+  FLTGoogleMobileAdsReader *reader =
+      [[FLTGoogleMobileAdsReader alloc] initWithFactory:_adSizeFactory data:data];
+  reader.mediationNetworkExtrasProvider = _mediationNetworkExtrasProvider;
+  return reader;
 }
 
 - (FlutterStandardWriter *_Nonnull)writerWithData:(NSMutableData *_Nonnull)data {
@@ -93,6 +96,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
       request.neighboringContentURLs = [self readValueOfType:[self readByte]];
       request.location = [self readValueOfType:[self readByte]];
       request.mediationExtrasIdentifier = [self readValueOfType:[self readByte]];
+      request.mediationNetworkExtrasProvider = _mediationNetworkExtrasProvider;
       return request;
     }
     case FLTAdMobFieldRewardItem: {
@@ -158,6 +162,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
       request.pubProvidedID = [self readValueOfType:[self readByte]];
       request.location = [self readValueOfType:[self readByte]];
       request.mediationExtrasIdentifier = [self readValueOfType:[self readByte]];
+      request.mediationNetworkExtrasProvider = _mediationNetworkExtrasProvider;
       return request;
     }
     case FLTAdMobFieldAdapterInitializationState: {

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
@@ -92,6 +92,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
       request.nonPersonalizedAds = nonPersonalizedAds.boolValue;
       request.neighboringContentURLs = [self readValueOfType:[self readByte]];
       request.location = [self readValueOfType:[self readByte]];
+      request.mediationExtrasIdentifier = [self readValueOfType:[self readByte]];
       return request;
     }
     case FLTAdMobFieldRewardItem: {
@@ -156,6 +157,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
       request.neighboringContentURLs = [self readValueOfType:[self readByte]];
       request.pubProvidedID = [self readValueOfType:[self readByte]];
       request.location = [self readValueOfType:[self readByte]];
+      request.mediationExtrasIdentifier = [self readValueOfType:[self readByte]];
       return request;
     }
     case FLTAdMobFieldAdapterInitializationState: {
@@ -278,6 +280,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     [self writeValue:request.neighboringContentURLs];
     [self writeValue:request.pubProvidedID];
     [self writeValue:request.location];
+    [self writeValue:request.mediationExtrasIdentifier];
   } else if ([value isKindOfClass:[FLTAdRequest class]]) {
     [self writeByte:FLTAdMobFieldAdRequest];
     FLTAdRequest *request = value;
@@ -286,6 +289,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     [self writeValue:@(request.nonPersonalizedAds)];
     [self writeValue:request.neighboringContentURLs];
     [self writeValue:request.location];
+    [self writeValue:request.mediationExtrasIdentifier];
   } else if ([value isKindOfClass:[FLTRewardItem class]]) {
     [self writeByte:FLTAdMobFieldRewardItem];
     FLTRewardItem *item = value;

--- a/packages/google_mobile_ads/ios/Classes/FLTMediationNetworkExtrasProvider.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTMediationNetworkExtrasProvider.h
@@ -1,12 +1,39 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <GoogleMobileAds/GADAdNetworkExtras.h>
+
 /**
- * TODO - this.
+ * Provides network specific parameters to include in ad requests.
+ * An implementation of this protocol can be passed to FLTGoogleMobileAdsPlugin using
+ * registerMediationNetworkExtrasProvider
  */
 @protocol FLTMediationNetworkExtrasProvider
 @required
+
 /**
- * TODO - this
+ * Get an array of GADAdNetworkExtras to include in the GADRequest for the given adUnitId and
+ * mediationExtrasIdentifier.
+ *
+ * @param adUnitId the ad unit id associated with the ad request
+ * @param mediationExtrasIdentifier  n optional string that comes from the associated dart ad
+ * request object. This allows for additional control of which extras to include for an ad request,
+ * beyond just the ad unit.
+ * @return an array of GADAdNetworkExtras to include in the ad request.
  */
-- (NSDictionary *_Nullable)getMediationExtras:(NSString * _Nonnull)adUnitId
-                    mediationExtrasIdentifier:(NSString *_Nullable)mediationExtrasIdentifier;
+- (NSArray<id<GADAdNetworkExtras>> *_Nullable)getMediationExtras:(NSString *_Nonnull)adUnitId
+                                       mediationExtrasIdentifier:
+                                           (NSString *_Nullable)mediationExtrasIdentifier;
 
 @end

--- a/packages/google_mobile_ads/ios/Classes/FLTMediationNetworkExtrasProvider.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTMediationNetworkExtrasProvider.h
@@ -1,0 +1,12 @@
+/**
+ * TODO - this.
+ */
+@protocol FLTMediationNetworkExtrasProvider
+@required
+/**
+ * TODO - this
+ */
+- (NSDictionary *_Nullable)getMediationExtras:(NSString * _Nonnull)adUnitId
+                    mediationExtrasIdentifier:(NSString *_Nullable)mediationExtrasIdentifier;
+
+@end

--- a/packages/google_mobile_ads/ios/Classes/FLTMediationNetworkExtrasProvider.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTMediationNetworkExtrasProvider.h
@@ -23,7 +23,7 @@
 @required
 
 /**
- * Get an array of GADAdNetworkExtras to include in the GADRequest for the given adUnitId and
+ * Gets an array of GADAdNetworkExtras to include in the GADRequest for the given adUnitId and
  * mediationExtrasIdentifier.
  *
  * @param adUnitId the ad unit id associated with the ad request

--- a/packages/google_mobile_ads/ios/Tests/FLTAdRequestTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTAdRequestTest.m
@@ -1,0 +1,149 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+#import "../Classes/FLTAd_Internal.h"
+#import "../Classes/FLTMediationNetworkExtrasProvider.h"
+
+@interface FLTAdRequestTest : XCTestCase
+@end
+
+@interface TestGADAdNetworkExtras : NSObject <GADAdNetworkExtras>
+@end
+
+@implementation TestGADAdNetworkExtras
+@end
+
+@implementation FLTAdRequestTest
+
+- (void)testAsAdRequestAllParams {
+  // Proxy [GADRequest init] to return a partial mock of a real GADRequest.
+  GADRequest *gadRequestSpy = OCMPartialMock([GADRequest request]);
+  id gadRequestClassMock = OCMClassMock([GADRequest class]);
+  OCMStub([gadRequestClassMock request]).andReturn(gadRequestSpy);
+
+  // Set values for all params.
+  FLTAdRequest *fltAdRequest = [[FLTAdRequest alloc] init];
+  fltAdRequest.contentURL = @"contentURL";
+  NSArray<NSString *> *keywords = @[ @"keyword1", @"keyword2" ];
+  fltAdRequest.keywords = keywords;
+  fltAdRequest.nonPersonalizedAds = YES;
+  FLTLocationParams *locationParams = [[FLTLocationParams alloc] initWithAccuracy:@1
+                                                                        longitude:@2
+                                                                         latitude:@3];
+  fltAdRequest.location = locationParams;
+  fltAdRequest.mediationExtrasIdentifier = @"identifier";
+  NSArray<NSString *> *neighbors = @[ @"neighbor1", @"neighbor2" ];
+  fltAdRequest.neighboringContentURLs = neighbors;
+
+  // Mock FLTMediationNetworkExtrasProvider.
+  GADExtras *extras = [[GADExtras alloc] init];
+  TestGADAdNetworkExtras *testExtras = [[TestGADAdNetworkExtras alloc] init];
+  NSArray<id<GADAdNetworkExtras>> *extrasArray = @[ extras, testExtras ];
+  id<FLTMediationNetworkExtrasProvider> extrasProvider =
+      OCMProtocolMock(@protocol(FLTMediationNetworkExtrasProvider));
+  OCMStub([extrasProvider getMediationExtras:[OCMArg isEqual:@"test-ad-unit"]
+                   mediationExtrasIdentifier:@"identifier"])
+      .andReturn(extrasArray);
+
+  fltAdRequest.mediationNetworkExtrasProvider = extrasProvider;
+
+  // Create a GADRequest and verify properties are set correctly.
+  GADRequest *gadRequest = [fltAdRequest asGADRequest:@"test-ad-unit"];
+
+  XCTAssertEqualObjects(gadRequest.contentURL, @"contentURL");
+  XCTAssertEqualObjects(gadRequest.keywords, keywords);
+  XCTAssertEqualObjects(gadRequest.neighboringContentURLStrings, neighbors);
+  GADExtras *updatedExtras = [gadRequest adNetworkExtrasFor:[GADExtras class]];
+  XCTAssertEqualObjects(updatedExtras, extras);
+  XCTAssertEqualObjects(updatedExtras.additionalParameters[@"npa"], @"1");
+  OCMVerify([gadRequestSpy registerAdNetworkExtras:[OCMArg isEqual:testExtras]]);
+  OCMVerify([gadRequestSpy setLocationWithLatitude:3 longitude:2 accuracy:1]);
+}
+
+- (void)testAsAdRequestNoParams {
+  // Proxy [GADRequest init] to return a partial mock of a real GADRequest.
+  GADRequest *gadRequestSpy = OCMPartialMock([GADRequest request]);
+  id gadRequestClassMock = OCMClassMock([GADRequest class]);
+  OCMStub([gadRequestClassMock request]).andReturn(gadRequestSpy);
+
+  // Create a GADRequest with no additional params.
+  FLTAdRequest *fltAdRequest = [[FLTAdRequest alloc] init];
+  GADRequest *gadRequest = [fltAdRequest asGADRequest:@"test-ad-unit"];
+
+  // Verify parameters are empty or nil.
+  XCTAssertNil(gadRequest.contentURL);
+  XCTAssertNil(gadRequest.keywords);
+  XCTAssertNil(gadRequest.neighboringContentURLStrings);
+  XCTAssertNil([gadRequest adNetworkExtrasFor:[GADExtras class]]);
+  XCTAssertNil([gadRequest valueForKey:@"_location"]);
+}
+
+- (void)testGADExtrasAddedWhenNpaSpecified {
+  // Proxy [GADRequest init] to return a partial mock of a real GADRequest.
+  GADRequest *gadRequestSpy = OCMPartialMock([GADRequest request]);
+  id gadRequestClassMock = OCMClassMock([GADRequest class]);
+  OCMStub([gadRequestClassMock request]).andReturn(gadRequestSpy);
+
+  // Create a GADRequest with NPA set, and a FLTMediationNetworkExtrasProvider
+  // that returns an empty array.
+  FLTAdRequest *fltAdRequest = [[FLTAdRequest alloc] init];
+  fltAdRequest.nonPersonalizedAds = YES;
+  fltAdRequest.mediationExtrasIdentifier = @"identifier";
+
+  NSArray<id<GADAdNetworkExtras>> *extrasArray = @[];
+  id<FLTMediationNetworkExtrasProvider> extrasProvider =
+      OCMProtocolMock(@protocol(FLTMediationNetworkExtrasProvider));
+  OCMStub([extrasProvider getMediationExtras:[OCMArg isEqual:@"test-ad-unit"]
+                   mediationExtrasIdentifier:@"identifier"])
+      .andReturn(extrasArray);
+
+  fltAdRequest.mediationNetworkExtrasProvider = extrasProvider;
+
+  GADRequest *gadRequest = [fltAdRequest asGADRequest:@"test-ad-unit"];
+
+  // GADExtras should be added with npa = 1.
+  GADExtras *updatedExtras = [gadRequest adNetworkExtrasFor:[GADExtras class]];
+  XCTAssertEqualObjects(updatedExtras.additionalParameters[@"npa"], @"1");
+}
+
+- (void)testGADExtrasWithoutNpa {
+  // Proxy [GADRequest init] to return a partial mock of a real GADRequest.
+  GADRequest *gadRequestSpy = OCMPartialMock([GADRequest request]);
+  id gadRequestClassMock = OCMClassMock([GADRequest class]);
+  OCMStub([gadRequestClassMock request]).andReturn(gadRequestSpy);
+
+  // Extras should be added even if npa is not set.
+  FLTAdRequest *fltAdRequest = [[FLTAdRequest alloc] init];
+  fltAdRequest.mediationExtrasIdentifier = @"identifier";
+
+  TestGADAdNetworkExtras *testExtras = [[TestGADAdNetworkExtras alloc] init];
+  NSArray<id<GADAdNetworkExtras>> *extrasArray = @[ testExtras ];
+  id<FLTMediationNetworkExtrasProvider> extrasProvider =
+      OCMProtocolMock(@protocol(FLTMediationNetworkExtrasProvider));
+  OCMStub([extrasProvider getMediationExtras:[OCMArg isEqual:@"test-ad-unit"]
+                   mediationExtrasIdentifier:@"identifier"])
+      .andReturn(extrasArray);
+
+  fltAdRequest.mediationNetworkExtrasProvider = extrasProvider;
+
+  GADRequest *gadRequest = [fltAdRequest asGADRequest:@"test-ad-unit"];
+
+  XCTAssertNil([gadRequest adNetworkExtrasFor:[GADExtras class]]);
+  OCMVerify([gadRequestSpy registerAdNetworkExtras:[OCMArg isEqual:testExtras]]);
+}
+
+@end

--- a/packages/google_mobile_ads/ios/Tests/FLTAppOpenAdTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTAppOpenAdTest.m
@@ -33,7 +33,7 @@
   FLTAdRequest *request = OCMClassMock([FLTAdRequest class]);
   OCMStub([request keywords]).andReturn(@[ @"apple" ]);
   GADRequest *gadRequest = OCMClassMock([GADRequest class]);
-  OCMStub([request asGADRequest]).andReturn(gadRequest);
+  OCMStub([request asGADRequest:[OCMArg any]]).andReturn(gadRequest);
 
   [self testLoadShowAppOpenAd:request gadOrGAMRequest:gadRequest];
 }
@@ -42,7 +42,7 @@
   FLTGAMAdRequest *request = OCMClassMock([FLTGAMAdRequest class]);
   OCMStub([request keywords]).andReturn(@[ @"apple" ]);
   GAMRequest *gamRequest = OCMClassMock([GAMRequest class]);
-  OCMStub([request asGAMRequest]).andReturn(gamRequest);
+  OCMStub([request asGAMRequest:[OCMArg any]]).andReturn(gamRequest);
   FLTServerSideVerificationOptions *serverSideVerificationOptions =
       OCMClassMock([FLTServerSideVerificationOptions class]);
   GADServerSideVerificationOptions *gadOptions =
@@ -140,7 +140,7 @@
   FLTAdRequest *request = OCMClassMock([FLTAdRequest class]);
   OCMStub([request keywords]).andReturn(@[ @"apple" ]);
   GADRequest *gadRequest = OCMClassMock([GADRequest class]);
-  OCMStub([request asGADRequest]).andReturn(gadRequest);
+  OCMStub([request asGADRequest:[OCMArg any]]).andReturn(gadRequest);
   [self testFailedToLoad:request];
 }
 
@@ -148,7 +148,7 @@
   FLTGAMAdRequest *request = OCMClassMock([FLTGAMAdRequest class]);
   OCMStub([request keywords]).andReturn(@[ @"apple" ]);
   GAMRequest *gamRequest = OCMClassMock([GAMRequest class]);
-  OCMStub([request asGAMRequest]).andReturn(gamRequest);
+  OCMStub([request asGAMRequest:[OCMArg any]]).andReturn(gamRequest);
   [self testFailedToLoad:request];
 }
 

--- a/packages/google_mobile_ads/ios/Tests/FLTGAMAdRequestTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGAMAdRequestTest.m
@@ -1,0 +1,156 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+#import "../Classes/FLTAd_Internal.h"
+#import "../Classes/FLTMediationNetworkExtrasProvider.h"
+
+@interface FLTGAMAdRequestTest : XCTestCase
+@end
+
+@interface TestGAMAdNetworkExtras : NSObject <GADAdNetworkExtras>
+@end
+
+@implementation TestGAMAdNetworkExtras
+@end
+
+@implementation FLTGAMAdRequestTest
+
+- (void)testAsAdRequestAllParams {
+  // Proxy [GAMRequest init] to return a partial mock of a real GAMRequest.
+  GAMRequest *gamRequestSpy = OCMPartialMock([GAMRequest request]);
+  id gamRequestClassMock = OCMClassMock([GAMRequest class]);
+  OCMStub([gamRequestClassMock request]).andReturn(gamRequestSpy);
+
+  // Set values for all params.
+  FLTGAMAdRequest *fltGAMAdRequest = [[FLTGAMAdRequest alloc] init];
+  fltGAMAdRequest.contentURL = @"contentURL";
+  NSArray<NSString *> *keywords = @[ @"keyword1", @"keyword2" ];
+  fltGAMAdRequest.keywords = keywords;
+  fltGAMAdRequest.nonPersonalizedAds = YES;
+  FLTLocationParams *locationParams = [[FLTLocationParams alloc] initWithAccuracy:@1
+                                                                        longitude:@2
+                                                                         latitude:@3];
+  fltGAMAdRequest.location = locationParams;
+  fltGAMAdRequest.mediationExtrasIdentifier = @"identifier";
+  NSArray<NSString *> *neighbors = @[ @"neighbor1", @"neighbor2" ];
+  fltGAMAdRequest.neighboringContentURLs = neighbors;
+  fltGAMAdRequest.customTargeting = @{@"key" : @"value"};
+  fltGAMAdRequest.pubProvidedID = @"pubProvidedId";
+  fltGAMAdRequest.customTargetingLists = @{@"key" : @[ @"value1", @"value2" ]};
+
+  // Mock FLTMediationNetworkExtrasProvider.
+  GADExtras *extras = [[GADExtras alloc] init];
+  TestGAMAdNetworkExtras *testExtras = [[TestGAMAdNetworkExtras alloc] init];
+  NSArray<id<GADAdNetworkExtras>> *extrasArray = @[ extras, testExtras ];
+  id<FLTMediationNetworkExtrasProvider> extrasProvider =
+      OCMProtocolMock(@protocol(FLTMediationNetworkExtrasProvider));
+  OCMStub([extrasProvider getMediationExtras:[OCMArg isEqual:@"test-ad-unit"]
+                   mediationExtrasIdentifier:@"identifier"])
+      .andReturn(extrasArray);
+
+  fltGAMAdRequest.mediationNetworkExtrasProvider = extrasProvider;
+
+  // Create a GAMRequest and verify properties are set correctly.
+  GAMRequest *gamRequest = [fltGAMAdRequest asGAMRequest:@"test-ad-unit"];
+
+  XCTAssertEqualObjects(gamRequest.contentURL, @"contentURL");
+  XCTAssertEqualObjects(gamRequest.keywords, keywords);
+  XCTAssertEqualObjects(gamRequest.neighboringContentURLStrings, neighbors);
+  XCTAssertEqualObjects(gamRequest.customTargeting[@"key"], @"value1,value2");
+  XCTAssertEqualObjects(gamRequest.publisherProvidedID, @"pubProvidedId");
+  GADExtras *updatedExtras = [gamRequest adNetworkExtrasFor:[GADExtras class]];
+  XCTAssertEqualObjects(updatedExtras, extras);
+  XCTAssertEqualObjects(updatedExtras.additionalParameters[@"npa"], @"1");
+  OCMVerify([gamRequestSpy registerAdNetworkExtras:[OCMArg isEqual:testExtras]]);
+  OCMVerify([gamRequestSpy setLocationWithLatitude:3 longitude:2 accuracy:1]);
+}
+
+- (void)testAsAdRequestNoParams {
+  // Proxy [GAMRequest init] to return a partial mock of a real GAMRequest.
+  GAMRequest *gamRequestSpy = OCMPartialMock([GAMRequest request]);
+  id gamRequestClassMock = OCMClassMock([GAMRequest class]);
+  OCMStub([gamRequestClassMock request]).andReturn(gamRequestSpy);
+
+  // Create a GAMRequest with no additional params.
+  FLTGAMAdRequest *fltGAMAdRequest = [[FLTGAMAdRequest alloc] init];
+  GAMRequest *gamRequest = [fltGAMAdRequest asGAMRequest:@"test-ad-unit"];
+
+  // Verify parameters are empty or nil.
+  XCTAssertNil(gamRequest.contentURL);
+  XCTAssertNil(gamRequest.keywords);
+  XCTAssertNil(gamRequest.neighboringContentURLStrings);
+  XCTAssertNil([gamRequest adNetworkExtrasFor:[GADExtras class]]);
+  XCTAssertNil([gamRequest valueForKey:@"_location"]);
+  XCTAssertNil(gamRequest.publisherProvidedID);
+  XCTAssertTrue(gamRequest.customTargeting.count == 0);
+}
+
+- (void)testGADExtrasAddedWhenNpaSpecified {
+  // Proxy [GAMRequest init] to return a partial mock of a real GAMRequest.
+  GAMRequest *gamRequestSpy = OCMPartialMock([GAMRequest request]);
+  id gamRequestClassMock = OCMClassMock([GAMRequest class]);
+  OCMStub([gamRequestClassMock request]).andReturn(gamRequestSpy);
+
+  // Create a GAMRequest with NPA set, and a FLTMediationNetworkExtrasProvider
+  // that returns an empty array.
+  FLTGAMAdRequest *fltGAMAdRequest = [[FLTGAMAdRequest alloc] init];
+  fltGAMAdRequest.nonPersonalizedAds = YES;
+  fltGAMAdRequest.mediationExtrasIdentifier = @"identifier";
+
+  NSArray<id<GADAdNetworkExtras>> *extrasArray = @[];
+  id<FLTMediationNetworkExtrasProvider> extrasProvider =
+      OCMProtocolMock(@protocol(FLTMediationNetworkExtrasProvider));
+  OCMStub([extrasProvider getMediationExtras:[OCMArg isEqual:@"test-ad-unit"]
+                   mediationExtrasIdentifier:@"identifier"])
+      .andReturn(extrasArray);
+
+  fltGAMAdRequest.mediationNetworkExtrasProvider = extrasProvider;
+
+  GAMRequest *gamRequest = [fltGAMAdRequest asGAMRequest:@"test-ad-unit"];
+
+  // GADExtras should be added with npa = 1.
+  GADExtras *updatedExtras = [gamRequest adNetworkExtrasFor:[GADExtras class]];
+  XCTAssertEqualObjects(updatedExtras.additionalParameters[@"npa"], @"1");
+}
+
+- (void)testGADExtrasWithoutNpa {
+  // Proxy [GAMRequest init] to return a partial mock of a real GAMRequest.
+  GAMRequest *gamRequestSpy = OCMPartialMock([GAMRequest request]);
+  id gamRequestClassMock = OCMClassMock([GAMRequest class]);
+  OCMStub([gamRequestClassMock request]).andReturn(gamRequestSpy);
+
+  // Extras should be added even if npa is not set.
+  FLTGAMAdRequest *fltGAMAdRequest = [[FLTGAMAdRequest alloc] init];
+  fltGAMAdRequest.mediationExtrasIdentifier = @"identifier";
+
+  TestGAMAdNetworkExtras *testExtras = [[TestGAMAdNetworkExtras alloc] init];
+  NSArray<id<GADAdNetworkExtras>> *extrasArray = @[ testExtras ];
+  id<FLTMediationNetworkExtrasProvider> extrasProvider =
+      OCMProtocolMock(@protocol(FLTMediationNetworkExtrasProvider));
+  OCMStub([extrasProvider getMediationExtras:[OCMArg isEqual:@"test-ad-unit"]
+                   mediationExtrasIdentifier:@"identifier"])
+      .andReturn(extrasArray);
+
+  fltGAMAdRequest.mediationNetworkExtrasProvider = extrasProvider;
+
+  GADRequest *gamRequest = [fltGAMAdRequest asGAMRequest:@"test-ad-unit"];
+
+  XCTAssertNil([gamRequest adNetworkExtrasFor:[GADExtras class]]);
+  OCMVerify([gamRequestSpy registerAdNetworkExtras:[OCMArg isEqual:testExtras]]);
+}
+
+@end

--- a/packages/google_mobile_ads/ios/Tests/FLTGamInterstitialAdTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGamInterstitialAdTest.m
@@ -33,7 +33,7 @@
   FLTGAMAdRequest *request = OCMClassMock([FLTGAMAdRequest class]);
   OCMStub([request keywords]).andReturn(@[ @"apple" ]);
   GAMRequest *gadRequest = OCMClassMock([GAMRequest class]);
-  OCMStub([request asGAMRequest]).andReturn(gadRequest);
+  OCMStub([request asGAMRequest:[OCMArg any]]).andReturn(gadRequest);
 
   UIViewController *mockRootViewController = OCMClassMock([UIViewController class]);
   FLTGAMInterstitialAd *ad = [[FLTGAMInterstitialAd alloc] initWithAdUnitId:@"testId"
@@ -132,7 +132,7 @@
   FLTGAMAdRequest *request = OCMClassMock([FLTGAMAdRequest class]);
   OCMStub([request keywords]).andReturn(@[ @"apple" ]);
   GAMRequest *gadRequest = OCMClassMock([GAMRequest class]);
-  OCMStub([request asGAMRequest]).andReturn(gadRequest);
+  OCMStub([request asGAMRequest:[OCMArg any]]).andReturn(gadRequest);
 
   UIViewController *mockRootViewController = OCMClassMock([UIViewController class]);
   FLTGAMInterstitialAd *ad = [[FLTGAMInterstitialAd alloc] initWithAdUnitId:@"testId"

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
@@ -229,6 +229,7 @@
   NSArray<NSString *> *contentURLs = @[ @"url-1.com", @"url-2.com" ];
   request.neighboringContentURLs = contentURLs;
   request.location = [[FLTLocationParams alloc] initWithAccuracy:@1.5 longitude:@52 latitude:@123];
+  request.mediationExtrasIdentifier = @"identifier";
   NSData *encodedMessage = [_messageCodec encode:request];
 
   FLTAdRequest *decodedRequest = [_messageCodec decode:encodedMessage];
@@ -239,6 +240,7 @@
   XCTAssertEqualObjects(decodedRequest.location.accuracy, @1.5);
   XCTAssertEqualObjects(decodedRequest.location.longitude, @52);
   XCTAssertEqualObjects(decodedRequest.location.latitude, @123);
+  XCTAssertEqualObjects(decodedRequest.mediationExtrasIdentifier, @"identifier");
 }
 
 - (void)testEncodeDecodeGAMAdRequest {
@@ -252,6 +254,7 @@
   request.neighboringContentURLs = contentURLs;
   request.pubProvidedID = @"pub-id";
   request.location = [[FLTLocationParams alloc] initWithAccuracy:@1.5 longitude:@52 latitude:@123];
+  request.mediationExtrasIdentifier = @"identifier";
   NSData *encodedMessage = [_messageCodec encode:request];
 
   FLTGAMAdRequest *decodedRequest = [_messageCodec decode:encodedMessage];
@@ -266,6 +269,7 @@
   XCTAssertEqualObjects(decodedRequest.location.accuracy, @1.5);
   XCTAssertEqualObjects(decodedRequest.location.longitude, @52);
   XCTAssertEqualObjects(decodedRequest.location.latitude, @123);
+  XCTAssertEqualObjects(decodedRequest.mediationExtrasIdentifier, @"identifier");
 }
 
 - (void)testEncodeDecodeRewardItem {

--- a/packages/google_mobile_ads/ios/Tests/FLTInterstitialAdTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTInterstitialAdTest.m
@@ -33,7 +33,7 @@
   FLTAdRequest *request = OCMClassMock([FLTAdRequest class]);
   OCMStub([request keywords]).andReturn(@[ @"apple" ]);
   GADRequest *gadRequest = OCMClassMock([GADRequest class]);
-  OCMStub([request asGADRequest]).andReturn(gadRequest);
+  OCMStub([request asGADRequest:[OCMArg any]]).andReturn(gadRequest);
 
   UIViewController *mockRootViewController = OCMClassMock([UIViewController class]);
   FLTInterstitialAd *ad = [[FLTInterstitialAd alloc] initWithAdUnitId:@"testId"
@@ -117,7 +117,7 @@
   FLTAdRequest *request = OCMClassMock([FLTAdRequest class]);
   OCMStub([request keywords]).andReturn(@[ @"apple" ]);
   GADRequest *gadRequest = OCMClassMock([GADRequest class]);
-  OCMStub([request asGADRequest]).andReturn(gadRequest);
+  OCMStub([request asGADRequest:[OCMArg any]]).andReturn(gadRequest);
 
   UIViewController *mockRootViewController = OCMClassMock([UIViewController class]);
   FLTInterstitialAd *ad = [[FLTInterstitialAd alloc] initWithAdUnitId:@"testId"

--- a/packages/google_mobile_ads/ios/Tests/FLTRewardedAdTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTRewardedAdTest.m
@@ -33,7 +33,7 @@
   FLTAdRequest *request = OCMClassMock([FLTAdRequest class]);
   OCMStub([request keywords]).andReturn(@[ @"apple" ]);
   GADRequest *gadRequest = OCMClassMock([GADRequest class]);
-  OCMStub([request asGADRequest]).andReturn(gadRequest);
+  OCMStub([request asGADRequest:[OCMArg any]]).andReturn(gadRequest);
   FLTServerSideVerificationOptions *serverSideVerificationOptions =
       OCMClassMock([FLTServerSideVerificationOptions class]);
   GADServerSideVerificationOptions *gadOptions =
@@ -49,7 +49,7 @@
   FLTGAMAdRequest *request = OCMClassMock([FLTGAMAdRequest class]);
   OCMStub([request keywords]).andReturn(@[ @"apple" ]);
   GAMRequest *gamRequest = OCMClassMock([GAMRequest class]);
-  OCMStub([request asGAMRequest]).andReturn(gamRequest);
+  OCMStub([request asGAMRequest:[OCMArg any]]).andReturn(gamRequest);
   FLTServerSideVerificationOptions *serverSideVerificationOptions =
       OCMClassMock([FLTServerSideVerificationOptions class]);
   GADServerSideVerificationOptions *gadOptions =
@@ -177,7 +177,7 @@
   FLTAdRequest *request = OCMClassMock([FLTAdRequest class]);
   OCMStub([request keywords]).andReturn(@[ @"apple" ]);
   GADRequest *gadRequest = OCMClassMock([GADRequest class]);
-  OCMStub([request asGADRequest]).andReturn(gadRequest);
+  OCMStub([request asGADRequest:[OCMArg any]]).andReturn(gadRequest);
   [self testFailedToLoad:request];
 }
 
@@ -185,7 +185,7 @@
   FLTGAMAdRequest *request = OCMClassMock([FLTGAMAdRequest class]);
   OCMStub([request keywords]).andReturn(@[ @"apple" ]);
   GAMRequest *gamRequest = OCMClassMock([GAMRequest class]);
-  OCMStub([request asGAMRequest]).andReturn(gamRequest);
+  OCMStub([request asGAMRequest:[OCMArg any]]).andReturn(gamRequest);
   [self testFailedToLoad:request];
 }
 
@@ -222,7 +222,7 @@
   FLTAdRequest *request = OCMClassMock([FLTAdRequest class]);
   OCMStub([request keywords]).andReturn(@[ @"apple" ]);
   GADRequest *gadRequest = OCMClassMock([GADRequest class]);
-  OCMStub([request asGADRequest]).andReturn(gadRequest);
+  OCMStub([request asGADRequest:[OCMArg any]]).andReturn(gadRequest);
   [self testLoadShowRewardedAd:request
                     gadOrGAMRequest:gadRequest
       serverSideVerificationOptions:nil];

--- a/packages/google_mobile_ads/ios/google_mobile_ads.podspec
+++ b/packages/google_mobile_ads/ios/google_mobile_ads.podspec
@@ -22,6 +22,6 @@ Google Mobile Ads plugin for Flutter.
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'Tests/**/*'
-    test_spec.dependency 'OCMock','3.5'
+    test_spec.dependency 'OCMock','3.6'
   end
 end

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -190,6 +190,7 @@ class AdRequest {
     this.nonPersonalizedAds,
     this.httpTimeoutMillis,
     this.location,
+    this.mediationExtrasIdentifier,
   });
 
   /// Words or phrases describing the current user activity.
@@ -219,6 +220,14 @@ class AdRequest {
   /// Used for mediation targeting purposes.
   final LocationParams? location;
 
+  /// String identifier used in providing mediation extras.
+  ///
+  /// Only relevant if you use mediation and need to provide network extras
+  /// to the ad request. This identifier will get passed to your platform-side
+  /// mediation extras factory class, allowing for additional customization
+  /// of network extras.
+  final String? mediationExtrasIdentifier;
+
   @override
   bool operator ==(Object other) {
     return other is AdRequest &&
@@ -244,6 +253,7 @@ class AdManagerAdRequest extends AdRequest {
     int? httpTimeoutMillis,
     this.publisherProvidedId,
     LocationParams? location,
+    String? mediationExtrasIdentifier,
   }) : super(
           keywords: keywords,
           contentUrl: contentUrl,
@@ -251,6 +261,7 @@ class AdManagerAdRequest extends AdRequest {
           nonPersonalizedAds: nonPersonalizedAds,
           httpTimeoutMillis: httpTimeoutMillis,
           location: location,
+          mediationExtrasIdentifier: mediationExtrasIdentifier,
         );
 
   /// Key-value pairs used for custom targeting.

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -236,7 +236,8 @@ class AdRequest {
         nonPersonalizedAds == other.nonPersonalizedAds &&
         listEquals(neighboringContentUrls, other.neighboringContentUrls) &&
         httpTimeoutMillis == other.httpTimeoutMillis &&
-        location == other.location;
+        location == other.location &&
+        mediationExtrasIdentifier == other.mediationExtrasIdentifier;
   }
 }
 

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -737,6 +737,7 @@ class AdMessageCodec extends StandardMessageCodec {
       }
       writeValue(buffer, value.publisherProvidedId);
       writeValue(buffer, value.location);
+      writeValue(buffer, value.mediationExtrasIdentifier);
     } else if (value is AdRequest) {
       buffer.putUint8(_valueAdRequest);
       writeValue(buffer, value.keywords);
@@ -747,6 +748,7 @@ class AdMessageCodec extends StandardMessageCodec {
         writeValue(buffer, value.httpTimeoutMillis);
       }
       writeValue(buffer, value.location);
+      writeValue(buffer, value.mediationExtrasIdentifier);
     } else if (value is RewardItem) {
       buffer.putUint8(_valueRewardItem);
       writeValue(buffer, value.amount);
@@ -885,6 +887,7 @@ class AdMessageCodec extends StandardMessageCodec {
               ? readValueOfType(buffer.getUint8(), buffer)
               : null,
           location: readValueOfType(buffer.getUint8(), buffer),
+          mediationExtrasIdentifier: readValueOfType(buffer.getUint8(), buffer),
         );
       case _valueRewardItem:
         return RewardItem(
@@ -934,6 +937,7 @@ class AdMessageCodec extends StandardMessageCodec {
               : null,
           publisherProvidedId: readValueOfType(buffer.getUint8(), buffer),
           location: readValueOfType(buffer.getUint8(), buffer),
+          mediationExtrasIdentifier: readValueOfType(buffer.getUint8(), buffer),
         );
       case _valueInitializationState:
         switch (readValueOfType(buffer.getUint8(), buffer)) {

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -1328,7 +1328,8 @@ void main() {
           neighboringContentUrls: <String>['url1.com', 'url2.com'],
           httpTimeoutMillis: 12345,
           location: LocationParams(
-              accuracy: 1.1, longitude: 25, latitude: 38, time: 1));
+              accuracy: 1.1, longitude: 25, latitude: 38, time: 1),
+          mediationExtrasIdentifier: 'identifier');
 
       final ByteData byteData = codec.encodeMessage(adRequest)!;
       expect(codec.decodeMessage(byteData), adRequest);
@@ -1344,7 +1345,8 @@ void main() {
           neighboringContentUrls: <String>['url1.com', 'url2.com'],
           httpTimeoutMillis: 12345,
           location: LocationParams(
-              accuracy: 1.1, longitude: 25, latitude: 38, time: 1));
+              accuracy: 1.1, longitude: 25, latitude: 38, time: 1),
+          mediationExtrasIdentifier: 'identifier');
 
       final ByteData byteData = codec.encodeMessage(adRequest)!;
       AdRequest decoded = codec.decodeMessage(byteData);
@@ -1353,9 +1355,11 @@ void main() {
       expect(decoded.contentUrl, adRequest.contentUrl);
       expect(decoded.nonPersonalizedAds, adRequest.nonPersonalizedAds);
       expect(decoded.keywords, adRequest.keywords);
+      // Time is not included on iOS.
       expect(decoded.location!.accuracy, 1.1);
       expect(decoded.location!.longitude, 25);
       expect(decoded.location!.latitude, 38);
+      expect(decoded.mediationExtrasIdentifier, 'identifier');
     });
 
     test('encode/decode $LoadAdError', () async {
@@ -1492,7 +1496,7 @@ void main() {
       );
     });
 
-    test('encode/decode AdManagerAdRequest Android', () async {
+    test('encode/decode $AdManagerAdRequest Android', () async {
       debugDefaultTargetPlatformOverride = TargetPlatform.android;
       final AdManagerAdRequest request = AdManagerAdRequest(
         keywords: <String>['who'],
@@ -1507,6 +1511,7 @@ void main() {
         publisherProvidedId: 'test-pub-id',
         location:
             LocationParams(accuracy: 1.1, longitude: 25, latitude: 38, time: 1),
+        mediationExtrasIdentifier: 'identifier',
       );
       final ByteData byteData = codec.encodeMessage(request)!;
 
@@ -1516,7 +1521,7 @@ void main() {
       );
     });
 
-    test('encode/decode AdManagerAdRequest iOS', () async {
+    test('encode/decode $AdManagerAdRequest iOS', () async {
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
 
       final AdManagerAdRequest request = AdManagerAdRequest(
@@ -1532,6 +1537,7 @@ void main() {
         publisherProvidedId: 'test-pub-id',
         location:
             LocationParams(accuracy: 1.1, longitude: 25, latitude: 38, time: 1),
+        mediationExtrasIdentifier: 'identifier',
       );
 
       final ByteData byteData = codec.encodeMessage(request)!;
@@ -1544,9 +1550,11 @@ void main() {
       expect(decoded.publisherProvidedId, request.publisherProvidedId);
       expect(decoded.customTargeting, request.customTargeting);
       expect(decoded.customTargetingLists, request.customTargetingLists);
+      // Time is not included on iOS.
       expect(decoded.location!.accuracy, 1.1);
       expect(decoded.location!.longitude, 25);
       expect(decoded.location!.latitude, 38);
+      expect(decoded.mediationExtrasIdentifier, 'identifier');
     });
   });
 }


### PR DESCRIPTION
## Description

Adds new APIs that support passing mediation network extras to the plugin when it creates an ad request.

- Adds new `MediationNetworkExtrasProvider` types on Android and iOS.
- Adds register and deregister methods to `GoogleMobileAdsPlugin`(android) and `FLTGoogleMobileAdsPlugin`(iOS)
- Plumbs the `adUnitId` and a new string identifier, `mediationNetworkExtras` through the ad request creation flow

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.