### PR TITLE
Fix version back to 1.2.0.

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.2.1
+## 1.2.0
 * Set new minimum height for `FluidAdWidget`.
   This is required after Flutter v2.11.0-0.1.pre because Android platform views
   that have no size don't load.
@@ -6,8 +6,6 @@
   * [Android release notes](https://developers.google.com/admob/android/rel-notes)
   * [iOS release notes](https://developers.google.com/admob/ios/rel-notes)
 * Deprecate `AdapterResponseInfo.credentials` in favor of `adUnitMapping`
-
-## 1.2.0
 * Deprecates `LocationParams` in `AdRequest` and `AdManagerAdRequest`.
 
 ## 1.1.0

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
@@ -17,7 +17,7 @@ package io.flutter.plugins.googlemobileads;
 /** Constants used in the plugin. */
 public class Constants {
   /** Version request agent. Should be bumped alongside plugin versions. */
-  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-1.2.1";
+  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-1.2.0";
 
   static final String ERROR_CODE_UNEXPECTED_AD_TYPE = "unexpected_ad_type";
 }

--- a/packages/google_mobile_ads/ios/Classes/FLTConstants.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTConstants.h
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /** Versioned request agent string. */
-#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-1.2.1"
+#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-1.2.0"

--- a/packages/google_mobile_ads/pubspec.yaml
+++ b/packages/google_mobile_ads/pubspec.yaml
@@ -16,7 +16,7 @@ name: google_mobile_ads
 description: Flutter plugin for Google Mobile Ads, supporting
   banner, interstitial (full-screen),  rewarded and native ads
 homepage: https://github.com/googleads/googleads-mobile-flutter/tree/master/packages/google_mobile_ads
-version: 1.2.1
+version: 1.2.0
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Fixes the version and changelog. The latest released version was 1.1.0, so we should be bumping to 1.2.0 instead of 1.2.1.

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
