### PR TITLE
Remove AdUnitId declaration from Ad container classes

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.2
+* Add support for [Rewarded Interstitial](https://support.google.com/admob/answer/9884467) (beta) ad format.
+
 ## 1.0.1
 
 * Fix for [Issue 449](https://github.com/googleads/googleads-mobile-flutter/issues/449).

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
@@ -17,7 +17,7 @@ package io.flutter.plugins.googlemobileads;
 /** Constants used in the plugin. */
 public class Constants {
   /** Version request agent. Should be bumped alongside plugin versions. */
-  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-1.0.1";
+  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-1.0.2";
 
   static final String ERROR_CODE_UNEXPECTED_AD_TYPE = "unexpected_ad_type";
 }

--- a/packages/google_mobile_ads/example/lib/main.dart
+++ b/packages/google_mobile_ads/example/lib/main.dart
@@ -15,11 +15,13 @@
 // ignore_for_file: public_member_api_docs
 
 import 'dart:io' show Platform;
+
 import 'package:flutter/material.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
+
 import 'anchored_adaptive_example.dart';
-import 'inline_adaptive_example.dart';
 import 'fluid_example.dart';
+import 'inline_adaptive_example.dart';
 import 'reusable_inline_example.dart';
 
 void main() {

--- a/packages/google_mobile_ads/example/lib/main.dart
+++ b/packages/google_mobile_ads/example/lib/main.dart
@@ -14,7 +14,7 @@
 
 // ignore_for_file: public_member_api_docs
 
-import 'dart:io';
+import 'dart:io' show Platform;
 import 'package:flutter/material.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'anchored_adaptive_example.dart';

--- a/packages/google_mobile_ads/example/lib/main.dart
+++ b/packages/google_mobile_ads/example/lib/main.dart
@@ -14,6 +14,7 @@
 
 // ignore_for_file: public_member_api_docs
 
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'anchored_adaptive_example.dart';
@@ -63,7 +64,9 @@ class _MyAppState extends State<MyApp> {
 
   void _createInterstitialAd() {
     InterstitialAd.load(
-        adUnitId: InterstitialAd.testAdUnitId,
+        adUnitId: Platform.isAndroid
+            ? 'ca-app-pub-3940256099942544/1033173712'
+            : 'ca-app-pub-3940256099942544/4411468910',
         request: request,
         adLoadCallback: InterstitialAdLoadCallback(
           onAdLoaded: (InterstitialAd ad) {
@@ -108,7 +111,9 @@ class _MyAppState extends State<MyApp> {
 
   void _createRewardedAd() {
     RewardedAd.load(
-        adUnitId: RewardedAd.testAdUnitId,
+        adUnitId: Platform.isAndroid
+            ? 'ca-app-pub-3940256099942544/5224354917'
+            : 'ca-app-pub-3940256099942544/1712485313',
         request: request,
         rewardedAdLoadCallback: RewardedAdLoadCallback(
           onAdLoaded: (RewardedAd ad) {
@@ -157,7 +162,9 @@ class _MyAppState extends State<MyApp> {
 
   void _createRewardedInterstitialAd() {
     RewardedInterstitialAd.load(
-        adUnitId: RewardedInterstitialAd.testAdUnitId,
+        adUnitId: Platform.isAndroid
+            ? 'ca-app-pub-3940256099942544/5354046379'
+            : 'ca-app-pub-3940256099942544/6978759866',
         request: request,
         rewardedInterstitialAdLoadCallback: RewardedInterstitialAdLoadCallback(
           onAdLoaded: (RewardedInterstitialAd ad) {

--- a/packages/google_mobile_ads/ios/Classes/FLTConstants.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTConstants.h
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /** Versioned request agent string. */
-#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-1.0.1"
+#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-1.0.2"

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -1280,14 +1280,6 @@ class RewardedInterstitialAd extends AdWithoutView {
   /// Callbacks for events that occur when attempting to load an ad.
   final RewardedInterstitialAdLoadCallback rewardedInterstitialAdLoadCallback;
 
-  /// Check [test ads](https://developers.google.com/admob/android/test-ads) for
-  /// demo ad units that point to specific test creatives for each format.
-  @Deprecated(
-      'Use test ad unit ids from the developer page while creating the ad.')
-  static final String testAdUnitId = Platform.isAndroid
-      ? 'ca-app-pub-3940256099942544/5354046379'
-      : 'ca-app-pub-3940256099942544/6978759866';
-
   /// Optional [ServerSideVerificationOptions].
   ServerSideVerificationOptions? serverSideVerificationOptions;
 

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -857,7 +857,8 @@ class BannerAd extends AdWithView {
   @override
   final BannerAdListener listener;
 
-  /// Check [test ads](https://developers.google.com/admob/android/test-ads) for
+  /// Check out developer pages for [Admob](https://developers.google.com/admob/flutter/test-ads)
+  /// and [AdManager](https://developers.google.com/ad-manager/mobile-ads-sdk/flutter/test-ads) for
   /// demo ad units that point to specific test creatives for each format.
   @Deprecated(
       'Use test ad unit ids from the developer page while creating the ad.')
@@ -1033,7 +1034,8 @@ class NativeAd extends AdWithView {
   /// Options to configure the native ad request.
   final NativeAdOptions? nativeAdOptions;
 
-  /// Check [test ads](https://developers.google.com/admob/android/test-ads) for
+  /// Check out developer pages for [Admob](https://developers.google.com/admob/flutter/test-ads)
+  /// and [AdManager](https://developers.google.com/ad-manager/mobile-ads-sdk/flutter/test-ads) for
   /// demo ad units that point to specific test creatives for each format.
   @Deprecated(
       'Use test ad unit ids from the developer page while creating the ad.')
@@ -1068,7 +1070,8 @@ class InterstitialAd extends AdWithoutView {
   /// Callbacks to be invoked when ads show and dismiss full screen content.
   FullScreenContentCallback<InterstitialAd>? fullScreenContentCallback;
 
-  /// Check [test ads](https://developers.google.com/admob/android/test-ads) for
+  /// Check out developer pages for [Admob](https://developers.google.com/admob/flutter/test-ads)
+  /// and [AdManager](https://developers.google.com/ad-manager/mobile-ads-sdk/flutter/test-ads) for
   /// demo ad units that point to specific test creatives for each format.
   @Deprecated(
       'Use test ad unit ids from the developer page while creating the ad.')
@@ -1179,7 +1182,8 @@ class RewardedAd extends AdWithoutView {
   /// Callbacks for events that occur when attempting to load an ad.
   final RewardedAdLoadCallback rewardedAdLoadCallback;
 
-  /// Check [test ads](https://developers.google.com/admob/android/test-ads) for
+  /// Check out developer pages for [Admob](https://developers.google.com/admob/flutter/test-ads)
+  /// and [AdManager](https://developers.google.com/ad-manager/mobile-ads-sdk/flutter/test-ads) for
   /// demo ad units that point to specific test creatives for each format.
   @Deprecated(
       'Use test ad unit ids from the developer page while creating the ad.')

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -857,17 +857,6 @@ class BannerAd extends AdWithView {
   @override
   final BannerAdListener listener;
 
-  /// {@template google_mobile_ads.testAdUnitId}
-  /// A platform-specific AdMob test ad unit ID.
-  ///
-  /// This ad unit has been specially configured to always return test ads, and
-  /// developers are encouraged to use it while building and testing their apps.
-  /// {@endtemplate}
-  /// {@macro google_mobile_ads.testAdUnitId}
-  static final String testAdUnitId = Platform.isAndroid
-      ? 'ca-app-pub-3940256099942544/6300978111'
-      : 'ca-app-pub-3940256099942544/2934735716';
-
   @override
   Future<void> load() async {
     await instanceManager.loadBannerAd(this);
@@ -1036,13 +1025,6 @@ class NativeAd extends AdWithView {
   /// Options to configure the native ad request.
   final NativeAdOptions? nativeAdOptions;
 
-  /// Check [test ads](https://developers.google.com/admob/android/test-ads) for
-  /// demo ad units that point to specific test creatives for each format.
-  @Deprecated('Use test ads from the developer page while creating the ad.')
-  static final String testAdUnitId = Platform.isAndroid
-      ? 'ca-app-pub-3940256099942544/2247696110'
-      : 'ca-app-pub-3940256099942544/3986624511';
-
   @override
   Future<void> load() async {
     await instanceManager.loadNativeAd(this);
@@ -1069,11 +1051,6 @@ class InterstitialAd extends AdWithoutView {
 
   /// Callbacks to be invoked when ads show and dismiss full screen content.
   FullScreenContentCallback<InterstitialAd>? fullScreenContentCallback;
-
-  /// {@macro google_mobile_ads.testAdUnitId}
-  static final String testAdUnitId = Platform.isAndroid
-      ? 'ca-app-pub-3940256099942544/1033173712'
-      : 'ca-app-pub-3940256099942544/4411468910';
 
   /// Loads an [InterstitialAd] with the given [adUnitId] and [request].
   static Future<void> load({
@@ -1178,17 +1155,6 @@ class RewardedAd extends AdWithoutView {
   /// Callbacks for events that occur when attempting to load an ad.
   final RewardedAdLoadCallback rewardedAdLoadCallback;
 
-  /// {@template google_mobile_ads.testAdUnitId}
-  /// A platform-specific AdMob test ad unit ID.
-  ///
-  /// This ad unit has been specially configured to always return test ads, and
-  /// developers are encouraged to use it while building and testing their apps.
-  /// {@endtemplate}
-  /// {@macro google_mobile_ads.testAdUnitId}
-  static final String testAdUnitId = Platform.isAndroid
-      ? 'ca-app-pub-3940256099942544/5224354917'
-      : 'ca-app-pub-3940256099942544/1712485313';
-
   /// Optional [ServerSideVerificationOptions].
   ServerSideVerificationOptions? serverSideVerificationOptions;
 
@@ -1281,17 +1247,6 @@ class RewardedInterstitialAd extends AdWithoutView {
 
   /// Callbacks for events that occur when attempting to load an ad.
   final RewardedInterstitialAdLoadCallback rewardedInterstitialAdLoadCallback;
-
-  /// {@template google_mobile_ads.testAdUnitId}
-  /// A platform-specific AdMob test ad unit ID.
-  ///
-  /// This ad unit has been specially configured to always return test ads, and
-  /// developers are encouraged to use it while building and testing their apps.
-  /// {@endtemplate}
-  /// {@macro google_mobile_ads.testAdUnitId}
-  static final String testAdUnitId = Platform.isAndroid
-      ? 'ca-app-pub-3940256099942544/5354046379'
-      : 'ca-app-pub-3940256099942544/6978759866';
 
   /// Optional [ServerSideVerificationOptions].
   ServerSideVerificationOptions? serverSideVerificationOptions;

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import 'dart:async';
-import 'dart:io' show Platform;
 import 'dart:math';
 
 import 'package:flutter/foundation.dart';

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -859,7 +859,8 @@ class BannerAd extends AdWithView {
 
   /// Check [test ads](https://developers.google.com/admob/android/test-ads) for
   /// demo ad units that point to specific test creatives for each format.
-  @Deprecated('Use test ad unit ids from the developer page while creating the ad.')
+  @Deprecated(
+      'Use test ad unit ids from the developer page while creating the ad.')
   static final String testAdUnitId = Platform.isAndroid
       ? 'ca-app-pub-3940256099942544/6300978111'
       : 'ca-app-pub-3940256099942544/2934735716';
@@ -1034,7 +1035,8 @@ class NativeAd extends AdWithView {
 
   /// Check [test ads](https://developers.google.com/admob/android/test-ads) for
   /// demo ad units that point to specific test creatives for each format.
-  @Deprecated('Use test ad unit ids from the developer page while creating the ad.')
+  @Deprecated(
+      'Use test ad unit ids from the developer page while creating the ad.')
   static final String testAdUnitId = Platform.isAndroid
       ? 'ca-app-pub-3940256099942544/2247696110'
       : 'ca-app-pub-3940256099942544/3986624511';
@@ -1068,7 +1070,8 @@ class InterstitialAd extends AdWithoutView {
 
   /// Check [test ads](https://developers.google.com/admob/android/test-ads) for
   /// demo ad units that point to specific test creatives for each format.
-  @Deprecated('Use test ad unit ids from the developer page while creating the ad.')
+  @Deprecated(
+      'Use test ad unit ids from the developer page while creating the ad.')
   static final String testAdUnitId = Platform.isAndroid
       ? 'ca-app-pub-3940256099942544/1033173712'
       : 'ca-app-pub-3940256099942544/4411468910';
@@ -1178,7 +1181,8 @@ class RewardedAd extends AdWithoutView {
 
   /// Check [test ads](https://developers.google.com/admob/android/test-ads) for
   /// demo ad units that point to specific test creatives for each format.
-  @Deprecated('Use test ad unit ids from the developer page while creating the ad.')
+  @Deprecated(
+      'Use test ad unit ids from the developer page while creating the ad.')
   static final String testAdUnitId = Platform.isAndroid
       ? 'ca-app-pub-3940256099942544/5224354917'
       : 'ca-app-pub-3940256099942544/1712485313';
@@ -1278,7 +1282,8 @@ class RewardedInterstitialAd extends AdWithoutView {
 
   /// Check [test ads](https://developers.google.com/admob/android/test-ads) for
   /// demo ad units that point to specific test creatives for each format.
-  @Deprecated('Use test ad unit ids from the developer page while creating the ad.')
+  @Deprecated(
+      'Use test ad unit ids from the developer page while creating the ad.')
   static final String testAdUnitId = Platform.isAndroid
       ? 'ca-app-pub-3940256099942544/5354046379'
       : 'ca-app-pub-3940256099942544/6978759866';

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'dart:async';
+import 'dart:io' show Platform;
 import 'dart:math';
 
 import 'package:flutter/foundation.dart';
@@ -856,6 +857,13 @@ class BannerAd extends AdWithView {
   @override
   final BannerAdListener listener;
 
+  /// Check [test ads](https://developers.google.com/admob/android/test-ads) for
+  /// demo ad units that point to specific test creatives for each format.
+  @Deprecated('Use test ad unit ids from the developer page while creating the ad.')
+  static final String testAdUnitId = Platform.isAndroid
+      ? 'ca-app-pub-3940256099942544/6300978111'
+      : 'ca-app-pub-3940256099942544/2934735716';
+
   @override
   Future<void> load() async {
     await instanceManager.loadBannerAd(this);
@@ -1024,6 +1032,13 @@ class NativeAd extends AdWithView {
   /// Options to configure the native ad request.
   final NativeAdOptions? nativeAdOptions;
 
+  /// Check [test ads](https://developers.google.com/admob/android/test-ads) for
+  /// demo ad units that point to specific test creatives for each format.
+  @Deprecated('Use test ad unit ids from the developer page while creating the ad.')
+  static final String testAdUnitId = Platform.isAndroid
+      ? 'ca-app-pub-3940256099942544/2247696110'
+      : 'ca-app-pub-3940256099942544/3986624511';
+
   @override
   Future<void> load() async {
     await instanceManager.loadNativeAd(this);
@@ -1050,6 +1065,13 @@ class InterstitialAd extends AdWithoutView {
 
   /// Callbacks to be invoked when ads show and dismiss full screen content.
   FullScreenContentCallback<InterstitialAd>? fullScreenContentCallback;
+
+  /// Check [test ads](https://developers.google.com/admob/android/test-ads) for
+  /// demo ad units that point to specific test creatives for each format.
+  @Deprecated('Use test ad unit ids from the developer page while creating the ad.')
+  static final String testAdUnitId = Platform.isAndroid
+      ? 'ca-app-pub-3940256099942544/1033173712'
+      : 'ca-app-pub-3940256099942544/4411468910';
 
   /// Loads an [InterstitialAd] with the given [adUnitId] and [request].
   static Future<void> load({
@@ -1154,6 +1176,13 @@ class RewardedAd extends AdWithoutView {
   /// Callbacks for events that occur when attempting to load an ad.
   final RewardedAdLoadCallback rewardedAdLoadCallback;
 
+  /// Check [test ads](https://developers.google.com/admob/android/test-ads) for
+  /// demo ad units that point to specific test creatives for each format.
+  @Deprecated('Use test ad unit ids from the developer page while creating the ad.')
+  static final String testAdUnitId = Platform.isAndroid
+      ? 'ca-app-pub-3940256099942544/5224354917'
+      : 'ca-app-pub-3940256099942544/1712485313';
+
   /// Optional [ServerSideVerificationOptions].
   ServerSideVerificationOptions? serverSideVerificationOptions;
 
@@ -1246,6 +1275,13 @@ class RewardedInterstitialAd extends AdWithoutView {
 
   /// Callbacks for events that occur when attempting to load an ad.
   final RewardedInterstitialAdLoadCallback rewardedInterstitialAdLoadCallback;
+
+  /// Check [test ads](https://developers.google.com/admob/android/test-ads) for
+  /// demo ad units that point to specific test creatives for each format.
+  @Deprecated('Use test ad unit ids from the developer page while creating the ad.')
+  static final String testAdUnitId = Platform.isAndroid
+      ? 'ca-app-pub-3940256099942544/5354046379'
+      : 'ca-app-pub-3940256099942544/6978759866';
 
   /// Optional [ServerSideVerificationOptions].
   ServerSideVerificationOptions? serverSideVerificationOptions;

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -106,7 +106,7 @@ void main() {
       RewardedAd? rewarded;
       AdRequest request = AdRequest();
       await RewardedAd.load(
-          adUnitId: RewardedAd.testAdUnitId,
+          adUnitId: 'test-ad-unit',
           request: request,
           rewardedAdLoadCallback: RewardedAdLoadCallback(
               onAdLoaded: (ad) {
@@ -124,7 +124,7 @@ void main() {
       expect(log, <Matcher>[
         isMethodCall('loadRewardedAd', arguments: <String, dynamic>{
           'adId': 0,
-          'adUnitId': RewardedAd.testAdUnitId,
+          'adUnitId': 'test-ad-unit',
           'request': request,
           'adManagerRequest': null,
           'serverSideVerificationOptions':
@@ -146,7 +146,7 @@ void main() {
     test('load interstitial ad and set immersive mode', () async {
       InterstitialAd? interstitial;
       await InterstitialAd.load(
-        adUnitId: InterstitialAd.testAdUnitId,
+        adUnitId: 'test-ad-unit',
         request: AdRequest(),
         adLoadCallback: InterstitialAdLoadCallback(
             onAdLoaded: (ad) {
@@ -161,7 +161,7 @@ void main() {
       expect(log, <Matcher>[
         isMethodCall('loadInterstitialAd', arguments: <String, dynamic>{
           'adId': 0,
-          'adUnitId': InterstitialAd.testAdUnitId,
+          'adUnitId': 'test-ad-unit',
           'request': interstitial!.request,
         })
       ]);
@@ -213,7 +213,7 @@ void main() {
 
     test('load banner', () async {
       final BannerAd banner = BannerAd(
-        adUnitId: BannerAd.testAdUnitId,
+        adUnitId: 'test-ad-unit',
         size: AdSize.banner,
         listener: BannerAdListener(),
         request: AdRequest(),
@@ -223,7 +223,7 @@ void main() {
       expect(log, <Matcher>[
         isMethodCall('loadBannerAd', arguments: <String, dynamic>{
           'adId': 0,
-          'adUnitId': BannerAd.testAdUnitId,
+          'adUnitId': 'test-ad-unit',
           'request': banner.request,
           'size': AdSize.banner,
         })
@@ -237,7 +237,7 @@ void main() {
 
     test('dispose banner', () async {
       final BannerAd banner = BannerAd(
-        adUnitId: BannerAd.testAdUnitId,
+        adUnitId: 'test-ad-unit',
         size: AdSize.banner,
         listener: BannerAdListener(),
         request: AdRequest(),
@@ -258,7 +258,7 @@ void main() {
 
     test('calling dispose without awaiting load', () {
       final BannerAd banner = BannerAd(
-        adUnitId: BannerAd.testAdUnitId,
+        adUnitId: 'test-ad-unit',
         size: AdSize.banner,
         listener: BannerAdListener(),
         request: AdRequest(),
@@ -284,7 +284,7 @@ void main() {
           shouldRequestMultipleImages: true,
           shouldReturnUrlsForImageAssets: false);
       final NativeAd native = NativeAd(
-        adUnitId: NativeAd.testAdUnitId,
+        adUnitId: 'test-ad-unit',
         factoryId: '0',
         customOptions: options,
         listener: NativeAdListener(),
@@ -296,7 +296,7 @@ void main() {
       expect(log, <Matcher>[
         isMethodCall('loadNativeAd', arguments: <String, dynamic>{
           'adId': 0,
-          'adUnitId': NativeAd.testAdUnitId,
+          'adUnitId': 'test-ad-unit',
           'request': native.request,
           'adManagerRequest': null,
           'factoryId': '0',
@@ -337,7 +337,7 @@ void main() {
 
     testWidgets('build ad widget', (WidgetTester tester) async {
       final NativeAd native = NativeAd(
-        adUnitId: NativeAd.testAdUnitId,
+        adUnitId: 'test-ad-unit',
         factoryId: '0',
         listener: NativeAdListener(),
         request: AdRequest(),
@@ -361,7 +361,7 @@ void main() {
 
     testWidgets('build ad widget', (WidgetTester tester) async {
       final NativeAd native = NativeAd(
-        adUnitId: NativeAd.testAdUnitId,
+        adUnitId: 'test-ad-unit',
         factoryId: '0',
         listener: NativeAdListener(),
         request: AdRequest(),
@@ -386,7 +386,7 @@ void main() {
     testWidgets('warns when ad has not been loaded',
         (WidgetTester tester) async {
       final NativeAd ad = NativeAd(
-        adUnitId: NativeAd.testAdUnitId,
+        adUnitId: 'test-ad-unit',
         factoryId: '0',
         listener: NativeAdListener(),
         request: AdRequest(),
@@ -422,7 +422,7 @@ void main() {
 
     testWidgets('warns when ad object is reused', (WidgetTester tester) async {
       final NativeAd ad = NativeAd(
-        adUnitId: NativeAd.testAdUnitId,
+        adUnitId: 'test-ad-unit',
         factoryId: '0',
         listener: NativeAdListener(),
         request: AdRequest(),
@@ -463,7 +463,7 @@ void main() {
 
     testWidgets('warns when the widget is reused', (WidgetTester tester) async {
       final NativeAd ad = NativeAd(
-        adUnitId: NativeAd.testAdUnitId,
+        adUnitId: 'test-ad-unit',
         factoryId: '0',
         listener: NativeAdListener(),
         request: AdRequest(),
@@ -507,7 +507,7 @@ void main() {
         'ad objects can be reused if the widget holding the object is disposed',
         (WidgetTester tester) async {
       final NativeAd ad = NativeAd(
-        adUnitId: NativeAd.testAdUnitId,
+        adUnitId: 'test-ad-unit',
         factoryId: '0',
         listener: NativeAdListener(),
         request: AdRequest(),
@@ -547,7 +547,7 @@ void main() {
       RewardedAd? rewarded;
       AdRequest request = AdRequest();
       await RewardedAd.load(
-          adUnitId: RewardedAd.testAdUnitId,
+          adUnitId: 'test-ad-unit',
           request: request,
           rewardedAdLoadCallback: RewardedAdLoadCallback(
               onAdLoaded: (ad) {
@@ -565,7 +565,7 @@ void main() {
       expect(log, <Matcher>[
         isMethodCall('loadRewardedAd', arguments: <String, dynamic>{
           'adId': 0,
-          'adUnitId': RewardedAd.testAdUnitId,
+          'adUnitId': 'test-ad-unit',
           'request': request,
           'adManagerRequest': null,
           'serverSideVerificationOptions':
@@ -589,7 +589,7 @@ void main() {
       RewardedAd? rewarded;
       AdManagerAdRequest request = AdManagerAdRequest();
       await RewardedAd.loadWithAdManagerAdRequest(
-          adUnitId: RewardedAd.testAdUnitId,
+          adUnitId: 'test-ad-unit',
           adManagerRequest: request,
           rewardedAdLoadCallback: RewardedAdLoadCallback(
               onAdLoaded: (ad) {
@@ -607,7 +607,7 @@ void main() {
       expect(log, <Matcher>[
         isMethodCall('loadRewardedAd', arguments: <String, dynamic>{
           'adId': 0,
-          'adUnitId': RewardedAd.testAdUnitId,
+          'adUnitId': 'test-ad-unit',
           'request': null,
           'adManagerRequest': request,
           'serverSideVerificationOptions':
@@ -629,7 +629,7 @@ void main() {
     test('load show interstitial', () async {
       InterstitialAd? interstitial;
       await InterstitialAd.load(
-        adUnitId: InterstitialAd.testAdUnitId,
+        adUnitId: 'test-ad-unit',
         request: AdRequest(),
         adLoadCallback: InterstitialAdLoadCallback(
             onAdLoaded: (ad) {
@@ -644,7 +644,7 @@ void main() {
       expect(log, <Matcher>[
         isMethodCall('loadInterstitialAd', arguments: <String, dynamic>{
           'adId': 0,
-          'adUnitId': InterstitialAd.testAdUnitId,
+          'adUnitId': 'test-ad-unit',
           'request': interstitial!.request,
         })
       ]);
@@ -725,7 +725,7 @@ void main() {
       final Completer<Ad> adEventCompleter = Completer<Ad>();
 
       final BannerAd banner = BannerAd(
-        adUnitId: BannerAd.testAdUnitId,
+        adUnitId: 'test-ad-unit',
         size: AdSize.banner,
         listener: BannerAdListener(
           onAdLoaded: (Ad ad) => adEventCompleter.complete(ad),
@@ -757,7 +757,7 @@ void main() {
           Completer<List<dynamic>>();
 
       final BannerAd banner = BannerAd(
-        adUnitId: BannerAd.testAdUnitId,
+        adUnitId: 'test-ad-unit',
         size: AdSize.banner,
         listener: BannerAdListener(
             onAdFailedToLoad: (Ad ad, LoadAdError error) =>
@@ -819,7 +819,7 @@ void main() {
       final Completer<LoadAdError> resultsCompleter = Completer<LoadAdError>();
       final AdRequest request = AdRequest();
       await InterstitialAd.load(
-        adUnitId: InterstitialAd.testAdUnitId,
+        adUnitId: 'test-ad-unit',
         request: request,
         adLoadCallback: InterstitialAdLoadCallback(
             onAdLoaded: (ad) => null,
@@ -829,7 +829,7 @@ void main() {
       expect(log, <Matcher>[
         isMethodCall('loadInterstitialAd', arguments: <String, dynamic>{
           'adId': 0,
-          'adUnitId': InterstitialAd.testAdUnitId,
+          'adUnitId': 'test-ad-unit',
           'request': request,
         })
       ]);
@@ -1044,7 +1044,7 @@ void main() {
       final Completer<Ad> adEventCompleter = Completer<Ad>();
 
       final NativeAd native = NativeAd(
-        adUnitId: NativeAd.testAdUnitId,
+        adUnitId: 'test-ad-unit',
         factoryId: 'testId',
         listener: NativeAdListener(
             onNativeAdClicked: (Ad ad) => adEventCompleter.complete(ad)),
@@ -1072,7 +1072,7 @@ void main() {
       final Completer<Ad> adEventCompleter = Completer<Ad>();
 
       final NativeAd native = NativeAd(
-        adUnitId: NativeAd.testAdUnitId,
+        adUnitId: 'test-ad-unit',
         factoryId: 'testId',
         listener: NativeAdListener(
             onAdImpression: (Ad ad) => adEventCompleter.complete(ad)),
@@ -1100,7 +1100,7 @@ void main() {
       final Completer<Ad> adEventCompleter = Completer<Ad>();
 
       final BannerAd banner = BannerAd(
-        adUnitId: BannerAd.testAdUnitId,
+        adUnitId: 'test-ad-unit',
         size: AdSize.banner,
         listener: BannerAdListener(
             onAdOpened: (Ad ad) => adEventCompleter.complete(ad)),
@@ -1128,7 +1128,7 @@ void main() {
       final Completer<Ad> adEventCompleter = Completer<Ad>();
 
       final BannerAd banner = BannerAd(
-        adUnitId: BannerAd.testAdUnitId,
+        adUnitId: 'test-ad-unit',
         size: AdSize.banner,
         listener: BannerAdListener(
             onAdClosed: (Ad ad) => adEventCompleter.complete(ad)),
@@ -1158,7 +1158,7 @@ void main() {
 
       RewardedAd? rewarded;
       await RewardedAd.load(
-          adUnitId: RewardedAd.testAdUnitId,
+          adUnitId: 'test-ad-unit',
           request: AdRequest(),
           rewardedAdLoadCallback: RewardedAdLoadCallback(
               onAdLoaded: (ad) {
@@ -1202,7 +1202,7 @@ void main() {
       Completer<List<dynamic>> resultCompleter = Completer<List<dynamic>>();
 
       final BannerAd banner = BannerAd(
-        adUnitId: BannerAd.testAdUnitId,
+        adUnitId: 'test-ad-unit',
         size: AdSize.banner,
         listener: BannerAdListener(
           onPaidEvent: (Ad ad, double value, precision, String currencyCode) =>


### PR DESCRIPTION
We don't need to use actual test ids for unit tests.

## Description

*Removes AdUnitId declaration from Ad container classes and uses 'test-ad-unit' for unit tests as we don't need to use actual test ids for unit tests.*

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/googleads/googleads-mobile-flutter/issues). Indicate, which of these issues are resolved or fixed by this PR.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
