### PR TITLE
Issue-404: Add App state event stream for app open ads

### DIFF
--- a/packages/app_open_example/ios/Flutter/AppFrameworkInfo.plist
+++ b/packages/app_open_example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>8.0</string>
+  <string>9.0</string>
 </dict>
 </plist>

--- a/packages/app_open_example/lib/app_lifecycle_reactor.dart
+++ b/packages/app_open_example/lib/app_lifecycle_reactor.dart
@@ -14,18 +14,23 @@
 
 // ignore_for_file: public_member_api_docs
 import 'package:app_open_example/app_open_ad_manager.dart';
-import 'package:flutter/material.dart';
+import 'package:google_mobile_ads/google_mobile_ads.dart';
 
-class AppLifecycleReactor extends WidgetsBindingObserver {
+/// Listens for app foreground events and shows app open ads.
+class AppLifecycleReactor {
   final AppOpenAdManager appOpenAdManager;
 
   AppLifecycleReactor({required this.appOpenAdManager});
 
-  @override
-  Future<void> didChangeAppLifecycleState(AppLifecycleState state) async {
-    // Try to show an app open ad if the app is being resumed and
-    // we're not already showing an app open ad.
-    if (state == AppLifecycleState.resumed) {
+  void listenToAppStateChanges() {
+    AppStateEventNotifier.startListening();
+    AppStateEventNotifier.appStateStream
+        .forEach((state) => _onAppStateChanged(state));
+  }
+
+  void _onAppStateChanged(AppState appState) {
+    print('New AppState state: $appState');
+    if (appState == AppState.foreground) {
       appOpenAdManager.showAdIfAvailable();
     }
   }

--- a/packages/app_open_example/lib/main.dart
+++ b/packages/app_open_example/lib/main.dart
@@ -51,13 +51,15 @@ class MyHomePage extends StatefulWidget {
 /// Example home page for an app open ad.
 class _MyHomePageState extends State<MyHomePage> {
   int _counter = 0;
+  late AppLifecycleReactor _appLifecycleReactor;
 
   @override
   void initState() {
     super.initState();
     AppOpenAdManager appOpenAdManager = AppOpenAdManager()..loadAd();
-    WidgetsBinding.instance!
-        .addObserver(AppLifecycleReactor(appOpenAdManager: appOpenAdManager));
+    _appLifecycleReactor =
+        AppLifecycleReactor(appOpenAdManager: appOpenAdManager);
+    _appLifecycleReactor.listenToAppStateChanges();
   }
 
   void _incrementCounter() {

--- a/packages/google_mobile_ads/android/build.gradle
+++ b/packages/google_mobile_ads/android/build.gradle
@@ -37,6 +37,7 @@ android {
             because 'previous versions have a bug impacting this android 12 behavior'
         }
       }
+      implementation 'androidx.lifecycle:lifecycle-process:2.2.0'
       testImplementation 'junit:junit:4.12'
       testImplementation 'org.hamcrest:hamcrest:2.2'
       testImplementation 'org.mockito:mockito-inline:3.9.0'

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AppStateNotifier.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AppStateNotifier.java
@@ -1,0 +1,96 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.flutter.plugins.googlemobileads;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.lifecycle.Lifecycle.Event;
+import androidx.lifecycle.LifecycleEventObserver;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.ProcessLifecycleOwner;
+import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.plugin.common.EventChannel;
+import io.flutter.plugin.common.EventChannel.EventSink;
+import io.flutter.plugin.common.EventChannel.StreamHandler;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
+import io.flutter.plugin.common.MethodChannel.Result;
+
+/** Listens to changes in app foreground/background and forwards events to Flutter. */
+final class AppStateNotifier implements LifecycleEventObserver, MethodCallHandler, StreamHandler {
+
+  private static final String METHOD_CHANNEL_NAME =
+      "plugins.flutter.io/google_mobile_ads/app_state_method";
+  private static final String EVENT_CHANNEL_NAME =
+      "plugins.flutter.io/google_mobile_ads/app_state_event";
+
+  @NonNull private MethodChannel methodChannel;
+
+  @NonNull private EventChannel eventChannel;
+
+  @NonNull private BinaryMessenger binaryMessenger;
+
+  @Nullable private EventSink events;
+
+  AppStateNotifier(BinaryMessenger binaryMessenger) {
+    this.binaryMessenger = binaryMessenger;
+    methodChannel = new MethodChannel(binaryMessenger, METHOD_CHANNEL_NAME);
+    methodChannel.setMethodCallHandler(this);
+    eventChannel = new EventChannel(binaryMessenger, EVENT_CHANNEL_NAME);
+    eventChannel.setStreamHandler(this);
+  }
+
+  private void start() {
+    ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
+  }
+
+  private void stop() {
+    ProcessLifecycleOwner.get().getLifecycle().removeObserver(this);
+  }
+
+  @Override
+  public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
+    switch (call.method) {
+      case "start":
+        start();
+        break;
+      case "stop":
+        stop();
+        break;
+      default:
+        result.notImplemented();
+    }
+  }
+
+  @Override
+  public void onStateChanged(@NonNull LifecycleOwner source, @NonNull Event event) {
+    if (event == Event.ON_START && events != null) {
+      events.success("foreground");
+    } else if (event == Event.ON_STOP && events != null) {
+      events.success("background");
+    }
+  }
+
+  @Override
+  public void onListen(Object arguments, EventSink events) {
+    this.events = events;
+  }
+
+  @Override
+  public void onCancel(Object arguments) {
+    this.events = null;
+  }
+}

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AppStateNotifier.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AppStateNotifier.java
@@ -38,11 +38,8 @@ final class AppStateNotifier implements LifecycleEventObserver, MethodCallHandle
       "plugins.flutter.io/google_mobile_ads/app_state_event";
 
   @NonNull private MethodChannel methodChannel;
-
   @NonNull private EventChannel eventChannel;
-
   @NonNull private BinaryMessenger binaryMessenger;
-
   @Nullable private EventSink events;
 
   AppStateNotifier(BinaryMessenger binaryMessenger) {

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -60,6 +60,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
   @Nullable private FlutterPluginBinding pluginBinding;
   @Nullable private AdInstanceManager instanceManager;
   @Nullable private AdMessageCodec adMessageCodec;
+  @Nullable private AppStateNotifier appStateNotifier;
   private final Map<String, NativeAdFactory> nativeAdFactories = new HashMap<>();
   private final FlutterMobileAdsWrapper flutterMobileAds;
   /**
@@ -188,6 +189,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
         .registerViewFactory(
             "plugins.flutter.io/google_mobile_ads/ad_widget",
             new GoogleMobileAdsViewFactory(instanceManager));
+    appStateNotifier = new AppStateNotifier(binding.getBinaryMessenger());
   }
 
   @Override
@@ -408,7 +410,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
                 requireNonNull(instanceManager),
                 requireNonNull(call.<String>argument("adUnitId")),
                 call.<FlutterAdRequest>argument("request"),
-                call.<FlutterAdManagerAdRequest>argument("adManagerAdRequest"),
+                call.<FlutterAdManagerAdRequest>argument("adManagerRequest"),
                 new FlutterAdLoader(appContext));
         instanceManager.trackAd(appOpenAd, call.<Integer>argument("adId"));
         appOpenAd.load();

--- a/packages/google_mobile_ads/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/google_mobile_ads/example/ios/Runner.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		9E4163BB26CCE99400220C78 /* FLTAppOpenAdTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E4163BA26CCE99300220C78 /* FLTAppOpenAdTest.m */; };
 		9E5A534926AA235D00B9438D /* FLTAdUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E5A534826AA235D00B9438D /* FLTAdUtil.m */; };
+		9E7B9D8F273206F800C6A6AB /* FLTAppStateNotifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E7B9D8E273206F800C6A6AB /* FLTAppStateNotifier.m */; };
 		9EA7213725BB6517008D57E3 /* GoogleMobileAds.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EA7213525BB6464008D57E3 /* GoogleMobileAds.xcframework */; };
 		9EA7213825BB6530008D57E3 /* GoogleMobileAds.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EA7213525BB6464008D57E3 /* GoogleMobileAds.xcframework */; };
 		9EA7474E2637CD6800E0B0E4 /* FLTBannerAdTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EA7474C2637CD6800E0B0E4 /* FLTBannerAdTest.m */; };
