### PR TITLE
Update inline adaptive example

### DIFF
--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
@@ -18,4 +18,6 @@ package io.flutter.plugins.googlemobileads;
 public class Constants {
   /** Version request agent. Should be bumped alongside plugin versions. */
   public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-0.13.6";
+
+  static final String ERROR_CODE_UNEXPECTED_AD_TYPE = "unexpected_ad_type";
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -463,10 +463,18 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
         break;
       case "getAdSize":
         FlutterAd ad = instanceManager.adForId(call.<Integer>argument("adId"));
-        if (ad instanceof FlutterBannerAd) {
+        if (ad == null) {
+          // This was called on a dart ad container that hasn't been loaded yet.
+          result.success(null);
+        } else if (ad instanceof FlutterBannerAd) {
           result.success(((FlutterBannerAd) ad).getAdSize());
         } else if (ad instanceof FlutterAdManagerBannerAd) {
           result.success(((FlutterAdManagerBannerAd) ad).getAdSize());
+        } else {
+          result.error(
+              Constants.ERROR_CODE_UNEXPECTED_AD_TYPE,
+              "Unexpected ad type for getAdSize: " + ad,
+              null);
         }
         break;
       default:

--- a/packages/google_mobile_ads/example/lib/inline_adaptive_example.dart
+++ b/packages/google_mobile_ads/example/lib/inline_adaptive_example.dart
@@ -62,9 +62,9 @@ class _InlineAdaptiveExampleState extends State<InlineAdaptiveExample> {
         onAdLoaded: (Ad ad) async {
           print('Inline adaptive banner loaded: ${ad.responseInfo}');
 
-          // After the ad is loaded, get the most ad size from the platform
-          // ad object and use it to update the height of the container. This is
-          // necessary because the height can change after the ad is loaded.
+          // After the ad is loaded, get the platform ad size and use it to
+          // update the height of the container. This is necessary because the
+          // height can change after the ad is loaded.
           AdManagerBannerAd bannerAd = (ad as AdManagerBannerAd);
           final AdSize? size = await bannerAd.getPlatformAdSize();
           if (size == null) {

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #import "FLTGoogleMobileAdsPlugin.h"
+#import "FLTAdUtil.h"
 
 @interface FLTGoogleMobileAdsPlugin ()
 @property(nonatomic, retain) FlutterMethodChannel *channel;
@@ -324,9 +325,17 @@
       result(nil);
     }
   } else if ([call.method isEqualToString:@"getAdSize"]) {
-    FLTBannerAd *ad = (FLTBannerAd *)[_manager adFor:call.arguments[@"adId"]];
-    result([ad getAdSize]);
-    ;
+    id<FLTAd> ad = [_manager adFor:call.arguments[@"adId"]];
+    if ([FLTAdUtil isNull:ad]) {
+      // Called on an ad that hasn't been loaded yet.
+      result(nil);
+    }
+    if ([ad isKindOfClass:[FLTBannerAd class]]) {
+      FLTBannerAd *bannerAd = (FLTBannerAd *)ad;
+      result([bannerAd getAdSize]);
+    } else {
+      result(FlutterMethodNotImplemented);
+    }
   } else {
     result(FlutterMethodNotImplemented);
   }

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -933,9 +933,9 @@ class AdManagerBannerAd extends AdWithView {
 
   /// Returns the AdSize of the associated platform ad object.
   ///
-  /// The dimensions of the [AdSize] returned here may differ from [size],
-  /// depending on what type of [AdSize] was used.
   /// The future will resolve to null if [load] has not been called yet.
+  /// The dimensions of the [AdSize] returned here may differ from [sizes],
+  /// depending on what type of [AdSize] was used.
   Future<AdSize?> getPlatformAdSize() async {
     return await instanceManager.getAdSize(this);
   }


### PR DESCRIPTION
## Description

* Updates the inline adaptive example to reload the ad when the screen orientation changes.
* Updates ios and android `getAdSize` error handling to be more explicit

## Related Issues


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
