### PR TITLE
Deprecate LocationParams

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.0
+* Deprecates `LocationParams` in `AdRequest` and `AdManagerAdRequest`.
+
 ## 1.1.0
 * Adds support for [Rewarded Interstitial](https://support.google.com/admob/answer/9884467) (beta) ad format.
 * Adds support for `onAdClicked` events to all ad formats. `NativeAdListener.onNativeAdClicked` is now deprecated.

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
@@ -16,7 +16,6 @@
 package io.flutter.plugins.googlemobileads;
 
 import android.content.Context;
-import android.location.Location;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -54,7 +53,6 @@ class AdMessageCodec extends StandardMessageCodec {
   private static final byte VALUE_NATIVE_AD_OPTIONS = (byte) 144;
   private static final byte VALUE_VIDEO_OPTIONS = (byte) 145;
   private static final byte VALUE_INLINE_ADAPTIVE_BANNER_AD_SIZE = (byte) 146;
-  private static final byte VALUE_LOCATION_PARAMS = (byte) 147;
   private static final byte VALUE_REQUEST_CONFIGURATION_PARAMS = (byte) 148;
 
   @NonNull Context context;
@@ -96,7 +94,6 @@ class AdMessageCodec extends StandardMessageCodec {
       writeValue(stream, request.getNeighboringContentUrls());
       writeValue(stream, request.getHttpTimeoutMillis());
       writeValue(stream, request.getPublisherProvidedId());
-      writeValue(stream, request.getLocation());
       writeValue(stream, request.getMediationExtrasIdentifier());
       writeValue(stream, request.getAdMobExtras());
     } else if (value instanceof FlutterAdRequest) {
@@ -107,7 +104,6 @@ class AdMessageCodec extends StandardMessageCodec {
       writeValue(stream, request.getNonPersonalizedAds());
       writeValue(stream, request.getNeighboringContentUrls());
       writeValue(stream, request.getHttpTimeoutMillis());
-      writeValue(stream, request.getLocation());
       writeValue(stream, request.getMediationExtrasIdentifier());
       writeValue(stream, request.getAdMobExtras());
     } else if (value instanceof FlutterRewardedAd.FlutterRewardItem) {
@@ -193,13 +189,6 @@ class AdMessageCodec extends StandardMessageCodec {
       writeValue(stream, options.clickToExpandRequested);
       writeValue(stream, options.customControlsRequested);
       writeValue(stream, options.startMuted);
-    } else if (value instanceof Location) {
-      stream.write(VALUE_LOCATION_PARAMS);
-      Location location = (Location) value;
-      writeValue(stream, location.getAccuracy());
-      writeValue(stream, location.getLongitude());
-      writeValue(stream, location.getLatitude());
-      writeValue(stream, location.getTime());
     } else {
       super.writeValue(stream, value);
     }
@@ -237,7 +226,6 @@ class AdMessageCodec extends StandardMessageCodec {
             .setNonPersonalizedAds(booleanValueOf(readValueOfType(buffer.get(), buffer)))
             .setNeighboringContentUrls((List<String>) readValueOfType(buffer.get(), buffer))
             .setHttpTimeoutMillis((Integer) readValueOfType(buffer.get(), buffer))
-            .setLocation((Location) readValueOfType(buffer.get(), buffer))
             .setMediationNetworkExtrasIdentifier((String) readValueOfType(buffer.get(), buffer))
             .setMediationNetworkExtrasProvider(mediationNetworkExtrasProvider)
             .setAdMobExtras((Map<String, String>) readValueOfType(buffer.get(), buffer))
@@ -280,7 +268,6 @@ class AdMessageCodec extends StandardMessageCodec {
         builder.setNeighboringContentUrls((List<String>) readValueOfType(buffer.get(), buffer));
         builder.setHttpTimeoutMillis((Integer) readValueOfType(buffer.get(), buffer));
         builder.setPublisherProvidedId((String) readValueOfType(buffer.get(), buffer));
-        builder.setLocation((Location) readValueOfType(buffer.get(), buffer));
         builder.setMediationNetworkExtrasIdentifier((String) readValueOfType(buffer.get(), buffer));
         builder.setMediationNetworkExtrasProvider(mediationNetworkExtrasProvider);
         builder.setAdMobExtras((Map<String, String>) readValueOfType(buffer.get(), buffer));
@@ -328,17 +315,6 @@ class AdMessageCodec extends StandardMessageCodec {
         rcb.setTagForUnderAgeOfConsent((Integer) readValueOfType(buffer.get(), buffer));
         rcb.setTestDeviceIds((List<String>) readValueOfType(buffer.get(), buffer));
         return rcb.build();
-      case VALUE_LOCATION_PARAMS:
-        Location location = new Location("");
-        // This is necessary because StandardMessageCodec converts floats to double.
-        location.setAccuracy(((Double) readValueOfType(buffer.get(), buffer)).floatValue());
-        location.setLongitude((double) readValueOfType(buffer.get(), buffer));
-        location.setLatitude((double) readValueOfType(buffer.get(), buffer));
-        Long time = (Long) readValueOfType(buffer.get(), buffer);
-        if (time != null) {
-          location.setTime(time);
-        }
-        return location;
       default:
         return super.readValueOfType(type, buffer);
     }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
@@ -17,7 +17,7 @@ package io.flutter.plugins.googlemobileads;
 /** Constants used in the plugin. */
 public class Constants {
   /** Version request agent. Should be bumped alongside plugin versions. */
-  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-1.1.0";
+  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-1.2.0";
 
   static final String ERROR_CODE_UNEXPECTED_AD_TYPE = "unexpected_ad_type";
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequest.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequest.java
@@ -14,7 +14,6 @@
 
 package io.flutter.plugins.googlemobileads;
 
-import android.location.Location;
 import androidx.annotation.Nullable;
 import com.google.android.gms.ads.admanager.AdManagerAdRequest;
 import java.util.List;
@@ -62,7 +61,6 @@ class FlutterAdManagerAdRequest extends FlutterAdRequest {
           getNonPersonalizedAds(),
           getNeighboringContentUrls(),
           getHttpTimeoutMillis(),
-          getLocation(),
           publisherProvidedId,
           getMediationExtrasIdentifier(),
           getMediationNetworkExtrasProvider(),
@@ -78,7 +76,6 @@ class FlutterAdManagerAdRequest extends FlutterAdRequest {
       @Nullable Boolean nonPersonalizedAds,
       @Nullable List<String> neighboringContentUrls,
       @Nullable Integer httpTimeoutMillis,
-      @Nullable Location location,
       @Nullable String publisherProvidedId,
       @Nullable String mediationExtrasIdentifier,
       @Nullable MediationNetworkExtrasProvider mediationNetworkExtrasProvider,
@@ -89,7 +86,6 @@ class FlutterAdManagerAdRequest extends FlutterAdRequest {
         nonPersonalizedAds,
         neighboringContentUrls,
         httpTimeoutMillis,
-        location,
         mediationExtrasIdentifier,
         mediationNetworkExtrasProvider,
         adMobExtras);

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdRequest.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdRequest.java
@@ -14,7 +14,6 @@
 
 package io.flutter.plugins.googlemobileads;
 
-import android.location.Location;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
 import com.google.ads.mediation.admob.AdMobAdapter;
@@ -32,7 +31,6 @@ class FlutterAdRequest {
   @Nullable private final Boolean nonPersonalizedAds;
   @Nullable private final List<String> neighboringContentUrls;
   @Nullable private final Integer httpTimeoutMillis;
-  @Nullable private final Location location;
   @Nullable private final String mediationExtrasIdentifier;
   @Nullable private final MediationNetworkExtrasProvider mediationNetworkExtrasProvider;
   @Nullable private final Map<String, String> adMobExtras;
@@ -43,7 +41,6 @@ class FlutterAdRequest {
     @Nullable private Boolean nonPersonalizedAds;
     @Nullable private List<String> neighboringContentUrls;
     @Nullable private Integer httpTimeoutMillis;
-    @Nullable private Location location;
     @Nullable private String mediationExtrasIdentifier;
     @Nullable private MediationNetworkExtrasProvider mediationNetworkExtrasProvider;
     @Nullable private Map<String, String> adMobExtras;
@@ -70,11 +67,6 @@ class FlutterAdRequest {
 
     Builder setHttpTimeoutMillis(@Nullable Integer httpTimeoutMillis) {
       this.httpTimeoutMillis = httpTimeoutMillis;
-      return this;
-    }
-
-    Builder setLocation(@Nullable Location location) {
-      this.location = location;
       return this;
     }
 
@@ -120,11 +112,6 @@ class FlutterAdRequest {
     }
 
     @Nullable
-    protected Location getLocation() {
-      return location;
-    }
-
-    @Nullable
     protected String getMediationExtrasIdentifier() {
       return mediationExtrasIdentifier;
     }
@@ -146,7 +133,6 @@ class FlutterAdRequest {
           nonPersonalizedAds,
           neighboringContentUrls,
           httpTimeoutMillis,
-          location,
           mediationExtrasIdentifier,
           mediationNetworkExtrasProvider,
           adMobExtras);
@@ -159,7 +145,6 @@ class FlutterAdRequest {
       @Nullable Boolean nonPersonalizedAds,
       @Nullable List<String> neighboringContentUrls,
       @Nullable Integer httpTimeoutMillis,
-      @Nullable Location location,
       @Nullable String mediationExtrasIdentifier,
       @Nullable MediationNetworkExtrasProvider mediationNetworkExtrasProvider,
       @Nullable Map<String, String> adMobExtras) {
@@ -168,7 +153,6 @@ class FlutterAdRequest {
     this.nonPersonalizedAds = nonPersonalizedAds;
     this.neighboringContentUrls = neighboringContentUrls;
     this.httpTimeoutMillis = httpTimeoutMillis;
-    this.location = location;
     this.mediationExtrasIdentifier = mediationExtrasIdentifier;
     this.mediationNetworkExtrasProvider = mediationNetworkExtrasProvider;
     this.adMobExtras = adMobExtras;
@@ -222,9 +206,6 @@ class FlutterAdRequest {
     if (httpTimeoutMillis != null) {
       builder.setHttpTimeoutMillis(httpTimeoutMillis);
     }
-    if (location != null) {
-      builder.setLocation(location);
-    }
     builder.setRequestAgent(Constants.REQUEST_AGENT_PREFIX_VERSIONED);
     return builder;
   }
@@ -259,11 +240,6 @@ class FlutterAdRequest {
   }
 
   @Nullable
-  protected Location getLocation() {
-    return location;
-  }
-
-  @Nullable
   protected String getMediationExtrasIdentifier() {
     return mediationExtrasIdentifier;
   }
@@ -287,13 +263,6 @@ class FlutterAdRequest {
         && Objects.equals(nonPersonalizedAds, request.nonPersonalizedAds)
         && Objects.equals(neighboringContentUrls, request.neighboringContentUrls)
         && Objects.equals(httpTimeoutMillis, request.httpTimeoutMillis)
-        && (location == null) == (request.location == null)
-        && (location == null
-            // We only care about these properties which are guaranteed by the Location API.
-            || (location.getAccuracy() == request.location.getAccuracy()
-                && location.getLongitude() == request.location.getLongitude()
-                && location.getLatitude() == request.location.getLatitude()
-                && location.getTime() == request.location.getTime()))
         && Objects.equals(mediationExtrasIdentifier, request.mediationExtrasIdentifier)
         && Objects.equals(mediationNetworkExtrasProvider, request.mediationNetworkExtrasProvider)
         && Objects.equals(adMobExtras, request.adMobExtras);
@@ -307,7 +276,6 @@ class FlutterAdRequest {
         nonPersonalizedAds,
         neighboringContentUrls,
         httpTimeoutMillis,
-        location,
         mediationExtrasIdentifier,
         mediationNetworkExtrasProvider);
   }

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 import android.content.Context;
-import android.location.Location;
 import com.google.android.gms.ads.AdSize;
 import com.google.android.gms.ads.RequestConfiguration;
 import io.flutter.plugins.googlemobileads.FlutterAd.FlutterAdapterResponseInfo;
@@ -263,34 +262,7 @@ public class AdMessageCodecTest {
   }
 
   @Test
-  public void testEncodeLocationWithoutTime() {
-    Location location = new Location("");
-    location.setAccuracy(12345f);
-    location.setLongitude(1.0);
-    location.setLatitude(5.0);
-
-    FlutterAdRequest request = new FlutterAdRequest.Builder().setLocation(location).build();
-    ByteBuffer message = codec.encodeMessage(request);
-    FlutterAdRequest decodedRequest =
-        (FlutterAdRequest) codec.decodeMessage((ByteBuffer) message.position(0));
-    assertEquals(request, decodedRequest);
-
-    FlutterAdManagerAdRequest.Builder builder = new FlutterAdManagerAdRequest.Builder();
-    builder.setLocation(location);
-    FlutterAdManagerAdRequest gamRequest = builder.build();
-    message = codec.encodeMessage(gamRequest);
-    final FlutterAdManagerAdRequest decodedGAMRequest =
-        (FlutterAdManagerAdRequest) codec.decodeMessage((ByteBuffer) message.position(0));
-    assertEquals(decodedGAMRequest, gamRequest);
-  }
-
-  @Test
   public void encodeFlutterAdRequest() {
-    Location location = new Location("");
-    location.setAccuracy(12345f);
-    location.setLongitude(1.0);
-    location.setLatitude(5.0);
-    location.setTime(54321);
     Map<String, String> extras = Collections.singletonMap("key", "value");
     FlutterAdRequest adRequest =
         new FlutterAdRequest.Builder()
@@ -299,7 +271,6 @@ public class AdMessageCodecTest {
             .setNonPersonalizedAds(false)
             .setNeighboringContentUrls(Arrays.asList("example.com", "test.com"))
             .setHttpTimeoutMillis(1000)
-            .setLocation(location)
             .setMediationNetworkExtrasIdentifier("identifier")
             .setAdMobExtras(extras)
             .build();
@@ -312,11 +283,6 @@ public class AdMessageCodecTest {
 
   @Test
   public void encodeFlutterAdManagerAdRequest() {
-    Location location = new Location("");
-    location.setAccuracy(12345f);
-    location.setLongitude(1.0);
-    location.setLatitude(5.0);
-    location.setTime(54321);
     FlutterAdManagerAdRequest.Builder builder = new FlutterAdManagerAdRequest.Builder();
     builder.setKeywords(Arrays.asList("1", "2", "3"));
     builder.setContentUrl("contentUrl");
@@ -325,7 +291,6 @@ public class AdMessageCodecTest {
         Collections.singletonMap("cherry", Collections.singletonList("pie")));
     builder.setNonPersonalizedAds(true);
     builder.setPublisherProvidedId("pub-provided-id");
-    builder.setLocation(location);
     builder.setMediationNetworkExtrasIdentifier("identifier");
     builder.setAdMobExtras(Collections.singletonMap("key", "value"));
 

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequestTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequestTest.java
@@ -22,7 +22,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
-import android.location.Location;
 import android.os.Bundle;
 import com.google.ads.mediation.admob.AdMobAdapter;
 import com.google.android.gms.ads.admanager.AdManagerAdRequest;
@@ -46,19 +45,12 @@ public class FlutterAdManagerAdRequestTest {
     assertTrue(adRequest.getNeighboringContentUrls().isEmpty());
     assertTrue(adRequest.getKeywords().isEmpty());
     assertTrue(adRequest.getCustomTargeting().isEmpty());
-    assertNull(adRequest.getLocation());
     assertNull(adRequest.getPublisherProvidedId());
     assertNull(adRequest.getNetworkExtrasBundle(AdMobAdapter.class));
   }
 
   @Test
   public void testAsAdRequest_allParams() {
-    Location location = new Location("");
-    location.setAccuracy(1);
-    location.setLongitude(2);
-    location.setLatitude(3);
-    location.setTime(12345);
-
     MediationNetworkExtrasProvider provider = mock(MediationNetworkExtrasProvider.class);
     Bundle bundle = new Bundle();
     bundle.putString("npa", "0");
@@ -67,7 +59,6 @@ public class FlutterAdManagerAdRequestTest {
         .getMediationExtras(eq("test-ad-unit"), eq("identifier"));
 
     Builder builder = new Builder();
-    builder.setLocation(location);
     builder.setKeywords(Collections.singletonList("keyword"));
     builder.setContentUrl("content-url");
     builder.setNeighboringContentUrls(Collections.singletonList("neighbor"));
@@ -89,10 +80,6 @@ public class FlutterAdManagerAdRequestTest {
     assertEquals(adRequest.getKeywords(), Collections.singleton("keyword"));
     assertEquals(adRequest.getContentUrl(), "content-url");
     assertEquals(adRequest.getNeighboringContentUrls(), Collections.singletonList("neighbor"));
-    assertEquals(adRequest.getLocation().getAccuracy(), 1, 0);
-    assertEquals(adRequest.getLocation().getLongitude(), 2, 0);
-    assertEquals(adRequest.getLocation().getLatitude(), 3, 0);
-    assertEquals(adRequest.getLocation().getTime(), 12345);
     // Previous value of "npa" should get overridden.
     assertEquals(adRequest.getNetworkExtrasBundle(AdMobAdapter.class).get("npa"), "1");
     assertEquals(adRequest.getPublisherProvidedId(), "pubProvidedId");

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdRequestTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdRequestTest.java
@@ -21,7 +21,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
-import android.location.Location;
 import android.os.Bundle;
 import com.google.ads.mediation.admob.AdMobAdapter;
 import com.google.android.gms.ads.AdRequest;
@@ -42,18 +41,11 @@ public class FlutterAdRequestTest {
     assertNull(adRequest.getContentUrl());
     assertTrue(adRequest.getNeighboringContentUrls().isEmpty());
     assertTrue(adRequest.getKeywords().isEmpty());
-    assertNull(adRequest.getLocation());
     assertNull(adRequest.getNetworkExtrasBundle(AdMobAdapter.class));
   }
 
   @Test
   public void testAsAdRequest_allParams() {
-    Location location = new Location("");
-    location.setAccuracy(1);
-    location.setLongitude(2);
-    location.setLatitude(3);
-    location.setTime(12345);
-
     MediationNetworkExtrasProvider provider = mock(MediationNetworkExtrasProvider.class);
     Bundle bundle = new Bundle();
     bundle.putString("npa", "0");
@@ -63,7 +55,6 @@ public class FlutterAdRequestTest {
 
     FlutterAdRequest flutterAdRequest =
         new Builder()
-            .setLocation(location)
             .setKeywords(Collections.singletonList("keyword"))
             .setContentUrl("content-url")
             .setNeighboringContentUrls(Collections.singletonList("neighbor"))
@@ -78,10 +69,6 @@ public class FlutterAdRequestTest {
     assertEquals(adRequest.getKeywords(), Collections.singleton("keyword"));
     assertEquals(adRequest.getContentUrl(), "content-url");
     assertEquals(adRequest.getNeighboringContentUrls(), Collections.singletonList("neighbor"));
-    assertEquals(adRequest.getLocation().getAccuracy(), 1, 0);
-    assertEquals(adRequest.getLocation().getLongitude(), 2, 0);
-    assertEquals(adRequest.getLocation().getLatitude(), 3, 0);
-    assertEquals(adRequest.getLocation().getTime(), 12345);
     // Previous value of "npa" should get overridden.
     assertEquals(adRequest.getNetworkExtrasBundle(AdMobAdapter.class).get("npa"), "1");
   }

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
@@ -65,17 +65,6 @@
 - (instancetype _Nonnull)initWithOrientation:(NSString *_Nonnull)orientation;
 @end
 
-@interface FLTLocationParams : NSObject
-
-@property NSNumber *_Nullable accuracy;
-@property NSNumber *_Nullable longitude;
-@property NSNumber *_Nullable latitude;
-
-- (instancetype _Nonnull)initWithAccuracy:(NSNumber *_Nonnull)accuracy
-                                longitude:(NSNumber *_Nonnull)longitude
-                                 latitude:(NSNumber *_Nonnull)latitude;
-@end
-
 @interface FLTFluidSize : FLTAdSize
 @end
 
@@ -84,7 +73,6 @@
 @property NSString *_Nullable contentURL;
 @property BOOL nonPersonalizedAds;
 @property NSArray<NSString *> *_Nullable neighboringContentURLs;
-@property FLTLocationParams *_Nullable location;
 @property NSString *_Nullable mediationExtrasIdentifier;
 @property id<FLTMediationNetworkExtrasProvider> _Nullable mediationNetworkExtrasProvider;
 @property NSDictionary<NSString *, NSString *> *_Nullable adMobExtras;

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
@@ -134,21 +134,6 @@
 }
 @end
 
-@implementation FLTLocationParams
-
-- (instancetype _Nonnull)initWithAccuracy:(NSNumber *_Nonnull)accuracy
-                                longitude:(NSNumber *_Nonnull)longitude
-                                 latitude:(NSNumber *_Nonnull)latitude {
-  self = [super init];
-  if (self) {
-    _accuracy = accuracy;
-    _longitude = longitude;
-    _latitude = latitude;
-  }
-  return self;
-}
-@end
-
 @implementation FLTFluidSize
 - (instancetype _Nonnull)init {
   self = [self initWithAdSize:kGADAdSizeFluid];
@@ -217,12 +202,6 @@
   request.neighboringContentURLStrings = _neighboringContentURLs;
   request.requestAgent = FLT_REQUEST_AGENT_VERSIONED;
   [self addNetworkExtrasToGADRequest:request adUnitId:adUnitId];
-
-  if ([FLTAdUtil isNotNull:_location]) {
-    [request setLocationWithLatitude:_location.latitude.floatValue
-                           longitude:_location.longitude.floatValue
-                            accuracy:_location.accuracy.floatValue];
-  }
   return request;
 }
 
@@ -295,11 +274,6 @@
   }
   request.customTargeting = targetingDictionary;
   [self addNetworkExtrasToGADRequest:request adUnitId:adUnitId];
-  if ([FLTAdUtil isNotNull:self.location]) {
-    [request setLocationWithLatitude:self.location.latitude.floatValue
-                           longitude:self.location.longitude.floatValue
-                            accuracy:self.location.accuracy.floatValue];
-  }
   request.requestAgent = FLT_REQUEST_AGENT_VERSIONED;
   return request;
 }

--- a/packages/google_mobile_ads/ios/Classes/FLTConstants.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTConstants.h
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /** Versioned request agent string. */
-#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-1.1.0"
+#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-1.2.0"

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
@@ -35,7 +35,6 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
   FLTAdmobFieldNativeAdOptions = 144,
   FLTAdmobFieldVideoOptions = 145,
   FLTAdmobFieldInlineAdaptiveAdSize = 146,
-  FLTAdmobFieldLocation = 147,
   FLTAdmobRequestConfigurationParams = 148,
 };
 
@@ -94,7 +93,6 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
       NSNumber *nonPersonalizedAds = [self readValueOfType:[self readByte]];
       request.nonPersonalizedAds = nonPersonalizedAds.boolValue;
       request.neighboringContentURLs = [self readValueOfType:[self readByte]];
-      request.location = [self readValueOfType:[self readByte]];
       request.mediationExtrasIdentifier = [self readValueOfType:[self readByte]];
       request.mediationNetworkExtrasProvider = _mediationNetworkExtrasProvider;
       request.adMobExtras = [self readValueOfType:[self readByte]];
@@ -161,7 +159,6 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
       request.nonPersonalizedAds = nonPersonalizedAds.boolValue;
       request.neighboringContentURLs = [self readValueOfType:[self readByte]];
       request.pubProvidedID = [self readValueOfType:[self readByte]];
-      request.location = [self readValueOfType:[self readByte]];
       request.mediationExtrasIdentifier = [self readValueOfType:[self readByte]];
       request.mediationNetworkExtrasProvider = _mediationNetworkExtrasProvider;
       request.adMobExtras = [self readValueOfType:[self readByte]];
@@ -230,11 +227,6 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
       requestConfig.testDeviceIdentifiers = [self readValueOfType:[self readByte]];
       return requestConfig;
     }
-    case FLTAdmobFieldLocation: {
-      return [[FLTLocationParams alloc] initWithAccuracy:[self readValueOfType:[self readByte]]
-                                               longitude:[self readValueOfType:[self readByte]]
-                                                latitude:[self readValueOfType:[self readByte]]];
-    }
     case FLTAdmobFieldInlineAdaptiveAdSize: {
       return [[FLTInlineAdaptiveBannerSize alloc]
           initWithFactory:_adSizeFactory
@@ -286,7 +278,6 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     [self writeValue:@(request.nonPersonalizedAds)];
     [self writeValue:request.neighboringContentURLs];
     [self writeValue:request.pubProvidedID];
-    [self writeValue:request.location];
     [self writeValue:request.mediationExtrasIdentifier];
     [self writeValue:request.adMobExtras];
   } else if ([value isKindOfClass:[FLTAdRequest class]]) {
@@ -296,7 +287,6 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     [self writeValue:request.contentURL];
     [self writeValue:@(request.nonPersonalizedAds)];
     [self writeValue:request.neighboringContentURLs];
-    [self writeValue:request.location];
     [self writeValue:request.mediationExtrasIdentifier];
     [self writeValue:request.adMobExtras];
   } else if ([value isKindOfClass:[FLTRewardItem class]]) {
@@ -380,12 +370,6 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     [super writeValue:NSNull.null];
     [super writeValue:NSNull.null];
     [self writeValue:params.testDeviceIdentifiers];
-  } else if ([value isKindOfClass:[FLTLocationParams class]]) {
-    [self writeByte:FLTAdmobFieldLocation];
-    FLTLocationParams *location = value;
-    [self writeValue:location.accuracy];
-    [self writeValue:location.longitude];
-    [self writeValue:location.latitude];
   } else {
     [super writeValue:value];
   }

--- a/packages/google_mobile_ads/ios/Tests/FLTAdRequestTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTAdRequestTest.m
@@ -41,10 +41,6 @@
   NSArray<NSString *> *keywords = @[ @"keyword1", @"keyword2" ];
   fltAdRequest.keywords = keywords;
   fltAdRequest.nonPersonalizedAds = YES;
-  FLTLocationParams *locationParams = [[FLTLocationParams alloc] initWithAccuracy:@1
-                                                                        longitude:@2
-                                                                         latitude:@3];
-  fltAdRequest.location = locationParams;
   fltAdRequest.mediationExtrasIdentifier = @"identifier";
   NSArray<NSString *> *neighbors = @[ @"neighbor1", @"neighbor2" ];
   fltAdRequest.neighboringContentURLs = neighbors;
@@ -71,7 +67,6 @@
   XCTAssertEqualObjects(updatedExtras, extras);
   XCTAssertEqualObjects(updatedExtras.additionalParameters[@"npa"], @"1");
   OCMVerify([gadRequestSpy registerAdNetworkExtras:[OCMArg isEqual:testExtras]]);
-  OCMVerify([gadRequestSpy setLocationWithLatitude:3 longitude:2 accuracy:1]);
 }
 
 - (void)testAsAdRequestNoParams {
@@ -89,7 +84,6 @@
   XCTAssertNil(gadRequest.keywords);
   XCTAssertNil(gadRequest.neighboringContentURLStrings);
   XCTAssertNil([gadRequest adNetworkExtrasFor:[GADExtras class]]);
-  XCTAssertNil([gadRequest valueForKey:@"_location"]);
 }
 
 - (void)testGADExtrasAddedWhenNpaSpecified {

--- a/packages/google_mobile_ads/ios/Tests/FLTGAMAdRequestTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGAMAdRequestTest.m
@@ -41,10 +41,6 @@
   NSArray<NSString *> *keywords = @[ @"keyword1", @"keyword2" ];
   fltGAMAdRequest.keywords = keywords;
   fltGAMAdRequest.nonPersonalizedAds = YES;
-  FLTLocationParams *locationParams = [[FLTLocationParams alloc] initWithAccuracy:@1
-                                                                        longitude:@2
-                                                                         latitude:@3];
-  fltGAMAdRequest.location = locationParams;
   fltGAMAdRequest.mediationExtrasIdentifier = @"identifier";
   NSArray<NSString *> *neighbors = @[ @"neighbor1", @"neighbor2" ];
   fltGAMAdRequest.neighboringContentURLs = neighbors;
@@ -76,7 +72,6 @@
   XCTAssertEqualObjects(updatedExtras, extras);
   XCTAssertEqualObjects(updatedExtras.additionalParameters[@"npa"], @"1");
   OCMVerify([gamRequestSpy registerAdNetworkExtras:[OCMArg isEqual:testExtras]]);
-  OCMVerify([gamRequestSpy setLocationWithLatitude:3 longitude:2 accuracy:1]);
 }
 
 - (void)testAsAdRequestNoParams {
@@ -94,7 +89,6 @@
   XCTAssertNil(gamRequest.keywords);
   XCTAssertNil(gamRequest.neighboringContentURLStrings);
   XCTAssertNil([gamRequest adNetworkExtrasFor:[GADExtras class]]);
-  XCTAssertNil([gamRequest valueForKey:@"_location"]);
   XCTAssertNil(gamRequest.publisherProvidedID);
   XCTAssertTrue(gamRequest.customTargeting.count == 0);
 }

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
@@ -228,7 +228,6 @@
   request.nonPersonalizedAds = YES;
   NSArray<NSString *> *contentURLs = @[ @"url-1.com", @"url-2.com" ];
   request.neighboringContentURLs = contentURLs;
-  request.location = [[FLTLocationParams alloc] initWithAccuracy:@1.5 longitude:@52 latitude:@123];
   request.mediationExtrasIdentifier = @"identifier";
   request.adMobExtras = @{@"key" : @"value"};
   NSData *encodedMessage = [_messageCodec encode:request];
@@ -238,9 +237,6 @@
   XCTAssertEqualObjects(decodedRequest.contentURL, @"banana");
   XCTAssertTrue(decodedRequest.nonPersonalizedAds);
   XCTAssertEqualObjects(decodedRequest.neighboringContentURLs, contentURLs);
-  XCTAssertEqualObjects(decodedRequest.location.accuracy, @1.5);
-  XCTAssertEqualObjects(decodedRequest.location.longitude, @52);
-  XCTAssertEqualObjects(decodedRequest.location.latitude, @123);
   XCTAssertEqualObjects(decodedRequest.mediationExtrasIdentifier, @"identifier");
   XCTAssertEqualObjects(decodedRequest.adMobExtras, @{@"key" : @"value"});
 }
@@ -255,7 +251,6 @@
   NSArray<NSString *> *contentURLs = @[ @"url-1.com", @"url-2.com" ];
   request.neighboringContentURLs = contentURLs;
   request.pubProvidedID = @"pub-id";
-  request.location = [[FLTLocationParams alloc] initWithAccuracy:@1.5 longitude:@52 latitude:@123];
   request.mediationExtrasIdentifier = @"identifier";
   request.adMobExtras = @{@"key" : @"value"};
   NSData *encodedMessage = [_messageCodec encode:request];
@@ -269,9 +264,6 @@
   XCTAssertTrue(decodedRequest.nonPersonalizedAds);
   XCTAssertEqualObjects(decodedRequest.neighboringContentURLs, contentURLs);
   XCTAssertEqualObjects(decodedRequest.pubProvidedID, @"pub-id");
-  XCTAssertEqualObjects(decodedRequest.location.accuracy, @1.5);
-  XCTAssertEqualObjects(decodedRequest.location.longitude, @52);
-  XCTAssertEqualObjects(decodedRequest.location.latitude, @123);
   XCTAssertEqualObjects(decodedRequest.mediationExtrasIdentifier, @"identifier");
   XCTAssertEqualObjects(decodedRequest.adMobExtras, @{@"key" : @"value"});
 }

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -144,7 +144,6 @@ class LoadAdError extends AdError {
 }
 
 /// Location parameters that can be configured in an ad request.
-@Deprecated('LocationParams is ignored and will be removed in a future release')
 class LocationParams {
   /// Location parameters that can be configured in an ad request.
   const LocationParams({
@@ -242,7 +241,6 @@ class AdRequest {
         nonPersonalizedAds == other.nonPersonalizedAds &&
         listEquals(neighboringContentUrls, other.neighboringContentUrls) &&
         httpTimeoutMillis == other.httpTimeoutMillis &&
-        location == other.location &&
         mediationExtrasIdentifier == other.mediationExtrasIdentifier &&
         mapEquals<String, String>(extras, other.extras);
   }

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -144,6 +144,7 @@ class LoadAdError extends AdError {
 }
 
 /// Location parameters that can be configured in an ad request.
+@Deprecated('LocationParams is ignored and will be removed in a future release')
 class LocationParams {
   /// Location parameters that can be configured in an ad request.
   const LocationParams({
@@ -219,6 +220,7 @@ class AdRequest {
   /// Location data.
   ///
   /// Used for mediation targeting purposes.
+  @Deprecated('Location is not used and will be deleted in a future release')
   final LocationParams? location;
 
   /// String identifier used in providing mediation extras.

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -783,7 +783,6 @@ class AdMessageCodec extends StandardMessageCodec {
   static const int _valueNativeAdOptions = 144;
   static const int _valueVideoOptions = 145;
   static const int _valueInlineAdaptiveBannerAdSize = 146;
-  static const int _valueLocationParams = 147;
   static const int _valueRequestConfigurationParams = 148;
 
   @override
@@ -802,7 +801,6 @@ class AdMessageCodec extends StandardMessageCodec {
         writeValue(buffer, value.httpTimeoutMillis);
       }
       writeValue(buffer, value.publisherProvidedId);
-      writeValue(buffer, value.location);
       writeValue(buffer, value.mediationExtrasIdentifier);
       writeValue(buffer, value.extras);
     } else if (value is AdRequest) {
@@ -814,7 +812,6 @@ class AdMessageCodec extends StandardMessageCodec {
       if (defaultTargetPlatform == TargetPlatform.android) {
         writeValue(buffer, value.httpTimeoutMillis);
       }
-      writeValue(buffer, value.location);
       writeValue(buffer, value.mediationExtrasIdentifier);
       writeValue(buffer, value.extras);
     } else if (value is RewardItem) {
@@ -878,14 +875,6 @@ class AdMessageCodec extends StandardMessageCodec {
       writeValue(buffer, value.tagForChildDirectedTreatment);
       writeValue(buffer, value.tagForUnderAgeOfConsent);
       writeValue(buffer, value.testDeviceIds);
-    } else if (value is LocationParams) {
-      buffer.putUint8(_valueLocationParams);
-      writeValue(buffer, value.accuracy);
-      writeValue(buffer, value.longitude);
-      writeValue(buffer, value.latitude);
-      if (defaultTargetPlatform == TargetPlatform.android) {
-        writeValue(buffer, value.time);
-      }
     } else {
       super.writeValue(buffer, value);
     }
@@ -954,7 +943,6 @@ class AdMessageCodec extends StandardMessageCodec {
           httpTimeoutMillis: (defaultTargetPlatform == TargetPlatform.android)
               ? readValueOfType(buffer.getUint8(), buffer)
               : null,
-          location: readValueOfType(buffer.getUint8(), buffer),
           mediationExtrasIdentifier: readValueOfType(buffer.getUint8(), buffer),
           extras: readValueOfType(buffer.getUint8(), buffer)
               ?.cast<String, String>(),
@@ -1006,7 +994,6 @@ class AdMessageCodec extends StandardMessageCodec {
               ? readValueOfType(buffer.getUint8(), buffer)
               : null,
           publisherProvidedId: readValueOfType(buffer.getUint8(), buffer),
-          location: readValueOfType(buffer.getUint8(), buffer),
           mediationExtrasIdentifier: readValueOfType(buffer.getUint8(), buffer),
           extras: readValueOfType(buffer.getUint8(), buffer)
               ?.cast<String, String>(),
@@ -1068,15 +1055,6 @@ class AdMessageCodec extends StandardMessageCodec {
           tagForUnderAgeOfConsent: readValueOfType(buffer.getUint8(), buffer),
           testDeviceIds:
               readValueOfType(buffer.getUint8(), buffer).cast<String>(),
-        );
-      case _valueLocationParams:
-        return LocationParams(
-          accuracy: readValueOfType(buffer.getUint8(), buffer),
-          longitude: readValueOfType(buffer.getUint8(), buffer),
-          latitude: readValueOfType(buffer.getUint8(), buffer),
-          time: (defaultTargetPlatform == TargetPlatform.android)
-              ? readValueOfType(buffer.getUint8(), buffer)
-              : null,
         );
       default:
         return super.readValueOfType(type, buffer);

--- a/packages/google_mobile_ads/pubspec.yaml
+++ b/packages/google_mobile_ads/pubspec.yaml
@@ -16,7 +16,7 @@ name: google_mobile_ads
 description: Flutter plugin for Google Mobile Ads, supporting
   banner, interstitial (full-screen),  rewarded and native ads
 homepage: https://github.com/googleads/googleads-mobile-flutter/tree/master/packages/google_mobile_ads
-version: 1.1.0
+version: 1.2.0
 
 flutter:
   plugin:

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -1071,8 +1071,17 @@ void main() {
         extras: {'key': 'value'},
       );
 
+      final AdRequest decodedRequest = AdRequest(
+        keywords: <String>['1', '2', '3'],
+        contentUrl: 'contentUrl',
+        nonPersonalizedAds: false,
+        neighboringContentUrls: <String>['url1.com', 'url2.com'],
+        httpTimeoutMillis: 12345,
+        mediationExtrasIdentifier: 'identifier',
+        extras: {'key': 'value'},
+      );
       final ByteData byteData = codec.encodeMessage(adRequest)!;
-      expect(codec.decodeMessage(byteData), adRequest);
+      expect(codec.decodeMessage(byteData), decodedRequest);
     });
 
     test('encode/decode AdRequest iOS', () async {
@@ -1097,10 +1106,7 @@ void main() {
       expect(decoded.contentUrl, adRequest.contentUrl);
       expect(decoded.nonPersonalizedAds, adRequest.nonPersonalizedAds);
       expect(decoded.keywords, adRequest.keywords);
-      // Time is not included on iOS.
-      expect(decoded.location!.accuracy, 1.1);
-      expect(decoded.location!.longitude, 25);
-      expect(decoded.location!.latitude, 38);
+      expect(decoded.location, null);
       expect(decoded.mediationExtrasIdentifier, 'identifier');
     });
 
@@ -1258,9 +1264,23 @@ void main() {
       );
       final ByteData byteData = codec.encodeMessage(request)!;
 
+      final AdManagerAdRequest decodedRequest = AdManagerAdRequest(
+        keywords: <String>['who'],
+        contentUrl: 'dat',
+        customTargeting: <String, String>{'boy': 'who'},
+        customTargetingLists: <String, List<String>>{
+          'him': <String>['is']
+        },
+        nonPersonalizedAds: true,
+        neighboringContentUrls: <String>['url1.com', 'url2.com'],
+        httpTimeoutMillis: 5000,
+        publisherProvidedId: 'test-pub-id',
+        mediationExtrasIdentifier: 'identifier',
+        extras: {'key': 'value'},
+      );
       expect(
         codec.decodeMessage(byteData),
-        request,
+        decodedRequest,
       );
     });
 
@@ -1294,10 +1314,7 @@ void main() {
       expect(decoded.publisherProvidedId, request.publisherProvidedId);
       expect(decoded.customTargeting, request.customTargeting);
       expect(decoded.customTargetingLists, request.customTargetingLists);
-      // Time is not included on iOS.
-      expect(decoded.location!.accuracy, 1.1);
-      expect(decoded.location!.longitude, 25);
-      expect(decoded.location!.latitude, 38);
+      expect(decoded.location, null);
       expect(decoded.mediationExtrasIdentifier, 'identifier');
     });
 


### PR DESCRIPTION
## Description

Deprecate location params, which are being removed in version 9 and 21: https://developers.google.com/admob/ios/migration#remove_location_setting_api_on_gadrequest

`AdRequest` and `AdManagerAdRequest` still allow you to pass `LocationParams`, but they are now ignored on the platform side when creating an ad request.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
