### PR TITLE
Issue 449 - make time optional on android.

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.1
+
+* Fix for [Issue 449](https://github.com/googleads/googleads-mobile-flutter/issues/449).
+  In `LocationParams`, time is now treated as an optional parameter on Android.
+  
+
 ## 1.0.0
 
 * Mediation is now supported in beta.

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
@@ -334,7 +334,10 @@ class AdMessageCodec extends StandardMessageCodec {
         location.setAccuracy(((Double) readValueOfType(buffer.get(), buffer)).floatValue());
         location.setLongitude((double) readValueOfType(buffer.get(), buffer));
         location.setLatitude((double) readValueOfType(buffer.get(), buffer));
-        location.setTime((long) readValueOfType(buffer.get(), buffer));
+        Long time = (Long) readValueOfType(buffer.get(), buffer);
+        if (time != null) {
+          location.setTime(time);
+        }
         return location;
       default:
         return super.readValueOfType(type, buffer);

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
@@ -17,7 +17,7 @@ package io.flutter.plugins.googlemobileads;
 /** Constants used in the plugin. */
 public class Constants {
   /** Version request agent. Should be bumped alongside plugin versions. */
-  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-1.0.0";
+  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-1.0.1";
 
   static final String ERROR_CODE_UNEXPECTED_AD_TYPE = "unexpected_ad_type";
 }

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
@@ -263,6 +263,28 @@ public class AdMessageCodecTest {
   }
 
   @Test
+  public void testEncodeLocationWithoutTime() {
+    Location location = new Location("");
+    location.setAccuracy(12345f);
+    location.setLongitude(1.0);
+    location.setLatitude(5.0);
+
+    FlutterAdRequest request = new FlutterAdRequest.Builder().setLocation(location).build();
+    ByteBuffer message = codec.encodeMessage(request);
+    FlutterAdRequest decodedRequest =
+        (FlutterAdRequest) codec.decodeMessage((ByteBuffer) message.position(0));
+    assertEquals(request, decodedRequest);
+
+    FlutterAdManagerAdRequest.Builder builder = new FlutterAdManagerAdRequest.Builder();
+    builder.setLocation(location);
+    FlutterAdManagerAdRequest gamRequest = builder.build();
+    message = codec.encodeMessage(gamRequest);
+    final FlutterAdManagerAdRequest decodedGAMRequest =
+        (FlutterAdManagerAdRequest) codec.decodeMessage((ByteBuffer) message.position(0));
+    assertEquals(decodedGAMRequest, gamRequest);
+  }
+
+  @Test
   public void encodeFlutterAdRequest() {
     Location location = new Location("");
     location.setAccuracy(12345f);

--- a/packages/google_mobile_ads/ios/Classes/FLTConstants.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTConstants.h
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /** Versioned request agent string. */
-#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-1.0.0"
+#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-1.0.1"

--- a/packages/google_mobile_ads/pubspec.yaml
+++ b/packages/google_mobile_ads/pubspec.yaml
@@ -16,7 +16,7 @@ name: google_mobile_ads
 description: Flutter plugin for Google Mobile Ads, supporting
   banner, interstitial (full-screen),  rewarded and native ads
 homepage: https://github.com/googleads/googleads-mobile-flutter/tree/master/packages/google_mobile_ads
-version: 1.0.0
+version: 1.0.1
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Makes `time` an optional param in `LocationParams` on Android. 


## Related Issues

https://github.com/googleads/googleads-mobile-flutter/issues/449

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
