### PR TITLE
Issue 447 - Use activity when available in GoogleMobileAdsPlugin.

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 * Fix for [Issue 449](https://github.com/googleads/googleads-mobile-flutter/issues/449).
   In `LocationParams`, time is now treated as an optional parameter on Android.
-  
+* Fix for [Issue 447](https://github.com/googleads/googleads-mobile-flutter/issues/447),
+  which affected mediation networks that require an Activity to be initialized on Android.
 
 ## 1.0.0
 

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -300,7 +300,11 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
       Log.e(TAG, "method call received before instanceManager initialized: " + call.method);
       return;
     }
-    Context appContext = pluginBinding.getApplicationContext();
+    // Use activity as context if available.
+    Context context =
+        (instanceManager.getActivity() != null)
+            ? instanceManager.getActivity()
+            : pluginBinding.getApplicationContext();
     switch (call.method) {
       case "_init":
         // Internal init. This is necessary to cleanup state on hot restart.
@@ -309,7 +313,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
         break;
 
       case "MobileAds#initialize":
-        flutterMobileAds.initialize(appContext, new FlutterInitializationListener(result));
+        flutterMobileAds.initialize(context, new FlutterInitializationListener(result));
         break;
       case "MobileAds#getRequestConfiguration":
         result.success(flutterMobileAds.getRequestConfiguration());
@@ -343,7 +347,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
                 call.<String>argument("adUnitId"),
                 call.<FlutterAdRequest>argument("request"),
                 call.<FlutterAdSize>argument("size"),
-                getBannerAdCreator(appContext));
+                getBannerAdCreator(context));
         instanceManager.trackAd(bannerAd, call.<Integer>argument("adId"));
         bannerAd.load();
         result.success(null);
@@ -367,7 +371,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
                 .setCustomOptions(call.<Map<String, Object>>argument("customOptions"))
                 .setId(call.<Integer>argument("adId"))
                 .setNativeAdOptions(call.<FlutterNativeAdOptions>argument("nativeAdOptions"))
-                .setFlutterAdLoader(new FlutterAdLoader(appContext))
+                .setFlutterAdLoader(new FlutterAdLoader(context))
                 .build();
         instanceManager.trackAd(nativeAd, call.<Integer>argument("adId"));
         nativeAd.load();
@@ -380,7 +384,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
                 instanceManager,
                 call.<String>argument("adUnitId"),
                 call.<FlutterAdRequest>argument("request"),
-                new FlutterAdLoader(appContext));
+                new FlutterAdLoader(context));
         instanceManager.trackAd(interstitial, call.<Integer>argument("adId"));
         interstitial.load();
         result.success(null);
@@ -401,7 +405,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
                   adUnitId,
                   request,
                   serverSideVerificationOptions,
-                  new FlutterAdLoader(appContext));
+                  new FlutterAdLoader(context));
         } else if (adManagerRequest != null) {
           rewardedAd =
               new FlutterRewardedAd(
@@ -410,7 +414,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
                   adUnitId,
                   adManagerRequest,
                   serverSideVerificationOptions,
-                  new FlutterAdLoader(appContext));
+                  new FlutterAdLoader(context));
         } else {
           result.error("InvalidRequest", "A null or invalid ad request was provided.", null);
           break;
@@ -428,7 +432,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
                 call.<String>argument("adUnitId"),
                 call.<List<FlutterAdSize>>argument("sizes"),
                 call.<FlutterAdManagerAdRequest>argument("request"),
-                getBannerAdCreator(appContext));
+                getBannerAdCreator(context));
         instanceManager.trackAd(adManagerBannerAd, call.<Integer>argument("adId"));
         adManagerBannerAd.load();
         result.success(null);
@@ -440,7 +444,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
                 instanceManager,
                 call.<String>argument("adUnitId"),
                 call.<FlutterAdManagerAdRequest>argument("request"),
-                getBannerAdCreator(appContext));
+                getBannerAdCreator(context));
         instanceManager.trackAd(fluidAd, call.<Integer>argument("adId"));
         fluidAd.load();
         result.success(null);