@@ -95,6 +96,8 @@
 		9E4163BA26CCE99300220C78 /* FLTAppOpenAdTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FLTAppOpenAdTest.m; path = ../../../ios/Tests/FLTAppOpenAdTest.m; sourceTree = "<group>"; };
 		9E5A534726AA235D00B9438D /* FLTAdUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FLTAdUtil.h; path = ../../ios/Classes/FLTAdUtil.h; sourceTree = "<group>"; };
 		9E5A534826AA235D00B9438D /* FLTAdUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FLTAdUtil.m; path = ../../ios/Classes/FLTAdUtil.m; sourceTree = "<group>"; };
+		9E7B9D8D273206F800C6A6AB /* FLTAppStateNotifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FLTAppStateNotifier.h; path = ../../ios/Classes/FLTAppStateNotifier.h; sourceTree = "<group>"; };
+		9E7B9D8E273206F800C6A6AB /* FLTAppStateNotifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FLTAppStateNotifier.m; path = ../../ios/Classes/FLTAppStateNotifier.m; sourceTree = "<group>"; };
 		9EA7213525BB6464008D57E3 /* GoogleMobileAds.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GoogleMobileAds.xcframework; path = "Pods/Google-Mobile-Ads-SDK/Frameworks/GoogleMobileAdsFramework-Current/GoogleMobileAds.xcframework"; sourceTree = "<group>"; };
 		9EA7474C2637CD6800E0B0E4 /* FLTBannerAdTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FLTBannerAdTest.m; path = ../../../ios/Tests/FLTBannerAdTest.m; sourceTree = "<group>"; };
 		9EA7474D2637CD6800E0B0E4 /* FLTGAMBannerAdTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FLTGAMBannerAdTest.m; path = ../../../ios/Tests/FLTGAMBannerAdTest.m; sourceTree = "<group>"; };
@@ -200,6 +203,8 @@
 		97C146E51CF9000F007C117D = {
 			isa = PBXGroup;
 			children = (
+				9E7B9D8D273206F800C6A6AB /* FLTAppStateNotifier.h */,
+				9E7B9D8E273206F800C6A6AB /* FLTAppStateNotifier.m */,
 				9E5A534726AA235D00B9438D /* FLTAdUtil.h */,
 				9E5A534826AA235D00B9438D /* FLTAdUtil.m */,
 				9EF4E6FB26392B230007E4FE /* FLTAd_Internal.h */,
