### PR TITLE
Admob extras api

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -17,6 +17,14 @@
   * See the app open [example app](https://github.com/googleads/googleads-mobile-flutter/tree/master/packages/app_open_example) for a reference
     on how to use the new API.
     
+* Adds a new parameter `extras` to `AdRequest` and `AdManagerAdRequest`.
+  * This can be used to pass additional signals to the AdMob adapter, such as
+    [CCPA](https://developers.google.com/admob/android/ccpa) signals.
+  * For example, to notify Google that [RDP](https://developers.google.com/admob/android/ccpa#rdp_signal)
+    should be enabled when constructing an ad request:
+    ```dart
+      AdRequest request = AdRequest(extras: {'rdp': '1'});
+    ```
 ## 0.13.6
 
 * Partial fix for [#265](https://github.com/googleads/googleads-mobile-flutter/issues/265).

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
@@ -91,6 +91,7 @@ class AdMessageCodec extends StandardMessageCodec {
       writeValue(stream, request.getHttpTimeoutMillis());
       writeValue(stream, request.getPublisherProvidedId());
       writeValue(stream, request.getLocation());
+      writeValue(stream, request.getAdMobExtras());
     } else if (value instanceof FlutterAdRequest) {
       stream.write(VALUE_AD_REQUEST);
       final FlutterAdRequest request = (FlutterAdRequest) value;
@@ -100,6 +101,7 @@ class AdMessageCodec extends StandardMessageCodec {
       writeValue(stream, request.getNeighboringContentUrls());
       writeValue(stream, request.getHttpTimeoutMillis());
       writeValue(stream, request.getLocation());
+      writeValue(stream, request.getAdMobExtras());
     } else if (value instanceof FlutterRewardedAd.FlutterRewardItem) {
       stream.write(VALUE_REWARD_ITEM);
       final FlutterRewardedAd.FlutterRewardItem item = (FlutterRewardedAd.FlutterRewardItem) value;
@@ -228,6 +230,7 @@ class AdMessageCodec extends StandardMessageCodec {
             .setNeighboringContentUrls((List<String>) readValueOfType(buffer.get(), buffer))
             .setHttpTimeoutMillis((Integer) readValueOfType(buffer.get(), buffer))
             .setLocation((Location) readValueOfType(buffer.get(), buffer))
+            .setAdMobExtras((Map<String, String>) readValueOfType(buffer.get(), buffer))
             .build();
       case VALUE_REWARD_ITEM:
         return new FlutterRewardedAd.FlutterRewardItem(
@@ -268,6 +271,7 @@ class AdMessageCodec extends StandardMessageCodec {
         builder.setHttpTimeoutMillis((Integer) readValueOfType(buffer.get(), buffer));
         builder.setPublisherProvidedId((String) readValueOfType(buffer.get(), buffer));
         builder.setLocation((Location) readValueOfType(buffer.get(), buffer));
+        builder.setAdMobExtras((Map<String, String>) readValueOfType(buffer.get(), buffer));
         return builder.build();
       case VALUE_INITIALIZATION_STATE:
         final String state = (String) readValueOfType(buffer.get(), buffer);

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequest.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequest.java
@@ -15,9 +15,7 @@
 package io.flutter.plugins.googlemobileads;
 
 import android.location.Location;
-import android.os.Bundle;
 import androidx.annotation.Nullable;
-import com.google.ads.mediation.admob.AdMobAdapter;
 import com.google.android.gms.ads.admanager.AdManagerAdRequest;
 import java.util.List;
 import java.util.Map;
@@ -65,7 +63,8 @@ class FlutterAdManagerAdRequest extends FlutterAdRequest {
           getNeighboringContentUrls(),
           getHttpTimeoutMillis(),
           getLocation(),
-          publisherProvidedId);
+          publisherProvidedId,
+          getAdMobExtras());
     }
   }
 
@@ -78,14 +77,16 @@ class FlutterAdManagerAdRequest extends FlutterAdRequest {
       @Nullable List<String> neighboringContentUrls,
       @Nullable Integer httpTimeoutMillis,
       @Nullable Location location,
-      @Nullable String publisherProvidedId) {
+      @Nullable String publisherProvidedId,
+      @Nullable Map<String, String> adMobExtras) {
     super(
         keywords,
         contentUrl,
         nonPersonalizedAds,
         neighboringContentUrls,
         httpTimeoutMillis,
-        location);
+        location,
+        adMobExtras);
     this.customTargeting = customTargeting;
     this.customTargetingLists = customTargetingLists;
     this.publisherProvidedId = publisherProvidedId;
@@ -112,11 +113,7 @@ class FlutterAdManagerAdRequest extends FlutterAdRequest {
         builder.addCustomTargeting(entry.getKey(), entry.getValue());
       }
     }
-    if (getNonPersonalizedAds() != null && getNonPersonalizedAds()) {
-      final Bundle extras = new Bundle();
-      extras.putString("npa", "1");
-      builder.addNetworkExtrasBundle(AdMobAdapter.class, extras);
-    }
+    addNetworkExtras(builder);
     if (publisherProvidedId != null) {
       builder.setPublisherProvidedId(publisherProvidedId);
     }

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -243,6 +244,24 @@ public class AdMessageCodecTest {
     assertNull(result.startMuted);
   }
 
+  public void encodeEmptyFlutterAdRequest() {
+    FlutterAdRequest adRequest = new FlutterAdRequest.Builder().build();
+    final ByteBuffer message = codec.encodeMessage(adRequest);
+
+    final FlutterAdRequest decodedRequest =
+        (FlutterAdRequest) codec.decodeMessage((ByteBuffer) message.position(0));
+    assertEquals(adRequest, decodedRequest);
+  }
+
+  public void encodeEmptyFlutterAdManagerAdRequest() {
+    FlutterAdManagerAdRequest adRequest = new FlutterAdManagerAdRequest.Builder().build();
+    final ByteBuffer message = codec.encodeMessage(adRequest);
+
+    final FlutterAdManagerAdRequest decodedRequest =
+        (FlutterAdManagerAdRequest) codec.decodeMessage((ByteBuffer) message.position(0));
+    assertEquals(adRequest, decodedRequest);
+  }
+
   @Test
   public void encodeFlutterAdRequest() {
     Location location = new Location("");
@@ -250,6 +269,7 @@ public class AdMessageCodecTest {
     location.setLongitude(1.0);
     location.setLatitude(5.0);
     location.setTime(54321);
+    Map<String, String> extras = Collections.singletonMap("key", "value");
     FlutterAdRequest adRequest =
         new FlutterAdRequest.Builder()
             .setKeywords(Arrays.asList("1", "2", "3"))
@@ -258,6 +278,7 @@ public class AdMessageCodecTest {
             .setNeighboringContentUrls(Arrays.asList("example.com", "test.com"))
             .setHttpTimeoutMillis(1000)
             .setLocation(location)
+            .setAdMobExtras(extras)
             .build();
     final ByteBuffer message = codec.encodeMessage(adRequest);
 
@@ -282,6 +303,8 @@ public class AdMessageCodecTest {
     builder.setNonPersonalizedAds(true);
     builder.setPublisherProvidedId("pub-provided-id");
     builder.setLocation(location);
+    builder.setAdMobExtras(Collections.singletonMap("key", "value"));
+
     FlutterAdManagerAdRequest flutterAdManagerAdRequest = builder.build();
 
     final ByteBuffer message = codec.encodeMessage(flutterAdManagerAdRequest);

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
@@ -84,6 +84,8 @@
 @property BOOL nonPersonalizedAds;
 @property NSArray<NSString *> *_Nullable neighboringContentURLs;
 @property FLTLocationParams *_Nullable location;
+@property NSDictionary<NSString *, NSString *> *_Nullable adMobExtras;
+
 - (GADRequest *_Nonnull)asGADRequest;
 @end
 

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
@@ -161,11 +161,7 @@
   GADRequest *request = [GADRequest request];
   request.keywords = _keywords;
   request.contentURL = _contentURL;
-  if (_nonPersonalizedAds) {
-    GADExtras *extras = [[GADExtras alloc] init];
-    extras.additionalParameters = @{@"npa" : @"1"};
-    [request registerAdNetworkExtras:extras];
-  }
+  [self addAdMobExtras:request];
   request.neighboringContentURLStrings = _neighboringContentURLs;
   request.requestAgent = FLT_REQUEST_AGENT_VERSIONED;
   if ([FLTAdUtil isNotNull:_location]) {
@@ -175,6 +171,24 @@
   }
   return request;
 }
+
+- (void)addAdMobExtras:(GADRequest *_Nonnull)request {
+  NSMutableDictionary<NSString *, NSString *> *additionalParams =
+      [[NSMutableDictionary alloc] init];
+
+  if (_nonPersonalizedAds) {
+    additionalParams[@"npa"] = @"1";
+  }
+  if (_adMobExtras) {
+    [additionalParams addEntriesFromDictionary:_adMobExtras];
+  }
+  if (additionalParams.count > 0) {
+    GADExtras *extras = [[GADExtras alloc] init];
+    extras.additionalParameters = additionalParams;
+    [request registerAdNetworkExtras:extras];
+  }
+}
+
 @end
 
 @implementation FLTGADResponseInfo
@@ -243,11 +257,7 @@
   [targetingDictionary addEntriesFromDictionary:self.customTargetingLists];
   request.customTargeting = targetingDictionary;
 
-  if (self.nonPersonalizedAds) {
-    GADExtras *extras = [[GADExtras alloc] init];
-    extras.additionalParameters = @{@"npa" : @"1"};
-    [request registerAdNetworkExtras:extras];
-  }
+  [self addAdMobExtras:request];
   if ([FLTAdUtil isNotNull:self.location]) {
     [request setLocationWithLatitude:self.location.latitude.floatValue
                            longitude:self.location.longitude.floatValue

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
@@ -92,6 +92,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
       request.nonPersonalizedAds = nonPersonalizedAds.boolValue;
       request.neighboringContentURLs = [self readValueOfType:[self readByte]];
       request.location = [self readValueOfType:[self readByte]];
+      request.adMobExtras = [self readValueOfType:[self readByte]];
       return request;
     }
     case FLTAdMobFieldRewardItem: {
@@ -156,6 +157,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
       request.neighboringContentURLs = [self readValueOfType:[self readByte]];
       request.pubProvidedID = [self readValueOfType:[self readByte]];
       request.location = [self readValueOfType:[self readByte]];
+      request.adMobExtras = [self readValueOfType:[self readByte]];
       return request;
     }
     case FLTAdMobFieldAdapterInitializationState: {
@@ -278,6 +280,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     [self writeValue:request.neighboringContentURLs];
     [self writeValue:request.pubProvidedID];
     [self writeValue:request.location];
+    [self writeValue:request.adMobExtras];
   } else if ([value isKindOfClass:[FLTAdRequest class]]) {
     [self writeByte:FLTAdMobFieldAdRequest];
     FLTAdRequest *request = value;
@@ -286,6 +289,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     [self writeValue:@(request.nonPersonalizedAds)];
     [self writeValue:request.neighboringContentURLs];
     [self writeValue:request.location];
+    [self writeValue:request.adMobExtras];
   } else if ([value isKindOfClass:[FLTRewardItem class]]) {
     [self writeByte:FLTAdMobFieldRewardItem];
     FLTRewardItem *item = value;

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
@@ -229,7 +229,7 @@
   NSArray<NSString *> *contentURLs = @[ @"url-1.com", @"url-2.com" ];
   request.neighboringContentURLs = contentURLs;
   request.location = [[FLTLocationParams alloc] initWithAccuracy:@1.5 longitude:@52 latitude:@123];
-  request.adMobExtras = @{@"key": @"value"};
+  request.adMobExtras = @{@"key" : @"value"};
   NSData *encodedMessage = [_messageCodec encode:request];
 
   FLTAdRequest *decodedRequest = [_messageCodec decode:encodedMessage];
@@ -240,7 +240,7 @@
   XCTAssertEqualObjects(decodedRequest.location.accuracy, @1.5);
   XCTAssertEqualObjects(decodedRequest.location.longitude, @52);
   XCTAssertEqualObjects(decodedRequest.location.latitude, @123);
-  XCTAssertEqualObjects(decodedRequest.adMobExtras, @{@"key": @"value"});
+  XCTAssertEqualObjects(decodedRequest.adMobExtras, @{@"key" : @"value"});
 }
 
 - (void)testEncodeDecodeGAMAdRequest {
@@ -254,7 +254,7 @@
   request.neighboringContentURLs = contentURLs;
   request.pubProvidedID = @"pub-id";
   request.location = [[FLTLocationParams alloc] initWithAccuracy:@1.5 longitude:@52 latitude:@123];
-  request.adMobExtras = @{@"key": @"value"};
+  request.adMobExtras = @{@"key" : @"value"};
   NSData *encodedMessage = [_messageCodec encode:request];
 
   FLTGAMAdRequest *decodedRequest = [_messageCodec decode:encodedMessage];
@@ -269,7 +269,7 @@
   XCTAssertEqualObjects(decodedRequest.location.accuracy, @1.5);
   XCTAssertEqualObjects(decodedRequest.location.longitude, @52);
   XCTAssertEqualObjects(decodedRequest.location.latitude, @123);
-  XCTAssertEqualObjects(decodedRequest.adMobExtras, @{@"key": @"value"});
+  XCTAssertEqualObjects(decodedRequest.adMobExtras, @{@"key" : @"value"});
 }
 
 - (void)testEncodeDecodeRewardItem {

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
@@ -229,6 +229,7 @@
   NSArray<NSString *> *contentURLs = @[ @"url-1.com", @"url-2.com" ];
   request.neighboringContentURLs = contentURLs;
   request.location = [[FLTLocationParams alloc] initWithAccuracy:@1.5 longitude:@52 latitude:@123];
+  request.adMobExtras = @{@"key": @"value"};
   NSData *encodedMessage = [_messageCodec encode:request];
 
   FLTAdRequest *decodedRequest = [_messageCodec decode:encodedMessage];
@@ -239,6 +240,7 @@
   XCTAssertEqualObjects(decodedRequest.location.accuracy, @1.5);
   XCTAssertEqualObjects(decodedRequest.location.longitude, @52);
   XCTAssertEqualObjects(decodedRequest.location.latitude, @123);
+  XCTAssertEqualObjects(decodedRequest.adMobExtras, @{@"key": @"value"});
 }
 
 - (void)testEncodeDecodeGAMAdRequest {
@@ -252,6 +254,7 @@
   request.neighboringContentURLs = contentURLs;
   request.pubProvidedID = @"pub-id";
   request.location = [[FLTLocationParams alloc] initWithAccuracy:@1.5 longitude:@52 latitude:@123];
+  request.adMobExtras = @{@"key": @"value"};
   NSData *encodedMessage = [_messageCodec encode:request];
 
   FLTGAMAdRequest *decodedRequest = [_messageCodec decode:encodedMessage];
@@ -266,6 +269,7 @@
   XCTAssertEqualObjects(decodedRequest.location.accuracy, @1.5);
   XCTAssertEqualObjects(decodedRequest.location.longitude, @52);
   XCTAssertEqualObjects(decodedRequest.location.latitude, @123);
+  XCTAssertEqualObjects(decodedRequest.adMobExtras, @{@"key": @"value"});
 }
 
 - (void)testEncodeDecodeRewardItem {

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -190,6 +190,7 @@ class AdRequest {
     this.nonPersonalizedAds,
     this.httpTimeoutMillis,
     this.location,
+    this.extras,
   });
 
   /// Words or phrases describing the current user activity.
@@ -219,6 +220,9 @@ class AdRequest {
   /// Used for mediation targeting purposes.
   final LocationParams? location;
 
+  /// Extras to pass to the AdMob adapter.
+  final Map<String, String>? extras;
+
   @override
   bool operator ==(Object other) {
     return other is AdRequest &&
@@ -227,7 +231,8 @@ class AdRequest {
         nonPersonalizedAds == other.nonPersonalizedAds &&
         listEquals(neighboringContentUrls, other.neighboringContentUrls) &&
         httpTimeoutMillis == other.httpTimeoutMillis &&
-        location == other.location;
+        location == other.location &&
+        extras == other.extras;
   }
 }
 
@@ -244,6 +249,7 @@ class AdManagerAdRequest extends AdRequest {
     int? httpTimeoutMillis,
     this.publisherProvidedId,
     LocationParams? location,
+    Map<String, String>? extras,
   }) : super(
           keywords: keywords,
           contentUrl: contentUrl,
@@ -251,6 +257,7 @@ class AdManagerAdRequest extends AdRequest {
           nonPersonalizedAds: nonPersonalizedAds,
           httpTimeoutMillis: httpTimeoutMillis,
           location: location,
+          extras: extras,
         );
 
   /// Key-value pairs used for custom targeting.

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -232,7 +232,7 @@ class AdRequest {
         listEquals(neighboringContentUrls, other.neighboringContentUrls) &&
         httpTimeoutMillis == other.httpTimeoutMillis &&
         location == other.location &&
-        extras == other.extras;
+        mapEquals<String, String>(extras, other.extras);
   }
 }
 

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -737,6 +737,7 @@ class AdMessageCodec extends StandardMessageCodec {
       }
       writeValue(buffer, value.publisherProvidedId);
       writeValue(buffer, value.location);
+      writeValue(buffer, value.extras);
     } else if (value is AdRequest) {
       buffer.putUint8(_valueAdRequest);
       writeValue(buffer, value.keywords);
@@ -747,6 +748,7 @@ class AdMessageCodec extends StandardMessageCodec {
         writeValue(buffer, value.httpTimeoutMillis);
       }
       writeValue(buffer, value.location);
+      writeValue(buffer, value.extras);
     } else if (value is RewardItem) {
       buffer.putUint8(_valueRewardItem);
       writeValue(buffer, value.amount);
@@ -885,6 +887,8 @@ class AdMessageCodec extends StandardMessageCodec {
               ? readValueOfType(buffer.getUint8(), buffer)
               : null,
           location: readValueOfType(buffer.getUint8(), buffer),
+          extras: readValueOfType(buffer.getUint8(), buffer)
+              ?.cast<String, String>(),
         );
       case _valueRewardItem:
         return RewardItem(
@@ -934,6 +938,8 @@ class AdMessageCodec extends StandardMessageCodec {
               : null,
           publisherProvidedId: readValueOfType(buffer.getUint8(), buffer),
           location: readValueOfType(buffer.getUint8(), buffer),
+          extras: readValueOfType(buffer.getUint8(), buffer)
+              ?.cast<String, String>(),
         );
       case _valueInitializationState:
         switch (readValueOfType(buffer.getUint8(), buffer)) {

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -1322,14 +1322,14 @@ void main() {
       debugDefaultTargetPlatformOverride = TargetPlatform.android;
 
       final AdRequest adRequest = AdRequest(
-          keywords: <String>['1', '2', '3'],
-          contentUrl: 'contentUrl',
-          nonPersonalizedAds: false,
-          neighboringContentUrls: <String>['url1.com', 'url2.com'],
-          httpTimeoutMillis: 12345,
-          location: LocationParams(
-              accuracy: 1.1, longitude: 25, latitude: 38, time: 1),
-          extras: {'key' : 'value'},
+        keywords: <String>['1', '2', '3'],
+        contentUrl: 'contentUrl',
+        nonPersonalizedAds: false,
+        neighboringContentUrls: <String>['url1.com', 'url2.com'],
+        httpTimeoutMillis: 12345,
+        location:
+            LocationParams(accuracy: 1.1, longitude: 25, latitude: 38, time: 1),
+        extras: {'key': 'value'},
       );
 
       final ByteData byteData = codec.encodeMessage(adRequest)!;
@@ -1340,14 +1340,14 @@ void main() {
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
 
       final AdRequest adRequest = AdRequest(
-          keywords: <String>['1', '2', '3'],
-          contentUrl: 'contentUrl',
-          nonPersonalizedAds: false,
-          neighboringContentUrls: <String>['url1.com', 'url2.com'],
-          httpTimeoutMillis: 12345,
-          location: LocationParams(
-              accuracy: 1.1, longitude: 25, latitude: 38, time: 1),
-        extras: {'key' : 'value'},
+        keywords: <String>['1', '2', '3'],
+        contentUrl: 'contentUrl',
+        nonPersonalizedAds: false,
+        neighboringContentUrls: <String>['url1.com', 'url2.com'],
+        httpTimeoutMillis: 12345,
+        location:
+            LocationParams(accuracy: 1.1, longitude: 25, latitude: 38, time: 1),
+        extras: {'key': 'value'},
       );
 
       final ByteData byteData = codec.encodeMessage(adRequest)!;
@@ -1511,7 +1511,7 @@ void main() {
         publisherProvidedId: 'test-pub-id',
         location:
             LocationParams(accuracy: 1.1, longitude: 25, latitude: 38, time: 1),
-        extras: {'key' : 'value'},
+        extras: {'key': 'value'},
       );
       final ByteData byteData = codec.encodeMessage(request)!;
 
@@ -1537,7 +1537,7 @@ void main() {
         publisherProvidedId: 'test-pub-id',
         location:
             LocationParams(accuracy: 1.1, longitude: 25, latitude: 38, time: 1),
-        extras: {'key' : 'value'},
+        extras: {'key': 'value'},
       );
 
       final ByteData byteData = codec.encodeMessage(request)!;

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -1328,7 +1328,9 @@ void main() {
           neighboringContentUrls: <String>['url1.com', 'url2.com'],
           httpTimeoutMillis: 12345,
           location: LocationParams(
-              accuracy: 1.1, longitude: 25, latitude: 38, time: 1));
+              accuracy: 1.1, longitude: 25, latitude: 38, time: 1),
+          extras: {'key' : 'value'},
+      );
 
       final ByteData byteData = codec.encodeMessage(adRequest)!;
       expect(codec.decodeMessage(byteData), adRequest);
@@ -1344,7 +1346,9 @@ void main() {
           neighboringContentUrls: <String>['url1.com', 'url2.com'],
           httpTimeoutMillis: 12345,
           location: LocationParams(
-              accuracy: 1.1, longitude: 25, latitude: 38, time: 1));
+              accuracy: 1.1, longitude: 25, latitude: 38, time: 1),
+        extras: {'key' : 'value'},
+      );
 
       final ByteData byteData = codec.encodeMessage(adRequest)!;
       AdRequest decoded = codec.decodeMessage(byteData);
@@ -1507,6 +1511,7 @@ void main() {
         publisherProvidedId: 'test-pub-id',
         location:
             LocationParams(accuracy: 1.1, longitude: 25, latitude: 38, time: 1),
+        extras: {'key' : 'value'},
       );
       final ByteData byteData = codec.encodeMessage(request)!;
 
@@ -1532,6 +1537,7 @@ void main() {
         publisherProvidedId: 'test-pub-id',
         location:
             LocationParams(accuracy: 1.1, longitude: 25, latitude: 38, time: 1),
+        extras: {'key' : 'value'},
       );
 
       final ByteData byteData = codec.encodeMessage(request)!;


### PR DESCRIPTION
## Description

Adds a new parameter `extras` to AdRequest and AdManagerAdRequest. This allows passing of additional signals to the AdMobAdapter, for things such as [CCPA](https://developers.google.com/admob/android/ccpa)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
