### PR TITLE
Prefer mavenCentral

### DIFF
--- a/packages/app_open_example/android/build.gradle
+++ b/packages/app_open_example/android/build.gradle
@@ -3,7 +3,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 
     dependencies {
@@ -16,7 +15,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 }
 

--- a/packages/app_open_example/android/build.gradle
+++ b/packages/app_open_example/android/build.gradle
@@ -2,6 +2,7 @@ buildscript {
     ext.kotlin_version = '1.5.31'
     repositories {
         google()
+        mavenCentral()
         jcenter()
     }
 
@@ -14,6 +15,7 @@ buildscript {
 allprojects {
     repositories {
         google()
+        mavenCentral()
         jcenter()
     }
 }

--- a/packages/google_mobile_ads/android/build.gradle
+++ b/packages/google_mobile_ads/android/build.gradle
@@ -4,6 +4,7 @@ version '1.0-SNAPSHOT'
 buildscript {
     repositories {
         google()
+        mavenCentral()
         jcenter()
     }
 
@@ -15,6 +16,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
+        mavenCentral()
         jcenter()
     }
 }

--- a/packages/google_mobile_ads/android/build.gradle
+++ b/packages/google_mobile_ads/android/build.gradle
@@ -5,7 +5,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 
     dependencies {
@@ -17,7 +16,6 @@ rootProject.allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 }
 

--- a/packages/google_mobile_ads/example/android/build.gradle
+++ b/packages/google_mobile_ads/example/android/build.gradle
@@ -1,8 +1,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
-        mavenLocal()
+        mavenCentral()
     }
 
     dependencies {
@@ -13,8 +12,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
-        mavenLocal()
+        mavenCentral()
     }
 }
 

--- a/packages/mediation_example/android/build.gradle
+++ b/packages/mediation_example/android/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         google()
+        mavenCentral()
         jcenter()
     }
 
@@ -12,6 +13,7 @@ buildscript {
 allprojects {
     repositories {
         google()
+        mavenCentral()
         jcenter()
     }
 }

--- a/packages/mediation_example/android/build.gradle
+++ b/packages/mediation_example/android/build.gradle
@@ -2,7 +2,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 
     dependencies {
@@ -14,7 +13,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 }
 


### PR DESCRIPTION
## Description

Fork of https://github.com/googleads/googleads-mobile-flutter/pull/488, which was automatically closed when the main branch of the repo was renamed.

Adds mavenCentral() to android build.gradle files, for https://blog.gradle.org/jcenter-shutdown. 

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/googleads/googleads-mobile-flutter/issues). Indicate, which of these issues are resolved or fixed by this PR.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