@@ -451,6 +456,7 @@
 				9EF4E70526392B230007E4FE /* FLTGoogleMobileAdsReaderWriter_Internal.h in Sources */,
 				9EF4E70626392B230007E4FE /* FLTAdInstanceManager_Internal.m in Sources */,
 				9EF4E70726392B230007E4FE /* FLTGoogleMobileAdsReaderWriter_Internal.m in Sources */,
+				9E7B9D8F273206F800C6A6AB /* FLTAppStateNotifier.m in Sources */,
 				9EF4E70826392B230007E4FE /* FLTAd_Internal.h in Sources */,
 				9E4163BB26CCE99400220C78 /* FLTAppOpenAdTest.m in Sources */,
 				9EF4E70926392B230007E4FE /* FLTGoogleMobileAdsPlugin.m in Sources */,

--- a/packages/google_mobile_ads/ios/Classes/FLTAppStateNotifier.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAppStateNotifier.h
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export 'src/ad_containers.dart';
-export 'src/ad_listeners.dart';
-export 'src/app_background_event_notifier.dart';
-export 'src/mobile_ads.dart';
-export 'src/request_configuration.dart';
+#import <Flutter/Flutter.h>
+
+@interface FLTAppStateNotifier : NSObject <FlutterStreamHandler>
+
+- (instancetype _Nonnull)initWithBinaryMessenger:
+    (NSObject<FlutterBinaryMessenger> *_Nonnull)messenger;
+
+@end

