### PR TITLE
Adinspector apis

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.3.0
 * Adds support for programmatically opening the debug options menu using`MobileAds.openDebugMenu(String adUnitId)`
+* Adds support for Ad inspector APIs
 
 ## 1.2.0
 * Set new minimum height for `FluidAdWidget`.

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterMobileAdsWrapper.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterMobileAdsWrapper.java
@@ -17,6 +17,7 @@ package io.flutter.plugins.googlemobileads;
 import android.content.Context;
 import androidx.annotation.NonNull;
 import com.google.android.gms.ads.MobileAds;
+import com.google.android.gms.ads.OnAdInspectorClosedListener;
 import com.google.android.gms.ads.RequestConfiguration;
 import com.google.android.gms.ads.initialization.OnInitializationCompleteListener;
 
@@ -59,5 +60,10 @@ public class FlutterMobileAdsWrapper {
   /** Wrapper for openDebugMenu. */
   public void openDebugMenu(Context context, String adUnitId) {
     MobileAds.openDebugMenu(context, adUnitId);
+  }
+
+  /** Open the ad inspector. */
+  public void openAdInspector(Context context, OnAdInspectorClosedListener listener) {
+    MobileAds.openAdInspector(context, listener);
   }
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -19,8 +19,10 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
+import com.google.android.gms.ads.AdInspectorError;
 import com.google.android.gms.ads.AdSize;
 import com.google.android.gms.ads.MobileAds;
+import com.google.android.gms.ads.OnAdInspectorClosedListener;
 import com.google.android.gms.ads.RequestConfiguration;
 import com.google.android.gms.ads.initialization.InitializationStatus;
 import com.google.android.gms.ads.initialization.OnInitializationCompleteListener;
@@ -317,13 +319,16 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
       case "MobileAds#openAdInspector":
         flutterMobileAds.openAdInspector(
             context,
-            adInspectorError -> {
-              if (adInspectorError != null) {
-                String errorCode = Integer.toString(adInspectorError.getCode());
-                result.error(
-                    errorCode, adInspectorError.getMessage(), adInspectorError.getDomain());
-              } else {
-                result.success(null);
+            new OnAdInspectorClosedListener() {
+              @Override
+              public void onAdInspectorClosed(@Nullable AdInspectorError adInspectorError) {
+                if (adInspectorError != null) {
+                  String errorCode = Integer.toString(adInspectorError.getCode());
+                  result.error(
+                      errorCode, adInspectorError.getMessage(), adInspectorError.getDomain());
+                } else {
+                  result.success(null);
+                }
               }
             });
         break;

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -311,9 +311,21 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
         instanceManager.disposeAllAds();
         result.success(null);
         break;
-
       case "MobileAds#initialize":
         flutterMobileAds.initialize(context, new FlutterInitializationListener(result));
+        break;
+      case "MobileAds#openAdInspector":
+        flutterMobileAds.openAdInspector(
+            context,
+            adInspectorError -> {
+              if (adInspectorError != null) {
+                String errorCode = Integer.toString(adInspectorError.getCode());
+                result.error(
+                    errorCode, adInspectorError.getMessage(), adInspectorError.getDomain());
+              } else {
+                result.success(null);
+              }
+            });
         break;
       case "MobileAds#getRequestConfiguration":
         result.success(flutterMobileAds.getRequestConfiguration());

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
@@ -237,6 +237,17 @@
                                  animated:YES
                                completion:nil];
     result(nil);
+  } else if ([call.method isEqualToString:@"MobileAds#openAdInspector"]) {
+    [GADMobileAds.sharedInstance presentAdInspectorFromViewController:rootController
+      completionHandler:^(NSError *error) {
+      if (error) {
+        result([FlutterError errorWithCode:[NSString stringWithFormat:@"%ld", (long) error.code]
+                                   message:error.localizedDescription
+                                   details:error.domain]);
+      } else {
+        result(nil);
+      }
+    }];
   } else if ([call.method isEqualToString:@"MobileAds#getVersionString"]) {
     result([GADMobileAds.sharedInstance sdkVersion]);
   } else if ([call.method

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
@@ -238,16 +238,20 @@
                                completion:nil];
     result(nil);
   } else if ([call.method isEqualToString:@"MobileAds#openAdInspector"]) {
-    [GADMobileAds.sharedInstance presentAdInspectorFromViewController:rootController
-      completionHandler:^(NSError *error) {
-      if (error) {
-        result([FlutterError errorWithCode:[NSString stringWithFormat:@"%ld", (long) error.code]
-                                   message:error.localizedDescription
-                                   details:error.domain]);
-      } else {
-        result(nil);
-      }
-    }];
+    [GADMobileAds.sharedInstance
+        presentAdInspectorFromViewController:rootController
+                           completionHandler:^(NSError *error) {
+                             if (error) {
+                               result([FlutterError
+                                   errorWithCode:[NSString stringWithFormat:
+                                                               @"%ld",
+                                                               (long)error.code]
+                                         message:error.localizedDescription
+                                         details:error.domain]);
+                             } else {
+                               result(nil);
+                             }
+                           }];
   } else if ([call.method isEqualToString:@"MobileAds#getVersionString"]) {
     result([GADMobileAds.sharedInstance sdkVersion]);
   } else if ([call.method

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
@@ -371,6 +371,76 @@
   XCTAssertEqual(returnedResult, nil);
 }
 
+- (void)testOpenAdInspectorSuccess {
+  FlutterMethodCall *methodCall = [FlutterMethodCall
+      methodCallWithMethodName:@"MobileAds#openAdInspector"
+                     arguments:@{}];
+
+  __block bool resultInvoked = false;
+  __block id _Nullable returnedResult;
+  FlutterResult result = ^(id _Nullable result) {
+    resultInvoked = true;
+    returnedResult = result;
+  };
+
+  id gadMobileAdsClassMock = OCMClassMock([GADMobileAds class]);
+  OCMStub(ClassMethod([gadMobileAdsClassMock sharedInstance]))
+      .andReturn((GADMobileAds *)gadMobileAdsClassMock);
+  
+  OCMStub([gadMobileAdsClassMock presentAdInspectorFromViewController:[OCMArg any] completionHandler:[OCMArg any]])
+    .andDo(^(NSInvocation *invocation) {
+      GADAdInspectorCompletionHandler completionHandler;
+      [invocation getArgument:&completionHandler atIndex:3];
+      completionHandler(nil);
+    });
+
+
+  [_fltGoogleMobileAdsPlugin handleMethodCall:methodCall result:result];
+
+  OCMVerify([gadMobileAdsClassMock presentAdInspectorFromViewController:[OCMArg any] completionHandler:[OCMArg any]]);
+  XCTAssertTrue(resultInvoked);
+  XCTAssertEqual(returnedResult, nil);
+}
+
+- (void)testOpenAdInspectorError {
+  FlutterMethodCall *methodCall = [FlutterMethodCall
+      methodCallWithMethodName:@"MobileAds#openAdInspector"
+                     arguments:@{}];
+
+  __block bool resultInvoked = false;
+  __block id _Nullable returnedResult;
+  FlutterResult result = ^(id _Nullable result) {
+    resultInvoked = true;
+    returnedResult = result;
+  };
+
+  id gadMobileAdsClassMock = OCMClassMock([GADMobileAds class]);
+  OCMStub(ClassMethod([gadMobileAdsClassMock sharedInstance]))
+      .andReturn((GADMobileAds *)gadMobileAdsClassMock);
+  NSDictionary *userInfo = @{
+    NSLocalizedDescriptionKey : @"message",
+  };
+  NSError *error = [NSError errorWithDomain:@"domain" code:1 userInfo:userInfo];
+  
+  OCMStub([gadMobileAdsClassMock presentAdInspectorFromViewController:[OCMArg any] completionHandler:[OCMArg any]])
+    .andDo(^(NSInvocation *invocation) {
+      GADAdInspectorCompletionHandler completionHandler;
+      [invocation getArgument:&completionHandler atIndex:3];
+      completionHandler(error);
+    });
+
+
+  [_fltGoogleMobileAdsPlugin handleMethodCall:methodCall result:result];
+
+  OCMVerify([gadMobileAdsClassMock presentAdInspectorFromViewController:[OCMArg any] completionHandler:[OCMArg any]]);
+  XCTAssertTrue(resultInvoked);
+  FlutterError *resultError = (FlutterError *)returnedResult;
+  
+  XCTAssertEqualObjects(resultError.code, @"1");
+  XCTAssertEqualObjects(resultError.message, @"message");
+  XCTAssertEqualObjects(resultError.details, @"domain");
+}
+
 - (void)testGetRequestConfiguration {
   FlutterMethodCall *methodCall = [FlutterMethodCall
       methodCallWithMethodName:@"MobileAds#getRequestConfiguration"

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
@@ -372,9 +372,9 @@
 }
 
 - (void)testOpenAdInspectorSuccess {
-  FlutterMethodCall *methodCall = [FlutterMethodCall
-      methodCallWithMethodName:@"MobileAds#openAdInspector"
-                     arguments:@{}];
+  FlutterMethodCall *methodCall =
+      [FlutterMethodCall methodCallWithMethodName:@"MobileAds#openAdInspector"
+                                        arguments:@{}];
 
   __block bool resultInvoked = false;
   __block id _Nullable returnedResult;
@@ -386,26 +386,29 @@
   id gadMobileAdsClassMock = OCMClassMock([GADMobileAds class]);
   OCMStub(ClassMethod([gadMobileAdsClassMock sharedInstance]))
       .andReturn((GADMobileAds *)gadMobileAdsClassMock);
-  
-  OCMStub([gadMobileAdsClassMock presentAdInspectorFromViewController:[OCMArg any] completionHandler:[OCMArg any]])
-    .andDo(^(NSInvocation *invocation) {
-      GADAdInspectorCompletionHandler completionHandler;
-      [invocation getArgument:&completionHandler atIndex:3];
-      completionHandler(nil);
-    });
 
+  OCMStub([gadMobileAdsClassMock
+              presentAdInspectorFromViewController:[OCMArg any]
+                                 completionHandler:[OCMArg any]])
+      .andDo(^(NSInvocation *invocation) {
+        GADAdInspectorCompletionHandler completionHandler;
+        [invocation getArgument:&completionHandler atIndex:3];
+        completionHandler(nil);
+      });
 
   [_fltGoogleMobileAdsPlugin handleMethodCall:methodCall result:result];
 
-  OCMVerify([gadMobileAdsClassMock presentAdInspectorFromViewController:[OCMArg any] completionHandler:[OCMArg any]]);
+  OCMVerify([gadMobileAdsClassMock
+      presentAdInspectorFromViewController:[OCMArg any]
+                         completionHandler:[OCMArg any]]);
   XCTAssertTrue(resultInvoked);
   XCTAssertEqual(returnedResult, nil);
 }
 
 - (void)testOpenAdInspectorError {
-  FlutterMethodCall *methodCall = [FlutterMethodCall
-      methodCallWithMethodName:@"MobileAds#openAdInspector"
-                     arguments:@{}];
+  FlutterMethodCall *methodCall =
+      [FlutterMethodCall methodCallWithMethodName:@"MobileAds#openAdInspector"
+                                        arguments:@{}];
 
   __block bool resultInvoked = false;
   __block id _Nullable returnedResult;
@@ -421,21 +424,24 @@
     NSLocalizedDescriptionKey : @"message",
   };
   NSError *error = [NSError errorWithDomain:@"domain" code:1 userInfo:userInfo];
-  
-  OCMStub([gadMobileAdsClassMock presentAdInspectorFromViewController:[OCMArg any] completionHandler:[OCMArg any]])
-    .andDo(^(NSInvocation *invocation) {
-      GADAdInspectorCompletionHandler completionHandler;
-      [invocation getArgument:&completionHandler atIndex:3];
-      completionHandler(error);
-    });
 
+  OCMStub([gadMobileAdsClassMock
+              presentAdInspectorFromViewController:[OCMArg any]
+                                 completionHandler:[OCMArg any]])
+      .andDo(^(NSInvocation *invocation) {
+        GADAdInspectorCompletionHandler completionHandler;
+        [invocation getArgument:&completionHandler atIndex:3];
+        completionHandler(error);
+      });
 
   [_fltGoogleMobileAdsPlugin handleMethodCall:methodCall result:result];
 
-  OCMVerify([gadMobileAdsClassMock presentAdInspectorFromViewController:[OCMArg any] completionHandler:[OCMArg any]]);
+  OCMVerify([gadMobileAdsClassMock
+      presentAdInspectorFromViewController:[OCMArg any]
+                         completionHandler:[OCMArg any]]);
   XCTAssertTrue(resultInvoked);
   FlutterError *resultError = (FlutterError *)returnedResult;
-  
+
   XCTAssertEqualObjects(resultError.code, @"1");
   XCTAssertEqualObjects(resultError.message, @"message");
   XCTAssertEqualObjects(resultError.details, @"domain");

--- a/packages/google_mobile_ads/lib/src/ad_inspector_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_inspector_containers.dart
@@ -1,0 +1,35 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Callback for when the ad inspector closes.
+typedef OnAdInspectorClosedListener = void Function(AdInspectorError?);
+
+/// Error information about why the ad inspector failed.
+class AdInspectorError {
+  /// Create an AdInspectorError with the given code, domain and message.
+  AdInspectorError({
+    required this.code,
+    required this.domain,
+    required this.message,
+  });
+
+  /// Code to identifier the error.
+  final int code;
+
+  /// The domain from which the error came.
+  final String? domain;
+
+  /// A message detailing the error.
+  final String? message;
+}

--- a/packages/google_mobile_ads/lib/src/ad_inspector_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_inspector_containers.dart
@@ -19,13 +19,13 @@ typedef OnAdInspectorClosedListener = void Function(AdInspectorError?);
 class AdInspectorError {
   /// Create an AdInspectorError with the given code, domain and message.
   AdInspectorError({
-    required this.code,
-    required this.domain,
-    required this.message,
+    this.code,
+    this.domain,
+    this.message,
   });
 
   /// Code to identifier the error.
-  final int code;
+  final String? code;
 
   /// The domain from which the error came.
   final String? domain;

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -782,7 +782,7 @@ class AdInstanceManager {
       listener(null);
     } on PlatformException catch (e) {
       var error = AdInspectorError(
-          code: int.parse(e.code), domain: e.details, message: e.message);
+          code: e.code, domain: e.details, message: e.message);
       listener(error);
     }
   }

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -19,6 +19,7 @@
 import 'dart:async';
 import 'dart:collection';
 
+import 'package:google_mobile_ads/src/ad_inspector_containers.dart';
 import 'package:google_mobile_ads/src/ad_listeners.dart';
 import 'package:google_mobile_ads/src/mobile_ads.dart';
 import 'package:flutter/cupertino.dart';
@@ -772,6 +773,18 @@ class AdInstanceManager {
         'adUnitId': adUnitId,
       },
     );
+  }
+
+  /// Send a platform message to open the ad inspector.
+  void openAdInspector(OnAdInspectorClosedListener listener) async {
+    try {
+      await channel.invokeMethod<void>('MobileAds#openAdInspector');
+      listener(null);
+    } on PlatformException catch (e) {
+      var error = AdInspectorError(
+          code: int.parse(e.code), domain: e.details, message: e.message);
+      listener(error);
+    }
   }
 }
 

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -781,8 +781,8 @@ class AdInstanceManager {
       await channel.invokeMethod<void>('MobileAds#openAdInspector');
       listener(null);
     } on PlatformException catch (e) {
-      var error = AdInspectorError(
-          code: e.code, domain: e.details, message: e.message);
+      var error =
+          AdInspectorError(code: e.code, domain: e.details, message: e.message);
       listener(error);
     }
   }

