### PR TITLE
Replace kGAD constants

### DIFF
--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
@@ -155,7 +155,7 @@
 
 @implementation FLTFluidSize
 - (instancetype _Nonnull)init {
-  self = [self initWithAdSize:kGADAdSizeFluid];
+  self = [self initWithAdSize:GADAdSizeFluid];
   return self;
 }
 @end
@@ -497,7 +497,7 @@
     _height = -1;
     _adRequest = request;
     _adUnitId = adUnitId;
-    _bannerView = [[GAMBannerView alloc] initWithAdSize:kGADAdSizeFluid];
+    _bannerView = [[GAMBannerView alloc] initWithAdSize:GADAdSizeFluid];
     _bannerView.adUnitID = adUnitId;
     _bannerView.rootViewController = rootViewController;
     _bannerView.appEventDelegate = self;
@@ -1086,7 +1086,7 @@
     _adLoader =
         [[GADAdLoader alloc] initWithAdUnitID:_adUnitId
                            rootViewController:rootViewController
-                                      adTypes:@[ kGADAdLoaderAdTypeNative ]
+                                      adTypes:@[ GADAdLoaderAdTypeNative ]
                                       options:adLoaderOptions];
     _nativeAdOptions = nativeAdOptions;
     self.adLoader.delegate = self;

--- a/packages/google_mobile_ads/ios/Tests/FLTFluidGAMBannerAdTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTFluidGAMBannerAdTest.m
@@ -120,7 +120,7 @@
 
   id gamBannerClassMock = OCMClassMock([GAMBannerView class]);
   OCMStub([gamBannerClassMock alloc]).andReturn(gamBannerClassMock);
-  OCMStub([gamBannerClassMock initWithAdSize:kGADAdSizeFluid])
+  OCMStub([gamBannerClassMock initWithAdSize:GADAdSizeFluid])
       .andReturn(gamBannerClassMock);
 
   // Create and load an ad.

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
@@ -244,11 +244,8 @@
   FLTFluidSize *decodedSize = [_messageCodec decode:encodedMessage];
 
   XCTAssertTrue([decodedSize isKindOfClass:FLTFluidSize.class]);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  XCTAssertEqual(decodedSize.size.size.width, kGADAdSizeFluid.size.width);
-  XCTAssertEqual(decodedSize.size.size.height, kGADAdSizeFluid.size.height);
-#pragma clang diagnostic pop
+  XCTAssertEqual(decodedSize.size.size.width, GADAdSizeFluid.size.width);
+  XCTAssertEqual(decodedSize.size.size.height, GADAdSizeFluid.size.height);
 }
 
 - (void)testEncodeDecodeAdRequest {


### PR DESCRIPTION
## Description

Replaces deprecated `kGADFluid` with `GADFluid`, and `kGADAdLoaderAdTypeNative` with `GADAdLoaderAdTypeNative`.

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