--- a/packages/google_mobile_ads/ios/Classes/FLTAppStateNotifier.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAppStateNotifier.m
@@ -1,0 +1,137 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "FLTAppStateNotifier.h"
+
+@implementation FLTAppStateNotifier {
+  FlutterEventChannel *_eventChannel;
+  FlutterMethodChannel *_methodChannel;
+  FlutterEventSink _events;
+  NSMutableArray<id<NSObject>> *_observers;
+  BOOL _applicationInBackground;
+}
+
+- (instancetype _Nonnull)initWithBinaryMessenger:
+    (NSObject<FlutterBinaryMessenger> *_Nonnull)messenger {
+  self = [self init];
+  if (self) {
+    FLTAppStateNotifier *__weak weakSelf = self;
+    _observers = [[NSMutableArray alloc] init];
+    _eventChannel = [FlutterEventChannel
+        eventChannelWithName:@"plugins.flutter.io/google_mobile_ads/app_state_event"
+             binaryMessenger:messenger];
+    _methodChannel = [FlutterMethodChannel
+        methodChannelWithName:@"plugins.flutter.io/google_mobile_ads/app_state_method"
+              binaryMessenger:messenger];
+    [_eventChannel setStreamHandler:self];
+    [_methodChannel
+        setMethodCallHandler:^(FlutterMethodCall *_Nonnull call, FlutterResult _Nonnull result) {
+          [weakSelf handleMethodCall:call result:result];
+        }];
+  }
+  return self;
+}
+
+- (void)handleMethodCall:(FlutterMethodCall *_Nonnull)call result:(FlutterResult _Nonnull)result {
+  if ([call.method isEqualToString:@"start"]) {
+    [self addAppStateObservers];
+    result(nil);
+  } else if ([call.method isEqualToString:@"stop"]) {
+    [self removeAppStateObservers];
+    result(nil);
+  } else {
+    result(FlutterMethodNotImplemented);
+  }
+}
+
+- (void)addAppStateObservers {
+  if (_observers.count > 0) {
+    NSLog(@"FLTAppStateNotifier: Already listening for foreground/background changes.");
+    return;
+  }
+
+  id<NSObject> foregroundObserver = [NSNotificationCenter.defaultCenter
+      addObserverForName:UIApplicationWillEnterForegroundNotification
+                  object:nil
+                   queue:nil
+              usingBlock:^(NSNotification *_Nonnull note) {
+                [self handleWillEnterForeground];
+              }];
+  [_observers addObject:foregroundObserver];
+
+  id<NSObject> backgroundObserver = [NSNotificationCenter.defaultCenter
+      addObserverForName:UIApplicationDidEnterBackgroundNotification
+                  object:nil
+                   queue:nil
+              usingBlock:^(NSNotification *_Nonnull note) {
+                [self handleDidEnterBackground];
+              }];
+  [_observers addObject:backgroundObserver];
+
+  if (@available(iOS 13.0, *)) {
+    id<NSObject> foregroundSceneObserver = [NSNotificationCenter.defaultCenter
+        addObserverForName:UISceneWillEnterForegroundNotification
+                    object:nil
+                     queue:nil
+                usingBlock:^(NSNotification *_Nonnull note) {
+                  [self handleWillEnterForeground];
+                }];
+    [_observers addObject:foregroundSceneObserver];
+
+    id<NSObject> backgroundSceneObserver =
+        [NSNotificationCenter.defaultCenter addObserverForName:UISceneDidEnterBackgroundNotification
+                                                        object:nil
+                                                         queue:nil
+                                                    usingBlock:^(NSNotification *_Nonnull note) {
+                                                      [self handleDidEnterBackground];
+                                                    }];
+    [_observers addObject:backgroundSceneObserver];
+  }
+}
+
+- (void)removeAppStateObservers {
+  while (_observers.count > 0) {
+    [NSNotificationCenter.defaultCenter removeObserver:_observers.lastObject];
+    [_observers removeLastObject];
+  }
+}
+
+- (void)handleWillEnterForeground {
+  if (!_applicationInBackground) {
+    return;
+  }
+  _applicationInBackground = NO;
+  _events(@"foreground");
+}
+
+- (void)handleDidEnterBackground {
+  if (_applicationInBackground) {
+    return;
+  }
+  _applicationInBackground = YES;
+  _events(@"background");
+}
+
+- (FlutterError *_Nullable)onCancelWithArguments:(id _Nullable)arguments {
+  _events = nil;
+  return nil;
+}
+
+- (FlutterError *_Nullable)onListenWithArguments:(id _Nullable)arguments
+                                       eventSink:(nonnull FlutterEventSink)events {
+  _events = events;
+  return nil;
+}
+
+@end

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
@@ -14,6 +14,7 @@
 
 #import "FLTGoogleMobileAdsPlugin.h"
 #import "FLTAdUtil.h"