--- a/packages/google_mobile_ads/lib/src/mobile_ads.dart
+++ b/packages/google_mobile_ads/lib/src/mobile_ads.dart
@@ -14,6 +14,7 @@
 
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 
+import 'ad_inspector_containers.dart';
 import 'ad_instance_manager.dart';
 import 'request_configuration.dart';
 import 'package:flutter/foundation.dart';
@@ -128,6 +129,11 @@ class MobileAds {
   /// invoked.
   Future<void> openDebugMenu(String adUnitId) {
     return instanceManager.openDebugMenu(adUnitId);
+  }
+
+  /// Open the ad inspector.
+  void openAdInspector(OnAdInspectorClosedListener listener) async {
+    instanceManager.openAdInspector(listener);
   }
 
   /// Internal init to cleanup state for hot restart.

--- a/packages/google_mobile_ads/test/mobile_ads_test.dart
+++ b/packages/google_mobile_ads/test/mobile_ads_test.dart
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:async';
+
 import 'package:google_mobile_ads/google_mobile_ads.dart';
+import 'package:google_mobile_ads/src/ad_inspector_containers.dart';
 import 'package:google_mobile_ads/src/ad_instance_manager.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -147,6 +150,43 @@ void main() {
       expect(status.state, AdapterInitializationState.notReady);
       expect(status.description, 'desc');
       expect(status.latency, 0);
+    });
+
+    test('$MobileAds.openAdInspector success', () async {
+      MethodChannel(
+        'plugins.flutter.io/google_mobile_ads',
+        StandardMethodCodec(AdMessageCodec()),
+      ).setMockMethodCallHandler((MethodCall methodCall) async {
+        return null;
+      });
+
+      Completer<AdInspectorError?> completer = Completer<AdInspectorError?>();
+      MobileAds.instance.openAdInspector((error) {
+        completer.complete(error);
+      });
+
+      AdInspectorError? error = await completer.future;
+      expect(error, null);
+    });
+
+    test('$MobileAds.openAdInspector error', () async {
+      MethodChannel(
+        'plugins.flutter.io/google_mobile_ads',
+        StandardMethodCodec(AdMessageCodec()),
+      ).setMockMethodCallHandler((MethodCall methodCall) async {
+        throw PlatformException(
+            code: '1', details: 'details', message: 'message');
+      });
+
+      Completer<AdInspectorError?> completer = Completer<AdInspectorError?>();
+      MobileAds.instance.openAdInspector((error) {
+        completer.complete(error);
+      });
+
+      AdInspectorError? error = await completer.future;
+      expect(error!.message, 'message');
+      expect(error.code, 1);
+      expect(error.domain, 'details');
     });
 
     test('$MobileAds.setSameAppKeyEnabled', () async {

--- a/packages/google_mobile_ads/test/mobile_ads_test.dart
+++ b/packages/google_mobile_ads/test/mobile_ads_test.dart
@@ -185,7 +185,7 @@ void main() {
 
       AdInspectorError? error = await completer.future;
       expect(error!.message, 'message');
-      expect(error.code, 1);
+      expect(error.code, '1');
       expect(error.domain, 'details');
     });
 


### PR DESCRIPTION
## Description

Adds support for opening the ad inspector programmatically:
- https://developers.google.com/admob/ios/ad-inspector
- https://developers.google.com/admob/android/ad-inspector#launch_ad_inspector

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