@@ -452,7 +456,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
                 requireNonNull(instanceManager),
                 requireNonNull(call.<String>argument("adUnitId")),
                 call.<FlutterAdManagerAdRequest>argument("request"),
-                new FlutterAdLoader(appContext));
+                new FlutterAdLoader(context));
         instanceManager.trackAd(
             adManagerInterstitialAd, requireNonNull(call.<Integer>argument("adId")));
         adManagerInterstitialAd.load();
@@ -467,7 +471,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
                 requireNonNull(call.<String>argument("adUnitId")),
                 call.<FlutterAdRequest>argument("request"),
                 call.<FlutterAdManagerAdRequest>argument("adManagerRequest"),
-                new FlutterAdLoader(appContext));
+                new FlutterAdLoader(context));
         instanceManager.trackAd(appOpenAd, call.<Integer>argument("adId"));
         appOpenAd.load();
         result.success(null);
@@ -487,7 +491,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
       case "AdSize#getAnchoredAdaptiveBannerAdSize":
         final FlutterAdSize.AnchoredAdaptiveBannerAdSize size =
             new FlutterAdSize.AnchoredAdaptiveBannerAdSize(
-                appContext,
+                context,
                 new FlutterAdSize.AdSizeFactory(),
                 call.<String>argument("orientation"),
                 call.<Integer>argument("width"));
@@ -511,7 +515,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
         result.success(null);
         break;
       case "MobileAds#disableMediationInitialization":
-        flutterMobileAds.disableMediationInitialization(appContext);
+        flutterMobileAds.disableMediationInitialization(context);
         result.success(null);
         break;
       case "MobileAds#getVersionString":

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
@@ -43,6 +44,7 @@ import com.google.android.gms.ads.initialization.OnInitializationCompleteListene
 import com.google.android.gms.ads.nativead.NativeAd;
 import com.google.android.gms.ads.nativead.NativeAdView;
 import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding;
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -490,6 +492,35 @@ public class GoogleMobileAdsTest {
     plugin.onMethodCall(methodCall, result);
 
     verify(result).success(ArgumentMatchers.any(FlutterInitializationStatus.class));
+  }
+
+  @Test
+  public void testPluginUsesActivityWhenAvailable() {
+    FlutterMobileAdsWrapper flutterMobileAdsWrapper = mock(FlutterMobileAdsWrapper.class);
+    BinaryMessenger mockBinaryMessenger = mock(BinaryMessenger.class);
+    doReturn(mockBinaryMessenger).when(mockFlutterPluginBinding).getBinaryMessenger();
+    PlatformViewRegistry mockPlatformViewRegistry = mock(PlatformViewRegistry.class);
+
+    doReturn(mockPlatformViewRegistry).when(mockFlutterPluginBinding).getPlatformViewRegistry();
+
+    GoogleMobileAdsPlugin plugin = new GoogleMobileAdsPlugin(null, null, flutterMobileAdsWrapper);
+    plugin.onAttachedToEngine(mockFlutterPluginBinding);
+
+    MethodCall methodCall = new MethodCall("MobileAds#initialize", null);
+    Result result = mock(Result.class);
+    plugin.onMethodCall(methodCall, result);
+
+    // Check that we use application context if activity is not available.
+    verify(flutterMobileAdsWrapper).initialize(eq(mockContext), any());
+
+    // Activity should be used instead of application context
+    ActivityPluginBinding activityPluginBinding = mock(ActivityPluginBinding.class);
+    doReturn(mockActivity).when(activityPluginBinding).getActivity();
+    plugin.onAttachedToActivity(activityPluginBinding);
+
+    plugin.onMethodCall(methodCall, result);
+
+    verify(flutterMobileAdsWrapper).initialize(eq(mockActivity), any());
   }
 
   @Test


### PR DESCRIPTION
## Description

Update `GoogleMobileAdsPlugin.java` to use the activity as the context for SDK calls, if available. 
This addresses the issue where certain mediation networks require an activity for initialization and loading ads.

## Related Issues

https://github.com/googleads/googleads-mobile-flutter/issues/447

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.