+#import "FLTAppStateNotifier.h"
 
 @interface FLTGoogleMobileAdsPlugin ()
 @property(nonatomic, retain) FlutterMethodChannel *channel;
@@ -53,6 +54,7 @@
 @implementation FLTGoogleMobileAdsPlugin {
   NSMutableDictionary<NSString *, id<FLTNativeAdFactory>> *_nativeAdFactories;
   FLTAdInstanceManager *_manager;
+  FLTAppStateNotifier *_appStateNotifier;
 }
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
@@ -86,6 +88,7 @@
   if (self) {
     _nativeAdFactories = [NSMutableDictionary dictionary];
     _manager = [[FLTAdInstanceManager alloc] initWithBinaryMessenger:binaryMessenger];
+    _appStateNotifier = [[FLTAppStateNotifier alloc] initWithBinaryMessenger:binaryMessenger];
   }
 
   return self;

--- a/packages/google_mobile_ads/lib/src/app_background_event_notifier.dart
+++ b/packages/google_mobile_ads/lib/src/app_background_event_notifier.dart
@@ -1,0 +1,61 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/services.dart';
+
+/// The app foreground/background state.
+enum AppState {
+  /// App is backgrounded.
+  background,
+
+  /// App is foregrounded.
+  foreground
+}
+
+/// Notifies changes in app foreground/background.
+///
+/// Subscribe to [appStateStream] to get notified of changes in [AppState].
+/// Use this when implementing app open ads instead of [WidgetsBindingObserver],
+/// because the latter also notifies when the state of the Flutter
+/// activity/view controller changes. This makes an interstitial taking control
+/// of the screen indistinguishable from the app background/foreground.
+class AppStateEventNotifier {
+  static const _eventChannelName =
+      'plugins.flutter.io/google_mobile_ads/app_state_event';
+  static const _methodChannelName =
+      'plugins.flutter.io/google_mobile_ads/app_state_method';
+  static const EventChannel _eventChannel = EventChannel(_eventChannelName);
+  static const MethodChannel _methodChannel = MethodChannel(_methodChannelName);
+
+  /// Subscribe to this to get notified of changes in [AppState].
+  ///
+  /// Call [startListening] before subscribing to this stream to
+  /// start listening to background/foreground events on the platform side.
+  static Stream<AppState> get appStateStream =>
+      _eventChannel.receiveBroadcastStream().map((event) =>
+          event == 'foreground' ? AppState.foreground : AppState.background);
+
+  /// Start listening to background/foreground events.
+  static Future<void> startListening() async {
+    return _methodChannel.invokeMethod('start');
+  }
+
+  /// Stop listening to background/foreground events.
+  static Future<void> stopListening() async {
+    return _methodChannel.invokeMethod('stop');
+  }
+}


### PR DESCRIPTION
## Description
- Adds an API that passes app foreground/background events from platform side to a Dart stream. 
- Updates the app open example app to use the new api
- This is necessary because `WidgetsBindingObserver` considers the Flutter activity/view controller losing focus the same as the app background/foreground. This makes it so actions such as showing an interstitial ad is treated the same as the app foregrounding/backgrounding.

## Related Issues
https://github.com/googleads/googleads-mobile-flutter/issues/404

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
