### PR TITLE
Change serverside verification options to setter

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## 2.0.0
-* Update GMA Android dependency to 21.0.0 and iOS to 9.6.0
-* Remove `credentials` from `AdapterResponseInfo`, which is replaced with
+* Updates GMA Android dependency to 21.0.0 and iOS to 9.6.0
+* Removes `credentials` from `AdapterResponseInfo`, which is replaced with
   `adUnitMapping`.
+* Removes `serverSideVerificationOptions` from `RewardedAd.load()` and 
+  `RewardedInterstitialAd.load()`, replacing them with setters 
+  `RewardedAd.setServerSideVerificationOptions()` and 
+  `RewardedInterstitialAd.setServerSideVerificationOptions()`. This lets you
+  update the ssv after the ad is loaded.
 
 ## 1.3.0
 * Adds support for programmatically opening the debug options menu using`MobileAds.openDebugMenu(String adUnitId)`

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedAd.java
@@ -34,7 +34,6 @@ class FlutterRewardedAd extends FlutterAd.FlutterOverlayAd {
   @NonNull private final FlutterAdLoader flutterAdLoader;
   @Nullable private final FlutterAdRequest request;
   @Nullable private final FlutterAdManagerAdRequest adManagerRequest;
-  @Nullable private final FlutterServerSideVerificationOptions serverSideVerificationOptions;
   @Nullable RewardedAd rewardedAd;
 
   /** A wrapper for {@link RewardItem}. */
@@ -76,14 +75,12 @@ class FlutterRewardedAd extends FlutterAd.FlutterOverlayAd {
       @NonNull AdInstanceManager manager,
       @NonNull String adUnitId,
       @NonNull FlutterAdRequest request,
-      @Nullable FlutterServerSideVerificationOptions serverSideVerificationOptions,
       @NonNull FlutterAdLoader flutterAdLoader) {
     super(adId);
     this.manager = manager;
     this.adUnitId = adUnitId;
     this.request = request;
     this.adManagerRequest = null;
-    this.serverSideVerificationOptions = serverSideVerificationOptions;
     this.flutterAdLoader = flutterAdLoader;
   }
 
@@ -93,14 +90,12 @@ class FlutterRewardedAd extends FlutterAd.FlutterOverlayAd {
       @NonNull AdInstanceManager manager,
       @NonNull String adUnitId,
       @NonNull FlutterAdManagerAdRequest adManagerRequest,
-      @Nullable FlutterServerSideVerificationOptions serverSideVerificationOptions,
       @NonNull FlutterAdLoader flutterAdLoader) {
     super(adId);
     this.manager = manager;
     this.adUnitId = adUnitId;
     this.adManagerRequest = adManagerRequest;
     this.request = null;
-    this.serverSideVerificationOptions = serverSideVerificationOptions;
     this.flutterAdLoader = flutterAdLoader;
   }
 
@@ -119,10 +114,6 @@ class FlutterRewardedAd extends FlutterAd.FlutterOverlayAd {
 
   void onAdLoaded(@NonNull RewardedAd rewardedAd) {
     FlutterRewardedAd.this.rewardedAd = rewardedAd;
-    if (serverSideVerificationOptions != null) {
-      rewardedAd.setServerSideVerificationOptions(
-          serverSideVerificationOptions.asServerSideVerificationOptions());
-    }
     rewardedAd.setOnPaidEventListener(new FlutterPaidEventListener(manager, this));
     manager.onAdLoaded(adId, rewardedAd.getResponseInfo());
   }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedAd.java
@@ -170,6 +170,14 @@ class FlutterRewardedAd extends FlutterAd.FlutterOverlayAd {
     rewardedAd = null;
   }
 
+  public void setServerSideVerificationOptions(FlutterServerSideVerificationOptions options) {
+    if (rewardedAd != null) {
+      rewardedAd.setServerSideVerificationOptions(options.asServerSideVerificationOptions());
+    } else {
+      Log.e(TAG, "RewardedAd is null in setServerSideVerificationOptions");
+    }
+  }
+
   /**
    * This class delegates various rewarded ad callbacks to FlutterRewardedAd. Maintains a weak
    * reference to avoid memory leaks.

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedInterstitialAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedInterstitialAd.java
@@ -145,7 +145,8 @@ class FlutterRewardedInterstitialAd extends FlutterAd.FlutterOverlayAd {
 
   public void setServerSideVerificationOptions(FlutterServerSideVerificationOptions options) {
     if (rewardedInterstitialAd != null) {
-      rewardedInterstitialAd.setServerSideVerificationOptions(options.asServerSideVerificationOptions());
+      rewardedInterstitialAd.setServerSideVerificationOptions(
+          options.asServerSideVerificationOptions());
     } else {
       Log.e(TAG, "RewardedInterstitialAd is null in setServerSideVerificationOptions");
     }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedInterstitialAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedInterstitialAd.java
@@ -35,7 +35,6 @@ class FlutterRewardedInterstitialAd extends FlutterAd.FlutterOverlayAd {
   @NonNull private final FlutterAdLoader flutterAdLoader;
   @Nullable private final FlutterAdRequest request;
   @Nullable private final FlutterAdManagerAdRequest adManagerRequest;
-  @Nullable private final FlutterServerSideVerificationOptions serverSideVerificationOptions;
   @Nullable RewardedInterstitialAd rewardedInterstitialAd;
 
   /** Constructor for AdMob Ad Request. */
@@ -44,14 +43,12 @@ class FlutterRewardedInterstitialAd extends FlutterAd.FlutterOverlayAd {
       @NonNull AdInstanceManager manager,
       @NonNull String adUnitId,
       @NonNull FlutterAdRequest request,
-      @Nullable FlutterServerSideVerificationOptions serverSideVerificationOptions,
       @NonNull FlutterAdLoader flutterAdLoader) {
     super(adId);
     this.manager = manager;
     this.adUnitId = adUnitId;
     this.request = request;
     this.adManagerRequest = null;
-    this.serverSideVerificationOptions = serverSideVerificationOptions;
     this.flutterAdLoader = flutterAdLoader;
   }
 
@@ -61,14 +58,12 @@ class FlutterRewardedInterstitialAd extends FlutterAd.FlutterOverlayAd {
       @NonNull AdInstanceManager manager,
       @NonNull String adUnitId,
       @NonNull FlutterAdManagerAdRequest adManagerRequest,
-      @Nullable FlutterServerSideVerificationOptions serverSideVerificationOptions,
       @NonNull FlutterAdLoader flutterAdLoader) {
     super(adId);
     this.manager = manager;
     this.adUnitId = adUnitId;
     this.adManagerRequest = adManagerRequest;
     this.request = null;
-    this.serverSideVerificationOptions = serverSideVerificationOptions;
     this.flutterAdLoader = flutterAdLoader;
   }
 
@@ -88,10 +83,6 @@ class FlutterRewardedInterstitialAd extends FlutterAd.FlutterOverlayAd {
 
   void onAdLoaded(@NonNull RewardedInterstitialAd rewardedInterstitialAd) {
     FlutterRewardedInterstitialAd.this.rewardedInterstitialAd = rewardedInterstitialAd;
-    if (serverSideVerificationOptions != null) {
-      rewardedInterstitialAd.setServerSideVerificationOptions(
-          serverSideVerificationOptions.asServerSideVerificationOptions());
-    }
     rewardedInterstitialAd.setOnPaidEventListener(new FlutterPaidEventListener(manager, this));
     manager.onAdLoaded(adId, rewardedInterstitialAd.getResponseInfo());
   }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedInterstitialAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRewardedInterstitialAd.java
@@ -143,6 +143,14 @@ class FlutterRewardedInterstitialAd extends FlutterAd.FlutterOverlayAd {
     rewardedInterstitialAd = null;
   }
 
+  public void setServerSideVerificationOptions(FlutterServerSideVerificationOptions options) {
+    if (rewardedInterstitialAd != null) {
+      rewardedInterstitialAd.setServerSideVerificationOptions(options.asServerSideVerificationOptions());
+    } else {
+      Log.e(TAG, "RewardedInterstitialAd is null in setServerSideVerificationOptions");
+    }
+  }
+
   /**
    * This class delegates various rewarded interstitial ad callbacks to
    * FlutterRewardedInterstitialAd. Maintains a weak reference to avoid memory leaks.

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -428,8 +428,6 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
         final FlutterAdRequest rewardedAdRequest = call.argument("request");
         final FlutterAdManagerAdRequest rewardedAdManagerRequest =
             call.argument("adManagerRequest");
-        final FlutterServerSideVerificationOptions rewardedAdServerSideVerificationOptions =
-            call.argument("serverSideVerificationOptions");
 
         final FlutterRewardedAd rewardedAd;
         if (rewardedAdRequest != null) {
@@ -439,7 +437,6 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
                   requireNonNull(instanceManager),
                   rewardedAdUnitId,
                   rewardedAdRequest,
-                  rewardedAdServerSideVerificationOptions,
                   new FlutterAdLoader(context));
         } else if (rewardedAdManagerRequest != null) {
           rewardedAd =
@@ -448,7 +445,6 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
                   requireNonNull(instanceManager),
                   rewardedAdUnitId,
                   rewardedAdManagerRequest,
-                  rewardedAdServerSideVerificationOptions,
                   new FlutterAdLoader(context));
         } else {
           result.error("InvalidRequest", "A null or invalid ad request was provided.", null);
@@ -503,9 +499,6 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
         final FlutterAdRequest rewardedInterstitialAdRequest = call.argument("request");
         final FlutterAdManagerAdRequest rewardedInterstitialAdManagerRequest =
             call.argument("adManagerRequest");
-        final FlutterServerSideVerificationOptions
-            rewardedInterstitialAdServerSideVerificationOptions =
-                call.argument("serverSideVerificationOptions");
 
         final FlutterRewardedInterstitialAd rewardedInterstitialAd;
         if (rewardedInterstitialAdRequest != null) {
@@ -515,7 +508,6 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
                   requireNonNull(instanceManager),
                   rewardedInterstitialAdUnitId,
                   rewardedInterstitialAdRequest,
-                  rewardedInterstitialAdServerSideVerificationOptions,
                   new FlutterAdLoader(context));
         } else if (rewardedInterstitialAdManagerRequest != null) {
           rewardedInterstitialAd =
@@ -524,7 +516,6 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
                   requireNonNull(instanceManager),
                   rewardedInterstitialAdUnitId,
                   rewardedInterstitialAdManagerRequest,
-                  rewardedInterstitialAdServerSideVerificationOptions,
                   new FlutterAdLoader(context));
         } else {
           result.error("InvalidRequest", "A null or invalid ad request was provided.", null);

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -600,37 +600,39 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
         flutterMobileAds.openDebugMenu(context, adUnitId);
         result.success(null);
         break;
-      case "getAdSize": {
-        FlutterAd ad = instanceManager.adForId(call.<Integer>argument("adId"));
-        if (ad == null) {
-          // This was called on a dart ad container that hasn't been loaded yet.
-          result.success(null);
-        } else if (ad instanceof FlutterBannerAd) {
-          result.success(((FlutterBannerAd) ad).getAdSize());
-        } else if (ad instanceof FlutterAdManagerBannerAd) {
-          result.success(((FlutterAdManagerBannerAd) ad).getAdSize());
-        } else {
-          result.error(
-              Constants.ERROR_CODE_UNEXPECTED_AD_TYPE,
-              "Unexpected ad type for getAdSize: " + ad,
-              null);
+      case "getAdSize":
+        {
+          FlutterAd ad = instanceManager.adForId(call.<Integer>argument("adId"));
+          if (ad == null) {
+            // This was called on a dart ad container that hasn't been loaded yet.
+            result.success(null);
+          } else if (ad instanceof FlutterBannerAd) {
+            result.success(((FlutterBannerAd) ad).getAdSize());
+          } else if (ad instanceof FlutterAdManagerBannerAd) {
+            result.success(((FlutterAdManagerBannerAd) ad).getAdSize());
+          } else {
+            result.error(
+                Constants.ERROR_CODE_UNEXPECTED_AD_TYPE,
+                "Unexpected ad type for getAdSize: " + ad,
+                null);
+          }
+          break;
         }
-        break;
-      }
-      case "setSSV": {
-        FlutterAd ad = instanceManager.adForId(call.<Integer>argument("adId"));
-        final FlutterServerSideVerificationOptions options =
-            call.argument("serverSideVerificationOptions");
-        if (ad instanceof FlutterRewardedAd) {
-          ((FlutterRewardedAd) ad).setServerSideVerificationOptions(options);
-        } else if (ad instanceof FlutterRewardedInterstitialAd) {
-          ((FlutterRewardedInterstitialAd) ad).setServerSideVerificationOptions(options);
-        } else {
-          Log.w(TAG, "Error - setSSV called on non-rewarded ad");
-          result.success(null);
+      case "setSSV":
+        {
+          FlutterAd ad = instanceManager.adForId(call.<Integer>argument("adId"));
+          final FlutterServerSideVerificationOptions options =
+              call.argument("serverSideVerificationOptions");
+          if (ad instanceof FlutterRewardedAd) {
+            ((FlutterRewardedAd) ad).setServerSideVerificationOptions(options);
+          } else if (ad instanceof FlutterRewardedInterstitialAd) {
+            ((FlutterRewardedInterstitialAd) ad).setServerSideVerificationOptions(options);
+          } else {
+            Log.w(TAG, "Error - setSSV called on non-rewarded ad");
+            result.success(null);
+          }
+          break;
         }
-        break;
-      }
       default:
         result.notImplemented();
     }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -616,15 +616,14 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
               call.argument("serverSideVerificationOptions");
           if (ad == null) {
             Log.w(TAG, "Error - null ad in setServerSideVerificationOptions");
-            result.success(null);
           } else if (ad instanceof FlutterRewardedAd) {
             ((FlutterRewardedAd) ad).setServerSideVerificationOptions(options);
           } else if (ad instanceof FlutterRewardedInterstitialAd) {
             ((FlutterRewardedInterstitialAd) ad).setServerSideVerificationOptions(options);
           } else {
             Log.w(TAG, "Error - setServerSideVerificationOptions called on " + "non-rewarded ad");
-            result.success(null);
           }
+          result.success(null);
           break;
         }
       default:

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -600,7 +600,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
         flutterMobileAds.openDebugMenu(context, adUnitId);
         result.success(null);
         break;
-      case "getAdSize":
+      case "getAdSize": {
         FlutterAd ad = instanceManager.adForId(call.<Integer>argument("adId"));
         if (ad == null) {
           // This was called on a dart ad container that hasn't been loaded yet.
@@ -616,6 +616,21 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
               null);
         }
         break;
+      }
+      case "setSSV": {
+        FlutterAd ad = instanceManager.adForId(call.<Integer>argument("adId"));
+        final FlutterServerSideVerificationOptions options =
+            call.argument("serverSideVerificationOptions");
+        if (ad instanceof FlutterRewardedAd) {
+          ((FlutterRewardedAd) ad).setServerSideVerificationOptions(options);
+        } else if (ad instanceof FlutterRewardedInterstitialAd) {
+          ((FlutterRewardedInterstitialAd) ad).setServerSideVerificationOptions(options);
+        } else {
+          Log.w(TAG, "Error - setSSV called on non-rewarded ad");
+          result.success(null);
+        }
+        break;
+      }
       default:
         result.notImplemented();
     }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -609,17 +609,20 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
           }
           break;
         }
-      case "setSSV":
+      case "setServerSideVerificationOptions":
         {
           FlutterAd ad = instanceManager.adForId(call.<Integer>argument("adId"));
           final FlutterServerSideVerificationOptions options =
               call.argument("serverSideVerificationOptions");
-          if (ad instanceof FlutterRewardedAd) {
+          if (ad == null) {
+            Log.w(TAG, "Error - null ad in setServerSideVerificationOptions");
+            result.success(null);
+          } else if (ad instanceof FlutterRewardedAd) {
             ((FlutterRewardedAd) ad).setServerSideVerificationOptions(options);
           } else if (ad instanceof FlutterRewardedInterstitialAd) {
             ((FlutterRewardedInterstitialAd) ad).setServerSideVerificationOptions(options);
           } else {
-            Log.w(TAG, "Error - setSSV called on non-rewarded ad");
+            Log.w(TAG, "Error - setServerSideVerificationOptions called on " + "non-rewarded ad");
             result.success(null);
           }
           break;

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterRewardedAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterRewardedAdTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
-import androidx.annotation.Nullable;
 import com.google.android.gms.ads.AdError;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.AdValue;
@@ -49,8 +48,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatcher;
-import org.mockito.ArgumentMatchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricTestRunner;
@@ -74,28 +71,27 @@ public class FlutterRewardedAdTest {
     mockFlutterAdLoader = mock(FlutterAdLoader.class);
   }
 
-  private void setupAdmobMocks(@Nullable FlutterServerSideVerificationOptions options) {
+  private void setupAdmobMocks() {
     FlutterAdRequest mockFlutterAdRequest = mock(FlutterAdRequest.class);
     mockAdRequest = mock(AdRequest.class);
     when(mockFlutterAdRequest.asAdRequest(anyString())).thenReturn(mockAdRequest);
     flutterRewardedAd =
-        new FlutterRewardedAd(
-            1, mockManager, "testId", mockFlutterAdRequest, options, mockFlutterAdLoader);
+        new FlutterRewardedAd(1, mockManager, "testId", mockFlutterAdRequest, mockFlutterAdLoader);
   }
 
-  private void setupAdManagerMocks(@Nullable FlutterServerSideVerificationOptions options) {
+  private void setupAdManagerMocks() {
     FlutterAdManagerAdRequest mockAdManagerFlutterRequest = mock(FlutterAdManagerAdRequest.class);
     mockAdManagerAdRequest = mock(AdManagerAdRequest.class);
     when(mockAdManagerFlutterRequest.asAdManagerAdRequest(anyString()))
         .thenReturn(mockAdManagerAdRequest);
     flutterRewardedAd =
         new FlutterRewardedAd(
-            1, mockManager, "testId", mockAdManagerFlutterRequest, options, mockFlutterAdLoader);
+            1, mockManager, "testId", mockAdManagerFlutterRequest, mockFlutterAdLoader);
   }
 
   @Test
   public void loadAdManagerRewardedAd_failedToLoad() {
-    setupAdManagerMocks(null);
+    setupAdManagerMocks();
     final LoadAdError loadAdError = mock(LoadAdError.class);
     doReturn(1).when(loadAdError).getCode();
     doReturn("2").when(loadAdError).getDomain();
@@ -127,9 +123,7 @@ public class FlutterRewardedAdTest {
 
   @Test
   public void loadAdManagerRewardedAd_showSuccessWithReward() {
-    final FlutterServerSideVerificationOptions options =
-        new FlutterServerSideVerificationOptions("userId", "customData");
-    setupAdManagerMocks(options);
+    setupAdManagerMocks();
 
     final RewardedAd mockAd = mock(RewardedAd.class);
     doAnswer(
@@ -225,17 +219,6 @@ public class FlutterRewardedAdTest {
     verify(mockAd).setFullScreenContentCallback(any(FullScreenContentCallback.class));
     verify(mockAd).show(eq(mockManager.getActivity()), any(OnUserEarnedRewardListener.class));
     verify(mockAd).setOnAdMetadataChangedListener(any(OnAdMetadataChangedListener.class));
-    ArgumentMatcher<ServerSideVerificationOptions> serverSideVerificationOptionsArgumentMatcher =
-        new ArgumentMatcher<ServerSideVerificationOptions>() {
-          @Override
-          public boolean matches(ServerSideVerificationOptions argument) {
-            return argument.getCustomData().equals(options.getCustomData())
-                && argument.getUserId().equals(options.getUserId());
-          }
-        };
-    verify(mockAd)
-        .setServerSideVerificationOptions(
-            ArgumentMatchers.argThat(serverSideVerificationOptionsArgumentMatcher));
     verify(mockManager).onAdShowedFullScreenContent(eq(1));
     verify(mockManager).onAdImpression(eq(1));
     verify(mockManager).onAdClicked(eq(1));
@@ -248,9 +231,7 @@ public class FlutterRewardedAdTest {
 
   @Test
   public void loadRewardedAdWithAdManagerRequest_nullServerSideOptions() {
-    final FlutterServerSideVerificationOptions options =
-        new FlutterServerSideVerificationOptions(null, null);
-    setupAdManagerMocks(options);
+    setupAdManagerMocks();
 
     final FlutterRewardedAd mockFlutterAd = spy(flutterRewardedAd);
     final RewardedAd mockAd = mock(RewardedAd.class);
@@ -295,22 +276,11 @@ public class FlutterRewardedAdTest {
     verify(mockAd).setFullScreenContentCallback(any(FullScreenContentCallback.class));
     verify(mockAd).show(eq(mockManager.getActivity()), any(OnUserEarnedRewardListener.class));
     verify(mockAd).setOnAdMetadataChangedListener(any(OnAdMetadataChangedListener.class));
-    ArgumentMatcher<ServerSideVerificationOptions> serverSideVerificationOptionsArgumentMatcher =
-        new ArgumentMatcher<ServerSideVerificationOptions>() {
-          @Override
-          public boolean matches(ServerSideVerificationOptions argument) {
-            return argument.getCustomData().isEmpty() && argument.getUserId().isEmpty();
-          }
-        };
-    verify(mockAd)
-        .setServerSideVerificationOptions(
-            ArgumentMatchers.argThat(serverSideVerificationOptionsArgumentMatcher));
   }
 
   @Test
   public void loadRewardedAdFailToShow() {
-    setupAdmobMocks(null);
-
+    setupAdmobMocks();
     final RewardedAd mockRewardedAd = mock(RewardedAd.class);
     doAnswer(
             new Answer() {
@@ -352,7 +322,7 @@ public class FlutterRewardedAdTest {
 
   @Test
   public void loadRewardedAd_setImmersiveMode() {
-    setupAdmobMocks(null);
+    setupAdmobMocks();
 
     final RewardedAd mockRewardedAd = mock(RewardedAd.class);
     doAnswer(
@@ -371,5 +341,33 @@ public class FlutterRewardedAdTest {
     flutterRewardedAd.load();
     flutterRewardedAd.setImmersiveMode(true);
     verify(mockRewardedAd).setImmersiveMode(true);
+  }
+
+  @Test
+  public void setServerSideVerificationOptions() {
+    setupAdManagerMocks();
+    final RewardedAd mockAd = mock(RewardedAd.class);
+    doAnswer(
+            new Answer() {
+              @Override
+              public Object answer(InvocationOnMock invocation) throws Throwable {
+                RewardedAdLoadCallback adLoadCallback = invocation.getArgument(2);
+                // Pass back null for ad
+                adLoadCallback.onAdLoaded(mockAd);
+                return null;
+              }
+            })
+        .when(mockFlutterAdLoader)
+        .loadAdManagerRewarded(
+            anyString(), any(AdManagerAdRequest.class), any(RewardedAdLoadCallback.class));
+
+    flutterRewardedAd.load();
+
+    FlutterServerSideVerificationOptions fltSsv = mock(FlutterServerSideVerificationOptions.class);
+    ServerSideVerificationOptions ssv = mock(ServerSideVerificationOptions.class);
+    doReturn(ssv).when(fltSsv).asServerSideVerificationOptions();
+
+    flutterRewardedAd.setServerSideVerificationOptions(fltSsv);
+    verify(mockAd).setServerSideVerificationOptions(eq(ssv));
   }
 }

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterRewardedInterstitialAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterRewardedInterstitialAdTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
-import androidx.annotation.Nullable;
 import com.google.android.gms.ads.AdError;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.AdValue;
@@ -49,8 +48,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatcher;
-import org.mockito.ArgumentMatchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricTestRunner;
@@ -74,28 +71,28 @@ public class FlutterRewardedInterstitialAdTest {
     mockFlutterAdLoader = mock(FlutterAdLoader.class);
   }
 
-  private void setupAdmobMocks(@Nullable FlutterServerSideVerificationOptions options) {
+  private void setupAdmobMocks() {
     FlutterAdRequest mockFlutterAdRequest = mock(FlutterAdRequest.class);
     mockAdRequest = mock(AdRequest.class);
     when(mockFlutterAdRequest.asAdRequest(anyString())).thenReturn(mockAdRequest);
     flutterRewardedInterstitialAd =
         new FlutterRewardedInterstitialAd(
-            1, mockManager, "testId", mockFlutterAdRequest, options, mockFlutterAdLoader);
+            1, mockManager, "testId", mockFlutterAdRequest, mockFlutterAdLoader);
   }
 
-  private void setupAdManagerMocks(@Nullable FlutterServerSideVerificationOptions options) {
+  private void setupAdManagerMocks() {
     FlutterAdManagerAdRequest mockAdManagerFlutterRequest = mock(FlutterAdManagerAdRequest.class);
     mockAdManagerAdRequest = mock(AdManagerAdRequest.class);
     when(mockAdManagerFlutterRequest.asAdManagerAdRequest(anyString()))
         .thenReturn(mockAdManagerAdRequest);
     flutterRewardedInterstitialAd =
         new FlutterRewardedInterstitialAd(
-            1, mockManager, "testId", mockAdManagerFlutterRequest, options, mockFlutterAdLoader);
+            1, mockManager, "testId", mockAdManagerFlutterRequest, mockFlutterAdLoader);
   }
 
   @Test
   public void loadAdManagerRewardedInterstitialAd_failedToLoad() {
-    setupAdManagerMocks(null);
+    setupAdManagerMocks();
     final LoadAdError loadAdError = mock(LoadAdError.class);
     doReturn(1).when(loadAdError).getCode();
     doReturn("2").when(loadAdError).getDomain();
@@ -131,9 +128,7 @@ public class FlutterRewardedInterstitialAdTest {
 
   @Test
   public void loadAdManagerRewardedInterstitialAd_showSuccessWithReward() {
-    final FlutterServerSideVerificationOptions options =
-        new FlutterServerSideVerificationOptions("userId", "customData");
-    setupAdManagerMocks(options);
+    setupAdManagerMocks();
 
     final RewardedInterstitialAd mockAd = mock(RewardedInterstitialAd.class);
     doAnswer(
@@ -233,17 +228,6 @@ public class FlutterRewardedInterstitialAdTest {
     verify(mockAd).setFullScreenContentCallback(any(FullScreenContentCallback.class));
     verify(mockAd).show(eq(mockManager.getActivity()), any(OnUserEarnedRewardListener.class));
     verify(mockAd).setOnAdMetadataChangedListener(any(OnAdMetadataChangedListener.class));
-    ArgumentMatcher<ServerSideVerificationOptions> serverSideVerificationOptionsArgumentMatcher =
-        new ArgumentMatcher<ServerSideVerificationOptions>() {
-          @Override
-          public boolean matches(ServerSideVerificationOptions argument) {
-            return argument.getCustomData().equals(options.getCustomData())
-                && argument.getUserId().equals(options.getUserId());
-          }
-        };
-    verify(mockAd)
-        .setServerSideVerificationOptions(
-            ArgumentMatchers.argThat(serverSideVerificationOptionsArgumentMatcher));
     verify(mockManager).onAdShowedFullScreenContent(eq(1));
     verify(mockManager).onAdImpression(eq(1));
     verify(mockManager).onAdClicked(eq(1));
@@ -256,9 +240,7 @@ public class FlutterRewardedInterstitialAdTest {
 
   @Test
   public void loadRewardedInterstitialAdWithAdManagerRequest_nullServerSideOptions() {
-    final FlutterServerSideVerificationOptions options =
-        new FlutterServerSideVerificationOptions(null, null);
-    setupAdManagerMocks(options);
+    setupAdManagerMocks();
 
     final FlutterRewardedInterstitialAd mockFlutterAd = spy(flutterRewardedInterstitialAd);
     final RewardedInterstitialAd mockAd = mock(RewardedInterstitialAd.class);
@@ -307,21 +289,11 @@ public class FlutterRewardedInterstitialAdTest {
     verify(mockAd).setFullScreenContentCallback(any(FullScreenContentCallback.class));
     verify(mockAd).show(eq(mockManager.getActivity()), any(OnUserEarnedRewardListener.class));
     verify(mockAd).setOnAdMetadataChangedListener(any(OnAdMetadataChangedListener.class));
-    ArgumentMatcher<ServerSideVerificationOptions> serverSideVerificationOptionsArgumentMatcher =
-        new ArgumentMatcher<ServerSideVerificationOptions>() {
-          @Override
-          public boolean matches(ServerSideVerificationOptions argument) {
-            return argument.getCustomData().isEmpty() && argument.getUserId().isEmpty();
-          }
-        };
-    verify(mockAd)
-        .setServerSideVerificationOptions(
-            ArgumentMatchers.argThat(serverSideVerificationOptionsArgumentMatcher));
   }
 
   @Test
   public void loadRewardedInterstitialAd_failToShow() {
-    setupAdmobMocks(null);
+    setupAdmobMocks();
 
     final RewardedInterstitialAd mockRewardedInterstitialAd = mock(RewardedInterstitialAd.class);
     doAnswer(
@@ -367,7 +339,7 @@ public class FlutterRewardedInterstitialAdTest {
 
   @Test
   public void loadRewardedInterstitialAd_setImmersiveMode() {
-    setupAdmobMocks(null);
+    setupAdmobMocks();
 
     final RewardedInterstitialAd mockRewardedInterstitialAd = mock(RewardedInterstitialAd.class);
     doAnswer(
@@ -387,5 +359,35 @@ public class FlutterRewardedInterstitialAdTest {
     flutterRewardedInterstitialAd.load();
     flutterRewardedInterstitialAd.setImmersiveMode(true);
     verify(mockRewardedInterstitialAd).setImmersiveMode(true);
+  }
+
+  @Test
+  public void setServerSideVerificationOptions() {
+    setupAdManagerMocks();
+    final RewardedInterstitialAd mockAd = mock(RewardedInterstitialAd.class);
+    doAnswer(
+            new Answer() {
+              @Override
+              public Object answer(InvocationOnMock invocation) throws Throwable {
+                RewardedInterstitialAdLoadCallback adLoadCallback = invocation.getArgument(2);
+                // Pass back null for ad
+                adLoadCallback.onAdLoaded(mockAd);
+                return null;
+              }
+            })
+        .when(mockFlutterAdLoader)
+        .loadAdManagerRewardedInterstitial(
+            anyString(),
+            any(AdManagerAdRequest.class),
+            any(RewardedInterstitialAdLoadCallback.class));
+
+    flutterRewardedInterstitialAd.load();
+
+    FlutterServerSideVerificationOptions fltSsv = mock(FlutterServerSideVerificationOptions.class);
+    ServerSideVerificationOptions ssv = mock(ServerSideVerificationOptions.class);
+    doReturn(ssv).when(fltSsv).asServerSideVerificationOptions();
+
+    flutterRewardedInterstitialAd.setServerSideVerificationOptions(fltSsv);
+    verify(mockAd).setServerSideVerificationOptions(eq(ssv));
   }
 }

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
@@ -868,7 +868,7 @@ public class GoogleMobileAdsTest {
   }
 
   @Test
-  public void testAppStateNotifieDetachFromEngine() {
+  public void testAppStateNotifyDetachFromEngine() {
     AppStateNotifier notifier = mock(AppStateNotifier.class);
     GoogleMobileAdsPlugin plugin = new GoogleMobileAdsPlugin(notifier);
     plugin.onDetachedFromEngine(null);

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
@@ -415,7 +415,7 @@ public class GoogleMobileAdsTest {
   public void flutterAdListener_onRewardedAdUserEarnedReward() {
     FlutterAdLoader mockFlutterAdLoader = mock(FlutterAdLoader.class);
     final FlutterRewardedAd ad =
-        new FlutterRewardedAd(0, testManager, "testId", request, null, mockFlutterAdLoader);
+        new FlutterRewardedAd(0, testManager, "testId", request, mockFlutterAdLoader);
     testManager.trackAd(ad, 0);
 
     testManager.onRewardedAdUserEarnedReward(

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import android.app.Activity;
 import android.content.Context;
@@ -873,5 +874,118 @@ public class GoogleMobileAdsTest {
     GoogleMobileAdsPlugin plugin = new GoogleMobileAdsPlugin(notifier);
     plugin.onDetachedFromEngine(null);
     verify(notifier).stop();
+  }
+
+  @Test
+  public void testServerSideVerificationOptions_rewardedAd() {
+    // Setup mocks
+    AdInstanceManager mockManager = mock(AdInstanceManager.class);
+    FlutterMobileAdsWrapper mockMobileAds = mock(FlutterMobileAdsWrapper.class);
+    GoogleMobileAdsPlugin plugin =
+        new GoogleMobileAdsPlugin(mockFlutterPluginBinding, mockManager, mockMobileAds);
+    GoogleMobileAdsPlugin pluginSpy = spy(plugin);
+
+    // Pretend that a rewarded ad has already been loaded with id 1
+    FlutterRewardedAd mockRewardedAd = mock(FlutterRewardedAd.class);
+    doReturn(mockRewardedAd).when(mockManager).adForId(1);
+
+    // Make a ssv method call
+    Map<String, Object> loadArgs = new HashMap<>();
+    loadArgs.put("adId", 1);
+    FlutterServerSideVerificationOptions mockFlutterSsv =
+        mock(FlutterServerSideVerificationOptions.class);
+    loadArgs.put("serverSideVerificationOptions", mockFlutterSsv);
+
+    // Successful call
+    MethodCall methodCall = new MethodCall("setServerSideVerificationOptions", loadArgs);
+    Result result = mock(Result.class);
+    pluginSpy.onMethodCall(methodCall, result);
+
+    verify(mockRewardedAd).setServerSideVerificationOptions(eq(mockFlutterSsv));
+    verify(result).success(null);
+  }
+
+  @Test
+  public void testServerSideVerificationOptions_rewardedInterstitialAd() {
+    // Setup mocks
+    AdInstanceManager mockManager = mock(AdInstanceManager.class);
+    FlutterMobileAdsWrapper mockMobileAds = mock(FlutterMobileAdsWrapper.class);
+    GoogleMobileAdsPlugin plugin =
+        new GoogleMobileAdsPlugin(mockFlutterPluginBinding, mockManager, mockMobileAds);
+    GoogleMobileAdsPlugin pluginSpy = spy(plugin);
+
+    // Pretend that a rewarded interstitial ad has already been loaded with id 1
+    FlutterRewardedInterstitialAd mockAd = mock(FlutterRewardedInterstitialAd.class);
+    doReturn(mockAd).when(mockManager).adForId(1);
+
+    // Make a ssv method call
+    Map<String, Object> loadArgs = new HashMap<>();
+    loadArgs.put("adId", 1);
+    FlutterServerSideVerificationOptions mockFlutterSsv =
+        mock(FlutterServerSideVerificationOptions.class);
+    loadArgs.put("serverSideVerificationOptions", mockFlutterSsv);
+
+    // Successful call
+    MethodCall methodCall = new MethodCall("setServerSideVerificationOptions", loadArgs);
+    Result result = mock(Result.class);
+    pluginSpy.onMethodCall(methodCall, result);
+
+    verify(mockAd).setServerSideVerificationOptions(eq(mockFlutterSsv));
+    verify(result).success(null);
+  }
+
+  @Test
+  public void testServerSideVerificationOptions_invalidAdId() {
+    // Setup mocks
+    AdInstanceManager mockManager = mock(AdInstanceManager.class);
+    FlutterMobileAdsWrapper mockMobileAds = mock(FlutterMobileAdsWrapper.class);
+    GoogleMobileAdsPlugin plugin =
+        new GoogleMobileAdsPlugin(mockFlutterPluginBinding, mockManager, mockMobileAds);
+    GoogleMobileAdsPlugin pluginSpy = spy(plugin);
+
+    // AdId matches a banner ad instead of rewarded or rewarded interstitial
+    FlutterBannerAd mockAd = mock(FlutterBannerAd.class);
+    doReturn(mockAd).when(mockManager).adForId(1);
+
+    // Make a ssv method call without any ads having loaded
+    Map<String, Object> loadArgs = new HashMap<>();
+    loadArgs.put("adId", 1);
+    FlutterServerSideVerificationOptions mockFlutterSsv =
+        mock(FlutterServerSideVerificationOptions.class);
+    loadArgs.put("serverSideVerificationOptions", mockFlutterSsv);
+
+    // Successful call
+    MethodCall methodCall = new MethodCall("setServerSideVerificationOptions", loadArgs);
+    Result result = mock(Result.class);
+    pluginSpy.onMethodCall(methodCall, result);
+
+    // result.success() still invoked, resulting in no-op
+    verifyNoInteractions(mockAd);
+    verify(result).success(null);
+  }
+
+  @Test
+  public void testServerSideVerificationOptions_invalidAdType() {
+    // Setup mocks
+    AdInstanceManager mockManager = mock(AdInstanceManager.class);
+    FlutterMobileAdsWrapper mockMobileAds = mock(FlutterMobileAdsWrapper.class);
+    GoogleMobileAdsPlugin plugin =
+        new GoogleMobileAdsPlugin(mockFlutterPluginBinding, mockManager, mockMobileAds);
+    GoogleMobileAdsPlugin pluginSpy = spy(plugin);
+
+    // Make a ssv method call without any ads having loaded
+    Map<String, Object> loadArgs = new HashMap<>();
+    loadArgs.put("adId", 1);
+    FlutterServerSideVerificationOptions mockFlutterSsv =
+        mock(FlutterServerSideVerificationOptions.class);
+    loadArgs.put("serverSideVerificationOptions", mockFlutterSsv);
+
+    // Successful call
+    MethodCall methodCall = new MethodCall("setServerSideVerificationOptions", loadArgs);
+    Result result = mock(Result.class);
+    pluginSpy.onMethodCall(methodCall, result);
+
+    // result.success() still invoked, resulting in no-op
+    verify(result).success(null);
   }
 }

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
@@ -218,26 +218,22 @@
 @end
 
 @interface FLTRewardedAd : FLTFullScreenAd
-- (instancetype _Nonnull)
-                 initWithAdUnitId:(NSString *_Nonnull)adUnitId
-                          request:(FLTAdRequest *_Nonnull)request
-               rootViewController:(UIViewController *_Nonnull)rootViewController
-    serverSideVerificationOptions:(FLTServerSideVerificationOptions *_Nullable)
-                                      serverSideVerificationOptions
-                             adId:(NSNumber *_Nonnull)adId;
+- (instancetype _Nonnull)initWithAdUnitId:(NSString *_Nonnull)adUnitId
+                                  request:(FLTAdRequest *_Nonnull)request
+                       rootViewController:
+                           (UIViewController *_Nonnull)rootViewController
+                                     adId:(NSNumber *_Nonnull)adId;
 - (GADRewardedAd *_Nullable)rewardedAd;
 - (void)setServerSideVerificationOptions:
     (FLTServerSideVerificationOptions *_Nullable)serverSideVerificationOptions;
 @end
 
 @interface FLTRewardedInterstitialAd : FLTFullScreenAd
-- (instancetype _Nonnull)
-                 initWithAdUnitId:(NSString *_Nonnull)adUnitId
-                          request:(FLTAdRequest *_Nonnull)request
-               rootViewController:(UIViewController *_Nonnull)rootViewController
-    serverSideVerificationOptions:(FLTServerSideVerificationOptions *_Nullable)
-                                      serverSideVerificationOptions
-                             adId:(NSNumber *_Nonnull)adId;
+- (instancetype _Nonnull)initWithAdUnitId:(NSString *_Nonnull)adUnitId
+                                  request:(FLTAdRequest *_Nonnull)request
+                       rootViewController:
+                           (UIViewController *_Nonnull)rootViewController
+                                     adId:(NSNumber *_Nonnull)adId;
 - (GADRewardedInterstitialAd *_Nullable)rewardedInterstitialAd;
 - (void)setServerSideVerificationOptions:
     (FLTServerSideVerificationOptions *_Nullable)serverSideVerificationOptions;

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
@@ -226,6 +226,7 @@
                                       serverSideVerificationOptions
                              adId:(NSNumber *_Nonnull)adId;
 - (GADRewardedAd *_Nullable)rewardedAd;
+- (void)setServerSideVerificationOptions:(FLTServerSideVerificationOptions *_Nullable)serverSideVerificationOptions;
 @end
 
 @interface FLTRewardedInterstitialAd : FLTFullScreenAd
@@ -237,6 +238,7 @@
                                       serverSideVerificationOptions
                              adId:(NSNumber *_Nonnull)adId;
 - (GADRewardedInterstitialAd *_Nullable)rewardedInterstitialAd;
+- (void)setServerSideVerificationOptions:(FLTServerSideVerificationOptions *_Nullable)serverSideVerificationOptions;
 @end
 
 @interface FLTAppOpenAd : FLTFullScreenAd

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
@@ -226,7 +226,8 @@
                                       serverSideVerificationOptions
                              adId:(NSNumber *_Nonnull)adId;
 - (GADRewardedAd *_Nullable)rewardedAd;
-- (void)setServerSideVerificationOptions:(FLTServerSideVerificationOptions *_Nullable)serverSideVerificationOptions;
+- (void)setServerSideVerificationOptions:
+    (FLTServerSideVerificationOptions *_Nullable)serverSideVerificationOptions;
 @end
 
 @interface FLTRewardedInterstitialAd : FLTFullScreenAd
@@ -238,7 +239,8 @@
                                       serverSideVerificationOptions
                              adId:(NSNumber *_Nonnull)adId;
 - (GADRewardedInterstitialAd *_Nullable)rewardedInterstitialAd;
-- (void)setServerSideVerificationOptions:(FLTServerSideVerificationOptions *_Nullable)serverSideVerificationOptions;
+- (void)setServerSideVerificationOptions:
+    (FLTServerSideVerificationOptions *_Nullable)serverSideVerificationOptions;
 @end
 
 @interface FLTAppOpenAd : FLTFullScreenAd

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
@@ -868,6 +868,15 @@
   }
 }
 
+- (void)setServerSideVerificationOptions:(FLTServerSideVerificationOptions *_Nullable)serverSideVerificationOptions {
+  if (_rewardedView) {
+    _rewardedView.serverSideVerificationOptions = [serverSideVerificationOptions asGADServerSideVerificationOptions];
+  } else {
+    NSLog(@"Error - rewardedView is nil in FLTRewardedAd.setServerSideVerificationOptions");
+  }
+}
+
+
 @end
 
 #pragma mark - FLTRewardedInterstitialAd
@@ -964,6 +973,15 @@
   } else {
     NSLog(
         @"RewardedInterstitialAd failed to show because the ad was not ready.");
+  }
+}
+
+- (void)setServerSideVerificationOptions:(FLTServerSideVerificationOptions *_Nullable)serverSideVerificationOptions {
+  if (_rewardedInterstitialView) {
+    _rewardedInterstitialView.serverSideVerificationOptions =
+      [serverSideVerificationOptions asGADServerSideVerificationOptions];
+  } else {
+    NSLog(@"Error - rewardedView is nil in FLTRewardedInterstitialAd.setServerSideVerificationOptions");
   }
 }
 

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
@@ -868,14 +868,16 @@
   }
 }
 
-- (void)setServerSideVerificationOptions:(FLTServerSideVerificationOptions *_Nullable)serverSideVerificationOptions {
+- (void)setServerSideVerificationOptions:
+    (FLTServerSideVerificationOptions *_Nullable)serverSideVerificationOptions {
   if (_rewardedView) {
-    _rewardedView.serverSideVerificationOptions = [serverSideVerificationOptions asGADServerSideVerificationOptions];
+    _rewardedView.serverSideVerificationOptions =
+        [serverSideVerificationOptions asGADServerSideVerificationOptions];
   } else {
-    NSLog(@"Error - rewardedView is nil in FLTRewardedAd.setServerSideVerificationOptions");
+    NSLog(@"Error - rewardedView is nil in "
+          @"FLTRewardedAd.setServerSideVerificationOptions");
   }
 }
-
 
 @end
 
@@ -976,12 +978,14 @@
   }
 }
 
-- (void)setServerSideVerificationOptions:(FLTServerSideVerificationOptions *_Nullable)serverSideVerificationOptions {
+- (void)setServerSideVerificationOptions:
+    (FLTServerSideVerificationOptions *_Nullable)serverSideVerificationOptions {
   if (_rewardedInterstitialView) {
     _rewardedInterstitialView.serverSideVerificationOptions =
-      [serverSideVerificationOptions asGADServerSideVerificationOptions];
+        [serverSideVerificationOptions asGADServerSideVerificationOptions];
   } else {
-    NSLog(@"Error - rewardedView is nil in FLTRewardedInterstitialAd.setServerSideVerificationOptions");
+    NSLog(@"Error - rewardedView is nil in "
+          @"FLTRewardedInterstitialAd.setServerSideVerificationOptions");
   }
 }
 

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
@@ -781,22 +781,18 @@
   GADRewardedAd *_rewardedView;
   FLTAdRequest *_adRequest;
   UIViewController *_rootViewController;
-  FLTServerSideVerificationOptions *_serverSideVerificationOptions;
   NSString *_adUnitId;
 }
 
 - (instancetype)initWithAdUnitId:(NSString *_Nonnull)adUnitId
-                          request:(FLTAdRequest *_Nonnull)request
-               rootViewController:(UIViewController *_Nonnull)rootViewController
-    serverSideVerificationOptions:(FLTServerSideVerificationOptions *_Nullable)
-                                      serverSideVerificationOptions
-                             adId:(NSNumber *_Nonnull)adId {
+                         request:(FLTAdRequest *_Nonnull)request
+              rootViewController:(UIViewController *_Nonnull)rootViewController
+                            adId:(NSNumber *_Nonnull)adId {
   self = [super init];
   if (self) {
     self.adId = adId;
     _adRequest = request;
     _rootViewController = rootViewController;
-    _serverSideVerificationOptions = serverSideVerificationOptions;
     _adUnitId = [adUnitId copy];
   }
   return self;
@@ -818,37 +814,31 @@
     return;
   }
 
-  [GADRewardedAd
-       loadWithAdUnitID:_adUnitId
-                request:request
-      completionHandler:^(GADRewardedAd *_Nullable rewardedAd,
-                          NSError *_Nullable error) {
-        if (error) {
-          [self.manager onAdFailedToLoad:self error:error];
-          return;
-        }
-        if (self->_serverSideVerificationOptions != NULL &&
-            ![self->_serverSideVerificationOptions isEqual:[NSNull null]]) {
-          rewardedAd.serverSideVerificationOptions =
-              [self->_serverSideVerificationOptions
-                      asGADServerSideVerificationOptions];
-        }
-        __weak FLTRewardedAd *weakSelf = self;
-        rewardedAd.paidEventHandler = ^(GADAdValue *_Nonnull value) {
-          if (weakSelf.manager == nil) {
-            return;
-          }
-          [weakSelf.manager
-              onPaidEvent:weakSelf
-                    value:[[FLTAdValue alloc]
-                              initWithValue:value.value
-                                  precision:(NSInteger)value.precision
-                               currencyCode:value.currencyCode]];
-        };
-        rewardedAd.fullScreenContentDelegate = self;
-        self->_rewardedView = rewardedAd;
-        [self.manager onAdLoaded:self responseInfo:rewardedAd.responseInfo];
-      }];
+  [GADRewardedAd loadWithAdUnitID:_adUnitId
+                          request:request
+                completionHandler:^(GADRewardedAd *_Nullable rewardedAd,
+                                    NSError *_Nullable error) {
+                  if (error) {
+                    [self.manager onAdFailedToLoad:self error:error];
+                    return;
+                  }
+                  __weak FLTRewardedAd *weakSelf = self;
+                  rewardedAd.paidEventHandler = ^(GADAdValue *_Nonnull value) {
+                    if (weakSelf.manager == nil) {
+                      return;
+                    }
+                    [weakSelf.manager
+                        onPaidEvent:weakSelf
+                              value:[[FLTAdValue alloc]
+                                        initWithValue:value.value
+                                            precision:(NSInteger)value.precision
+                                         currencyCode:value.currencyCode]];
+                  };
+                  rewardedAd.fullScreenContentDelegate = self;
+                  self->_rewardedView = rewardedAd;
+                  [self.manager onAdLoaded:self
+                              responseInfo:rewardedAd.responseInfo];
+                }];
 }
 
 - (void)show {
@@ -886,22 +876,18 @@
   GADRewardedInterstitialAd *_rewardedInterstitialView;
   FLTAdRequest *_adRequest;
   UIViewController *_rootViewController;
-  FLTServerSideVerificationOptions *_serverSideVerificationOptions;
   NSString *_adUnitId;
 }
 
 - (instancetype)initWithAdUnitId:(NSString *_Nonnull)adUnitId
-                          request:(FLTAdRequest *_Nonnull)request
-               rootViewController:(UIViewController *_Nonnull)rootViewController
-    serverSideVerificationOptions:(FLTServerSideVerificationOptions *_Nullable)
-                                      serverSideVerificationOptions
-                             adId:(NSNumber *_Nonnull)adId {
+                         request:(FLTAdRequest *_Nonnull)request
+              rootViewController:(UIViewController *_Nonnull)rootViewController
+                            adId:(NSNumber *_Nonnull)adId {
   self = [super init];
   if (self) {
     self.adId = adId;
     _adRequest = request;
     _rootViewController = rootViewController;
-    _serverSideVerificationOptions = serverSideVerificationOptions;
     _adUnitId = [adUnitId copy];
   }
   return self;
@@ -932,12 +918,6 @@
         if (error) {
           [self.manager onAdFailedToLoad:self error:error];
           return;
-        }
-        if (self->_serverSideVerificationOptions != NULL &&
-            ![self->_serverSideVerificationOptions isEqual:[NSNull null]]) {
-          rewardedInterstitialAd.serverSideVerificationOptions =
-              [self->_serverSideVerificationOptions
-                      asGADServerSideVerificationOptions];
         }
         __weak FLTRewardedInterstitialAd *weakSelf = self;
         rewardedInterstitialAd.paidEventHandler =

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
@@ -481,7 +481,8 @@
     } else {
       result(FlutterMethodNotImplemented);
     }
-  } else if ([call.method isEqualToString:@"setSSV"]) {
+  } else if ([call.method
+                 isEqualToString:@"setServerSideVerificationOptions"]) {
     id<FLTAd> ad = [_manager adFor:call.arguments[@"adId"]];
     FLTServerSideVerificationOptions *options =
         call.arguments[@"serverSideVerificationOptions"];
@@ -493,7 +494,8 @@
           (FLTRewardedInterstitialAd *)ad;
       [rewardedInterstitialAd setServerSideVerificationOptions:options];
     } else {
-      NSLog(@"Error - setSSV called on missing or invalid ad id: %@",
+      NSLog(@"Error - setServerSideVerificationOptions called on missing or "
+            @"invalid ad id: %@",
             call.arguments[@"adId"]);
     }
     result(nil);

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
@@ -487,15 +487,18 @@
     }
   } else if ([call.method isEqualToString:@"setSSV"]) {
     id<FLTAd> ad = [_manager adFor:call.arguments[@"adId"]];
-    FLTServerSideVerificationOptions* options = call.arguments[@"serverSideVerificationOptions"];
+    FLTServerSideVerificationOptions *options =
+        call.arguments[@"serverSideVerificationOptions"];
     if ([ad isKindOfClass:[FLTRewardedAd class]]) {
       FLTRewardedAd *rewardedAd = (FLTRewardedAd *)ad;
       [rewardedAd setServerSideVerificationOptions:options];
     } else if ([ad isKindOfClass:[FLTRewardedInterstitialAd class]]) {
-      FLTRewardedInterstitialAd *rewardedInterstitialAd = (FLTRewardedInterstitialAd *)ad;
+      FLTRewardedInterstitialAd *rewardedInterstitialAd =
+          (FLTRewardedInterstitialAd *)ad;
       [rewardedInterstitialAd setServerSideVerificationOptions:options];
     } else {
-      NSLog(@"Error - setSSV called on missing or invalid ad id: %@", call.arguments[@"adId"]);
+      NSLog(@"Error - setSSV called on missing or invalid ad id: %@",
+            call.arguments[@"adId"]);
     }
     result(nil);
   } else {

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
@@ -485,6 +485,19 @@
     } else {
       result(FlutterMethodNotImplemented);
     }
+  } else if ([call.method isEqualToString:@"setSSV"]) {
+    id<FLTAd> ad = [_manager adFor:call.arguments[@"adId"]];
+    FLTServerSideVerificationOptions* options = call.arguments[@"serverSideVerificationOptions"];
+    if ([ad isKindOfClass:[FLTRewardedAd class]]) {
+      FLTRewardedAd *rewardedAd = (FLTRewardedAd *)ad;
+      [rewardedAd setServerSideVerificationOptions:options];
+    } else if ([ad isKindOfClass:[FLTRewardedInterstitialAd class]]) {
+      FLTRewardedInterstitialAd *rewardedInterstitialAd = (FLTRewardedInterstitialAd *)ad;
+      [rewardedInterstitialAd setServerSideVerificationOptions:options];
+    } else {
+      NSLog(@"Error - setSSV called on missing or invalid ad id: %@", call.arguments[@"adId"]);
+    }
+    result(nil);
   } else {
     result(FlutterMethodNotImplemented);
   }

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
@@ -407,8 +407,6 @@
         [[FLTRewardedAd alloc] initWithAdUnitId:call.arguments[@"adUnitId"]
                                         request:request
                              rootViewController:rootController
-                  serverSideVerificationOptions:
-                      call.arguments[@"serverSideVerificationOptions"]
                                            adId:call.arguments[@"adId"]];
     [_manager loadAd:ad];
     result(nil);
@@ -427,12 +425,10 @@
     }
 
     FLTRewardedInterstitialAd *ad = [[FLTRewardedInterstitialAd alloc]
-                     initWithAdUnitId:call.arguments[@"adUnitId"]
-                              request:request
-                   rootViewController:rootController
-        serverSideVerificationOptions:call.arguments
-                                          [@"serverSideVerificationOptions"]
-                                 adId:call.arguments[@"adId"]];
+          initWithAdUnitId:call.arguments[@"adUnitId"]
+                   request:request
+        rootViewController:rootController
+                      adId:call.arguments[@"adId"]];
     [_manager loadAd:ad];
     result(nil);
   } else if ([call.method isEqualToString:@"loadAppOpenAd"]) {

--- a/packages/google_mobile_ads/ios/Classes/UserMessagingPlatform/FLTUserMessagingPlatformManager.m
+++ b/packages/google_mobile_ads/ios/Classes/UserMessagingPlatform/FLTUserMessagingPlatformManager.m
@@ -14,7 +14,7 @@
 
 #import "FLTUserMessagingPlatformManager.h"
 #import "../FLTAdUtil.h"
-#import "FLTNSString.h"
+#import "../FLTNSString.h"
 #import "FLTUserMessagingPlatformReaderWriter.h"
 #include <UserMessagingPlatform/UserMessagingPlatform.h>
 

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
@@ -561,4 +561,111 @@
   XCTAssertEqualObjects(returnedGetAdSizeResult.width, @1);
   XCTAssertEqualObjects(returnedGetAdSizeResult.height, @2);
 }
+
+- (void)testServerSideVerificationOptions_rewardedAd {
+  // Mock having already loaded an ad
+  FLTRewardedAd *mockAd = OCMClassMock([FLTRewardedAd class]);
+  OCMStub([_mockAdInstanceManager adFor:[OCMArg isEqual:@1]]).andReturn(mockAd);
+
+  // Method calls to set ssv
+  FLTServerSideVerificationOptions *mockSsv =
+      OCMClassMock([FLTServerSideVerificationOptions class]);
+  FlutterMethodCall *methodCall = [FlutterMethodCall
+      methodCallWithMethodName:@"setServerSideVerificationOptions"
+                     arguments:@{
+                       @"adId" : @(1),
+                       @"adUnitId" : @"ad-unit-id",
+                       @"serverSideVerificationOptions" : mockSsv,
+                     }];
+
+  __block bool resultInvoked = false;
+  FlutterResult result = ^(id _Nullable result) {
+    resultInvoked = true;
+  };
+
+  [_fltGoogleMobileAdsPlugin handleMethodCall:methodCall result:result];
+
+  XCTAssertTrue(resultInvoked);
+  OCMVerify([mockAd setServerSideVerificationOptions:[OCMArg isEqual:mockSsv]]);
+}
+
+- (void)testServerSideVerificationOptions_rewardedInterstitialAd {
+  // Mock having already loaded an ad
+  FLTRewardedInterstitialAd *mockAd =
+      OCMClassMock([FLTRewardedInterstitialAd class]);
+  OCMStub([_mockAdInstanceManager adFor:[OCMArg isEqual:@1]]).andReturn(mockAd);
+
+  // Method calls to set ssv
+  FLTServerSideVerificationOptions *mockSsv =
+      OCMClassMock([FLTServerSideVerificationOptions class]);
+  FlutterMethodCall *methodCall = [FlutterMethodCall
+      methodCallWithMethodName:@"setServerSideVerificationOptions"
+                     arguments:@{
+                       @"adId" : @(1),
+                       @"adUnitId" : @"ad-unit-id",
+                       @"serverSideVerificationOptions" : mockSsv,
+                     }];
+
+  __block bool resultInvoked = false;
+  FlutterResult result = ^(id _Nullable result) {
+    resultInvoked = true;
+  };
+
+  [_fltGoogleMobileAdsPlugin handleMethodCall:methodCall result:result];
+
+  XCTAssertTrue(resultInvoked);
+  OCMVerify([mockAd setServerSideVerificationOptions:[OCMArg isEqual:mockSsv]]);
+}
+
+- (void)testServerSideVerificationOptions_nullAd {
+  // Try to set ssv without any ads being loaded
+  FLTServerSideVerificationOptions *mockSsv =
+      OCMClassMock([FLTServerSideVerificationOptions class]);
+  FlutterMethodCall *methodCall = [FlutterMethodCall
+      methodCallWithMethodName:@"setServerSideVerificationOptions"
+                     arguments:@{
+                       @"adId" : @(1),
+                       @"adUnitId" : @"ad-unit-id",
+                       @"serverSideVerificationOptions" : mockSsv,
+                     }];
+
+  __block bool resultInvoked = false;
+  FlutterResult result = ^(id _Nullable result) {
+    resultInvoked = true;
+  };
+
+  [_fltGoogleMobileAdsPlugin handleMethodCall:methodCall result:result];
+
+  // Result still invoked - no op
+  XCTAssertTrue(resultInvoked);
+}
+
+- (void)testServerSideVerificationOptions_invalidAdType {
+  // Mock having already loaded an ad that does not support ssv
+  // Strict mock will fail if there are any interactions
+  FLTBannerAd *mockAd = OCMStrictClassMock([FLTBannerAd class]);
+  OCMStub([_mockAdInstanceManager adFor:[OCMArg isEqual:@1]]).andReturn(mockAd);
+
+  // Try to set ssv without any ads being loaded
+  FLTServerSideVerificationOptions *mockSsv =
+      OCMClassMock([FLTServerSideVerificationOptions class]);
+  FlutterMethodCall *methodCall = [FlutterMethodCall
+      methodCallWithMethodName:@"setServerSideVerificationOptions"
+                     arguments:@{
+                       @"adId" : @(1),
+                       @"adUnitId" : @"ad-unit-id",
+                       @"serverSideVerificationOptions" : mockSsv,
+                     }];
+
+  __block bool resultInvoked = false;
+  FlutterResult result = ^(id _Nullable result) {
+    resultInvoked = true;
+  };
+
+  [_fltGoogleMobileAdsPlugin handleMethodCall:methodCall result:result];
+
+  // Result still invoked - no op
+  XCTAssertTrue(resultInvoked);
+}
+
 @end

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsPluginMethodCallsTest.m
@@ -64,18 +64,12 @@
 - (void)testLoadRewardedAd {
   FLTAdRequest *request = [[FLTAdRequest alloc] init];
   request.keywords = @[ @"apple" ];
-  FLTServerSideVerificationOptions *serverSideVerificationOptions =
-      [[FLTServerSideVerificationOptions alloc] init];
-  serverSideVerificationOptions.customRewardString = @"reward";
-  serverSideVerificationOptions.userIdentifier = @"user-id";
   FlutterMethodCall *methodCall =
       [FlutterMethodCall methodCallWithMethodName:@"loadRewardedAd"
                                         arguments:@{
                                           @"adId" : @2,
                                           @"adUnitId" : @"testId",
                                           @"request" : request,
-                                          @"serverSideVerificationOptions" :
-                                              serverSideVerificationOptions
                                         }];
 
   __block bool resultInvoked = false;
@@ -92,11 +86,8 @@
   BOOL (^verificationBlock)(FLTRewardedAd *) = ^BOOL(FLTRewardedAd *ad) {
     FLTAdRequest *adRequest = [ad valueForKey:@"_adRequest"];
     NSString *adUnit = [ad valueForKey:@"_adUnitId"];
-    FLTServerSideVerificationOptions *options =
-        [ad valueForKey:@"_serverSideVerificationOptions"];
     XCTAssertEqualObjects(adRequest, request);
     XCTAssertEqualObjects(adUnit, @"testId");
-    XCTAssertEqualObjects(options, serverSideVerificationOptions);
     return YES;
   };
   OCMVerify([_mockAdInstanceManager

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsTest.m
@@ -246,11 +246,10 @@ static NSString *channel = @"plugins.flutter.io/google_mobile_ads";
 
 - (void)testAdInstanceManagerOnRewardedAdUserEarnedReward {
   FLTRewardedAd *ad = [[FLTRewardedAd alloc]
-                   initWithAdUnitId:@"testId"
-                            request:[[FLTAdRequest alloc] init]
-                 rootViewController:OCMClassMock([UIViewController class])
-      serverSideVerificationOptions:nil
-                               adId:@1];
+        initWithAdUnitId:@"testId"
+                 request:[[FLTAdRequest alloc] init]
+      rootViewController:OCMClassMock([UIViewController class])
+                    adId:@1];
   [_manager loadAd:ad];
 
   [_manager onRewardedAdUserEarnedReward:ad
@@ -274,11 +273,10 @@ static NSString *channel = @"plugins.flutter.io/google_mobile_ads";
 
 - (void)testAdInstanceManagerOnRewardedInterstitialAdUserEarnedReward {
   FLTRewardedInterstitialAd *ad = [[FLTRewardedInterstitialAd alloc]
-                   initWithAdUnitId:@"testId"
-                            request:[[FLTAdRequest alloc] init]
-                 rootViewController:OCMClassMock([UIViewController class])
-      serverSideVerificationOptions:nil
-                               adId:@1];
+        initWithAdUnitId:@"testId"
+                 request:[[FLTAdRequest alloc] init]
+      rootViewController:OCMClassMock([UIViewController class])
+                    adId:@1];
   [_manager loadAd:ad];
 
   [_manager
@@ -367,11 +365,10 @@ static NSString *channel = @"plugins.flutter.io/google_mobile_ads";
 
 - (void)testFullScreenEventsRewardedAd {
   FLTRewardedAd *rewardedAd = [[FLTRewardedAd alloc]
-                   initWithAdUnitId:@"testId"
-                            request:[[FLTAdRequest alloc] init]
-                 rootViewController:OCMClassMock([UIViewController class])
-      serverSideVerificationOptions:nil
-                               adId:@1];
+        initWithAdUnitId:@"testId"
+                 request:[[FLTAdRequest alloc] init]
+      rootViewController:OCMClassMock([UIViewController class])
+                    adId:@1];
   [_manager loadAd:rewardedAd];
 
   [_manager adWillPresentFullScreenContent:rewardedAd];
@@ -398,11 +395,10 @@ static NSString *channel = @"plugins.flutter.io/google_mobile_ads";
 - (void)testFullScreenEventsRewardedInterstitialAd {
   FLTRewardedInterstitialAd *rewardedInterstitialAd =
       [[FLTRewardedInterstitialAd alloc]
-                       initWithAdUnitId:@"testId"
-                                request:[[FLTAdRequest alloc] init]
-                     rootViewController:OCMClassMock([UIViewController class])
-          serverSideVerificationOptions:nil
-                                   adId:@1];
+            initWithAdUnitId:@"testId"
+                     request:[[FLTAdRequest alloc] init]
+          rootViewController:OCMClassMock([UIViewController class])
+                        adId:@1];
   [_manager loadAd:rewardedInterstitialAd];
 
   [_manager adWillPresentFullScreenContent:rewardedInterstitialAd];
@@ -463,11 +459,10 @@ static NSString *channel = @"plugins.flutter.io/google_mobile_ads";
 - (void)testAdClick {
   FLTRewardedInterstitialAd *rewardedInterstitialAd =
       [[FLTRewardedInterstitialAd alloc]
-                       initWithAdUnitId:@"testId"
-                                request:[[FLTAdRequest alloc] init]
-                     rootViewController:OCMClassMock([UIViewController class])
-          serverSideVerificationOptions:nil
-                                   adId:@1];
+            initWithAdUnitId:@"testId"
+                     request:[[FLTAdRequest alloc] init]
+          rootViewController:OCMClassMock([UIViewController class])
+                        adId:@1];
 
   [_manager adDidRecordClick:rewardedInterstitialAd];
   NSData *impressionData = [self getDataForEvent:@"adDidRecordClick" adId:@1];

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -1241,6 +1241,11 @@ class RewardedAd extends AdWithoutView {
     onUserEarnedRewardCallback = onUserEarnedReward;
     return instanceManager.showAdWithoutView(this);
   }
+
+  /// Set [ServerSideVerificationOptions] for the ad.
+  Future<void> setServerSideOptions(ServerSideVerificationOptions options) {
+    return instanceManager.setServerSideVerificationOptions(options, this);
+  }
 }
 
 /// Rewarded interstitials are full screen ads that reward users and can be
@@ -1337,6 +1342,11 @@ class RewardedInterstitialAd extends AdWithoutView {
   Future<void> show({required OnUserEarnedRewardCallback onUserEarnedReward}) {
     onUserEarnedRewardCallback = onUserEarnedReward;
     return instanceManager.showAdWithoutView(this);
+  }
+
+  /// Set [ServerSideVerificationOptions] for the ad.
+  Future<void> setServerSideOptions(ServerSideVerificationOptions options) {
+    return instanceManager.setServerSideVerificationOptions(options, this);
   }
 }
 

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -1158,7 +1158,6 @@ class RewardedAd extends AdWithoutView {
     required String adUnitId,
     required this.rewardedAdLoadCallback,
     required this.request,
-    this.serverSideVerificationOptions,
   })  : adManagerRequest = null,
         super(adUnitId: adUnitId);
 
@@ -1169,7 +1168,6 @@ class RewardedAd extends AdWithoutView {
     required String adUnitId,
     required this.rewardedAdLoadCallback,
     required this.adManagerRequest,
-    this.serverSideVerificationOptions,
   })  : request = null,
         super(adUnitId: adUnitId);
 
@@ -1191,9 +1189,6 @@ class RewardedAd extends AdWithoutView {
       ? 'ca-app-pub-3940256099942544/5224354917'
       : 'ca-app-pub-3940256099942544/1712485313';
 
-  /// Optional [ServerSideVerificationOptions].
-  ServerSideVerificationOptions? serverSideVerificationOptions;
-
   /// Callbacks to be invoked when ads show and dismiss full screen content.
   FullScreenContentCallback<RewardedAd>? fullScreenContentCallback;
 
@@ -1205,13 +1200,11 @@ class RewardedAd extends AdWithoutView {
     required String adUnitId,
     required AdRequest request,
     required RewardedAdLoadCallback rewardedAdLoadCallback,
-    ServerSideVerificationOptions? serverSideVerificationOptions,
   }) async {
     RewardedAd rewardedAd = RewardedAd._(
         adUnitId: adUnitId,
         request: request,
-        rewardedAdLoadCallback: rewardedAdLoadCallback,
-        serverSideVerificationOptions: serverSideVerificationOptions);
+        rewardedAdLoadCallback: rewardedAdLoadCallback);
 
     await instanceManager.loadRewardedAd(rewardedAd);
   }
@@ -1221,13 +1214,11 @@ class RewardedAd extends AdWithoutView {
     required String adUnitId,
     required AdManagerAdRequest adManagerRequest,
     required RewardedAdLoadCallback rewardedAdLoadCallback,
-    ServerSideVerificationOptions? serverSideVerificationOptions,
   }) async {
     RewardedAd rewardedAd = RewardedAd._fromAdManagerRequest(
         adUnitId: adUnitId,
         adManagerRequest: adManagerRequest,
-        rewardedAdLoadCallback: rewardedAdLoadCallback,
-        serverSideVerificationOptions: serverSideVerificationOptions);
+        rewardedAdLoadCallback: rewardedAdLoadCallback);
 
     await instanceManager.loadRewardedAd(rewardedAd);
   }
@@ -1265,7 +1256,6 @@ class RewardedInterstitialAd extends AdWithoutView {
     required String adUnitId,
     required this.rewardedInterstitialAdLoadCallback,
     required this.request,
-    this.serverSideVerificationOptions,
   })  : adManagerRequest = null,
         super(adUnitId: adUnitId);
 
@@ -1276,7 +1266,6 @@ class RewardedInterstitialAd extends AdWithoutView {
     required String adUnitId,
     required this.rewardedInterstitialAdLoadCallback,
     required this.adManagerRequest,
-    this.serverSideVerificationOptions,
   })  : request = null,
         super(adUnitId: adUnitId);
 
@@ -1288,9 +1277,6 @@ class RewardedInterstitialAd extends AdWithoutView {
 
   /// Callbacks for events that occur when attempting to load an ad.
   final RewardedInterstitialAdLoadCallback rewardedInterstitialAdLoadCallback;
-
-  /// Optional [ServerSideVerificationOptions].
-  ServerSideVerificationOptions? serverSideVerificationOptions;
 
   /// Callbacks to be invoked when ads show and dismiss full screen content.
   FullScreenContentCallback<RewardedInterstitialAd>? fullScreenContentCallback;
@@ -1304,13 +1290,11 @@ class RewardedInterstitialAd extends AdWithoutView {
     required AdRequest request,
     required RewardedInterstitialAdLoadCallback
         rewardedInterstitialAdLoadCallback,
-    ServerSideVerificationOptions? serverSideVerificationOptions,
   }) async {
     RewardedInterstitialAd rewardedInterstitialAd = RewardedInterstitialAd._(
         adUnitId: adUnitId,
         request: request,
-        rewardedInterstitialAdLoadCallback: rewardedInterstitialAdLoadCallback,
-        serverSideVerificationOptions: serverSideVerificationOptions);
+        rewardedInterstitialAdLoadCallback: rewardedInterstitialAdLoadCallback);
 
     await instanceManager.loadRewardedInterstitialAd(rewardedInterstitialAd);
   }
@@ -1321,15 +1305,13 @@ class RewardedInterstitialAd extends AdWithoutView {
     required AdManagerAdRequest adManagerRequest,
     required RewardedInterstitialAdLoadCallback
         rewardedInterstitialAdLoadCallback,
-    ServerSideVerificationOptions? serverSideVerificationOptions,
   }) async {
     RewardedInterstitialAd rewardedInterstitialAd =
         RewardedInterstitialAd._fromAdManagerRequest(
             adUnitId: adUnitId,
             adManagerRequest: adManagerRequest,
             rewardedInterstitialAdLoadCallback:
-                rewardedInterstitialAdLoadCallback,
-            serverSideVerificationOptions: serverSideVerificationOptions);
+                rewardedInterstitialAdLoadCallback);
 
     await instanceManager.loadRewardedInterstitialAd(rewardedInterstitialAd);
   }

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -769,7 +769,7 @@ class AdInstanceManager {
       'setServerSideVerificationOptions',
       <dynamic, dynamic>{
         'adId': adIdFor(ad),
-        'options': options,
+        'serverSideVerificationOptions': options,
       },
     );
   }

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -762,6 +762,19 @@ class AdInstanceManager {
         .invokeMethod<String>('MobileAds#getVersionString'))!;
   }
 
+  /// Set server side verification options on the ad.
+  Future<void> setServerSideVerificationOptions(
+      ServerSideVerificationOptions options,
+      Ad ad,) {
+    return channel.invokeMethod<void>(
+      'setSSV',
+      <dynamic, dynamic>{
+        'adId': adIdFor(ad),
+        'options': options,
+      },
+    );
+  }
+
   /// Opens the debug menu.
   ///
   /// Returns a Future that completes when the platform side api has been

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -762,8 +762,9 @@ class AdInstanceManager {
 
   /// Set server side verification options on the ad.
   Future<void> setServerSideVerificationOptions(
-      ServerSideVerificationOptions options,
-      Ad ad,) {
+    ServerSideVerificationOptions options,
+    Ad ad,
+  ) {
     return channel.invokeMethod<void>(
       'setSSV',
       <dynamic, dynamic>{

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -536,7 +536,6 @@ class AdInstanceManager {
         'adUnitId': ad.adUnitId,
         'request': ad.request,
         'adManagerRequest': ad.adManagerRequest,
-        'serverSideVerificationOptions': ad.serverSideVerificationOptions,
       },
     );
   }
@@ -558,7 +557,6 @@ class AdInstanceManager {
         'adUnitId': ad.adUnitId,
         'request': ad.request,
         'adManagerRequest': ad.adManagerRequest,
-        'serverSideVerificationOptions': ad.serverSideVerificationOptions,
       },
     );
   }

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -766,7 +766,7 @@ class AdInstanceManager {
     Ad ad,
   ) {
     return channel.invokeMethod<void>(
-      'setSSV',
+      'setServerSideVerificationOptions',
       <dynamic, dynamic>{
         'adId': adIdFor(ad),
         'options': options,

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -49,6 +49,7 @@ void main() {
           case 'loadInterstitialAd':
           case 'loadAdManagerInterstitialAd':
           case 'loadAdManagerBannerAd':
+          case 'setServerSideVerificationOptions':
             return Future<void>.value();
           case 'getAdSize':
             return Future<dynamic>.value(AdSize.banner);
@@ -102,7 +103,7 @@ void main() {
       ]);
     });
 
-    test('load rewarded ad and set immersive mode', () async {
+    test('load rewarded ad and set immersive mode and ssv', () async {
       RewardedAd? rewarded;
       AdRequest request = AdRequest();
       await RewardedAd.load(
@@ -130,11 +131,21 @@ void main() {
       expect(instanceManager.adFor(0), isNotNull);
       expect(rewarded, createdAd);
 
+      // Set immersive mode
       log.clear();
       await createdAd.setImmersiveMode(true);
       expect(log, <Matcher>[
         isMethodCall('setImmersiveMode',
             arguments: {'adId': 0, 'immersiveModeEnabled': true})
+      ]);
+
+      // Set ssv
+      log.clear();
+      final ssv = ServerSideVerificationOptions();
+      await createdAd.setServerSideOptions(ssv);
+      expect(log, <Matcher>[
+        isMethodCall('setServerSideVerificationOptions',
+            arguments: {'adId': 0, 'serverSideVerificationOptions': ssv})
       ]);
     });
 

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -113,10 +113,7 @@ void main() {
                 rewarded = ad;
               },
               onAdFailedToLoad: (error) => null),
-          serverSideVerificationOptions: ServerSideVerificationOptions(
-            userId: 'test-user-id',
-            customData: 'test-custom-data',
-          ));
+      );
 
       RewardedAd createdAd = instanceManager.adFor(0) as RewardedAd;
       (createdAd).rewardedAdLoadCallback.onAdLoaded(createdAd);
@@ -127,8 +124,6 @@ void main() {
           'adUnitId': 'test-ad-unit',
           'request': request,
           'adManagerRequest': null,
-          'serverSideVerificationOptions':
-              rewarded!.serverSideVerificationOptions,
         }),
       ]);
 
@@ -494,11 +489,7 @@ void main() {
               onAdLoaded: (ad) {
                 rewarded = ad;
               },
-              onAdFailedToLoad: (error) => null),
-          serverSideVerificationOptions: ServerSideVerificationOptions(
-            userId: 'test-user-id',
-            customData: 'test-custom-data',
-          ));
+              onAdFailedToLoad: (error) => null),);
 
       RewardedAd createdAd = instanceManager.adFor(0) as RewardedAd;
       (createdAd).rewardedAdLoadCallback.onAdLoaded(createdAd);
@@ -509,8 +500,6 @@ void main() {
           'adUnitId': 'test-ad-unit',
           'request': request,
           'adManagerRequest': null,
-          'serverSideVerificationOptions':
-              rewarded!.serverSideVerificationOptions,
         }),
       ]);
 
@@ -537,10 +526,7 @@ void main() {
                 rewarded = ad;
               },
               onAdFailedToLoad: (error) => null),
-          serverSideVerificationOptions: ServerSideVerificationOptions(
-            userId: 'test-user-id',
-            customData: 'test-custom-data',
-          ));
+      );
 
       RewardedAd createdAd = instanceManager.adFor(0) as RewardedAd;
       (createdAd).rewardedAdLoadCallback.onAdLoaded(createdAd);
@@ -551,8 +537,6 @@ void main() {
           'adUnitId': 'test-ad-unit',
           'request': null,
           'adManagerRequest': request,
-          'serverSideVerificationOptions':
-              rewarded!.serverSideVerificationOptions,
         }),
       ]);
 
@@ -803,7 +787,6 @@ void main() {
           'adUnitId': 'test-ad-unit',
           'request': request,
           'adManagerRequest': null,
-          'serverSideVerificationOptions': null,
         })
       ]);
 
@@ -902,11 +885,7 @@ void main() {
               onAdLoaded: (ad) {
                 rewarded = ad;
               },
-              onAdFailedToLoad: (error) => null),
-          serverSideVerificationOptions: ServerSideVerificationOptions(
-            userId: 'test-user-id',
-            customData: 'test-custom-data',
-          ));
+              onAdFailedToLoad: (error) => null));
 
       RewardedAd createdAd = instanceManager.adFor(0) as RewardedAd;
       createdAd.rewardedAdLoadCallback.onAdLoaded(createdAd);
@@ -1373,11 +1352,7 @@ void main() {
                   ad.fullScreenContentCallback = FullScreenContentCallback(
                       onAdClicked: (ad) => adClickCompleter.complete(ad));
                 },
-                onAdFailedToLoad: (error) => null),
-            serverSideVerificationOptions: ServerSideVerificationOptions(
-              userId: 'test-user-id',
-              customData: 'test-custom-data',
-            ));
+                onAdFailedToLoad: (error) => null));
 
         MethodCall methodCall = MethodCall('onAdEvent', <dynamic, dynamic>{
           'adId': adId,

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -106,13 +106,13 @@ void main() {
       RewardedAd? rewarded;
       AdRequest request = AdRequest();
       await RewardedAd.load(
-          adUnitId: 'test-ad-unit',
-          request: request,
-          rewardedAdLoadCallback: RewardedAdLoadCallback(
-              onAdLoaded: (ad) {
-                rewarded = ad;
-              },
-              onAdFailedToLoad: (error) => null),
+        adUnitId: 'test-ad-unit',
+        request: request,
+        rewardedAdLoadCallback: RewardedAdLoadCallback(
+            onAdLoaded: (ad) {
+              rewarded = ad;
+            },
+            onAdFailedToLoad: (error) => null),
       );
 
       RewardedAd createdAd = instanceManager.adFor(0) as RewardedAd;
@@ -483,13 +483,14 @@ void main() {
       RewardedAd? rewarded;
       AdRequest request = AdRequest();
       await RewardedAd.load(
-          adUnitId: 'test-ad-unit',
-          request: request,
-          rewardedAdLoadCallback: RewardedAdLoadCallback(
-              onAdLoaded: (ad) {
-                rewarded = ad;
-              },
-              onAdFailedToLoad: (error) => null),);
+        adUnitId: 'test-ad-unit',
+        request: request,
+        rewardedAdLoadCallback: RewardedAdLoadCallback(
+            onAdLoaded: (ad) {
+              rewarded = ad;
+            },
+            onAdFailedToLoad: (error) => null),
+      );
 
       RewardedAd createdAd = instanceManager.adFor(0) as RewardedAd;
       (createdAd).rewardedAdLoadCallback.onAdLoaded(createdAd);
@@ -519,13 +520,13 @@ void main() {
       RewardedAd? rewarded;
       AdManagerAdRequest request = AdManagerAdRequest();
       await RewardedAd.loadWithAdManagerAdRequest(
-          adUnitId: 'test-ad-unit',
-          adManagerRequest: request,
-          rewardedAdLoadCallback: RewardedAdLoadCallback(
-              onAdLoaded: (ad) {
-                rewarded = ad;
-              },
-              onAdFailedToLoad: (error) => null),
+        adUnitId: 'test-ad-unit',
+        adManagerRequest: request,
+        rewardedAdLoadCallback: RewardedAdLoadCallback(
+            onAdLoaded: (ad) {
+              rewarded = ad;
+            },
+            onAdFailedToLoad: (error) => null),
       );
 
       RewardedAd createdAd = instanceManager.adFor(0) as RewardedAd;

--- a/packages/google_mobile_ads/test/rewarded_interstitial_ad_test.dart
+++ b/packages/google_mobile_ads/test/rewarded_interstitial_ad_test.dart
@@ -39,6 +39,7 @@ void main() {
           case 'loadRewardedInterstitialAd':
           case 'showAdWithoutView':
           case 'disposeAd':
+          case 'setSSV':
             return Future<void>.value();
           default:
             assert(false);
@@ -52,14 +53,13 @@ void main() {
       RewardedInterstitialAd? rewardedInterstitial;
       AdRequest request = AdRequest();
       await RewardedInterstitialAd.load(
-          adUnitId: 'test-ad-unit',
-          request: request,
-          rewardedInterstitialAdLoadCallback:
-              RewardedInterstitialAdLoadCallback(
-                  onAdLoaded: (ad) {
-                    rewardedInterstitial = ad;
-                  },
-                  onAdFailedToLoad: (error) => null),
+        adUnitId: 'test-ad-unit',
+        request: request,
+        rewardedInterstitialAdLoadCallback: RewardedInterstitialAdLoadCallback(
+            onAdLoaded: (ad) {
+              rewardedInterstitial = ad;
+            },
+            onAdFailedToLoad: (error) => null),
       );
 
       RewardedInterstitialAd createdAd =
@@ -152,14 +152,13 @@ void main() {
       RewardedInterstitialAd? rewardedInterstitial;
       AdRequest request = AdRequest();
       await RewardedInterstitialAd.load(
-          adUnitId: 'test-ad-unit',
-          request: request,
-          rewardedInterstitialAdLoadCallback:
-              RewardedInterstitialAdLoadCallback(
-                  onAdLoaded: (ad) {
-                    rewardedInterstitial = ad;
-                  },
-                  onAdFailedToLoad: (error) => null),
+        adUnitId: 'test-ad-unit',
+        request: request,
+        rewardedInterstitialAdLoadCallback: RewardedInterstitialAdLoadCallback(
+            onAdLoaded: (ad) {
+              rewardedInterstitial = ad;
+            },
+            onAdFailedToLoad: (error) => null),
       );
 
       RewardedInterstitialAd createdAd =
@@ -262,14 +261,13 @@ void main() {
       RewardedInterstitialAd? rewardedInterstitial;
       AdManagerAdRequest request = AdManagerAdRequest();
       await RewardedInterstitialAd.loadWithAdManagerAdRequest(
-          adUnitId: 'test-ad-unit',
-          adManagerRequest: request,
-          rewardedInterstitialAdLoadCallback:
-              RewardedInterstitialAdLoadCallback(
-                  onAdLoaded: (ad) {
-                    rewardedInterstitial = ad;
-                  },
-                  onAdFailedToLoad: (error) => null),
+        adUnitId: 'test-ad-unit',
+        adManagerRequest: request,
+        rewardedInterstitialAdLoadCallback: RewardedInterstitialAdLoadCallback(
+            onAdLoaded: (ad) {
+              rewardedInterstitial = ad;
+            },
+            onAdFailedToLoad: (error) => null),
       );
 
       RewardedInterstitialAd createdAd =
@@ -378,14 +376,13 @@ void main() {
 
       RewardedInterstitialAd? rewardedInterstitial;
       await RewardedInterstitialAd.load(
-          adUnitId: 'test-ad-unit',
-          request: AdRequest(),
-          rewardedInterstitialAdLoadCallback:
-              RewardedInterstitialAdLoadCallback(
-                  onAdLoaded: (ad) {
-                    rewardedInterstitial = ad;
-                  },
-                  onAdFailedToLoad: (error) => null),
+        adUnitId: 'test-ad-unit',
+        request: AdRequest(),
+        rewardedInterstitialAdLoadCallback: RewardedInterstitialAdLoadCallback(
+            onAdLoaded: (ad) {
+              rewardedInterstitial = ad;
+            },
+            onAdFailedToLoad: (error) => null),
       );
 
       RewardedInterstitialAd createdAd =
@@ -415,6 +412,34 @@ void main() {
       expect(result[0], rewardedInterstitial!);
       expect(result[1].amount, 1);
       expect(result[1].type, 'one');
+    });
+
+    test('setServerSideVerificationOptions', () async {
+      final adLoadCompleter = Completer<RewardedInterstitialAd>();
+      await RewardedInterstitialAd.load(
+        adUnitId: 'test-ad-unit',
+        request: AdRequest(),
+        rewardedInterstitialAdLoadCallback: RewardedInterstitialAdLoadCallback(
+            onAdLoaded: (ad) {
+              adLoadCompleter.complete(ad);
+            },
+            onAdFailedToLoad: (_) => null),
+      );
+
+      await TestUtil.sendAdEvent(0, 'onAdLoaded', instanceManager);
+      expect(adLoadCompleter.isCompleted, true);
+      final ad = await adLoadCompleter.future;
+
+      log.clear();
+      final ssv =
+          ServerSideVerificationOptions(userId: 'id', customData: 'data');
+      await ad.setServerSideOptions(ssv);
+      expect(log, <Matcher>[
+        isMethodCall('setSSV', arguments: <dynamic, dynamic>{
+          'adId': 0,
+          'options': ssv,
+        }),
+      ]);
     });
   });
 }

--- a/packages/google_mobile_ads/test/rewarded_interstitial_ad_test.dart
+++ b/packages/google_mobile_ads/test/rewarded_interstitial_ad_test.dart
@@ -60,10 +60,7 @@ void main() {
                     rewardedInterstitial = ad;
                   },
                   onAdFailedToLoad: (error) => null),
-          serverSideVerificationOptions: ServerSideVerificationOptions(
-            userId: 'test-user-id',
-            customData: 'test-custom-data',
-          ));
+      );
 
       RewardedInterstitialAd createdAd =
           instanceManager.adFor(0) as RewardedInterstitialAd;
@@ -75,8 +72,6 @@ void main() {
           'adUnitId': 'test-ad-unit',
           'request': request,
           'adManagerRequest': null,
-          'serverSideVerificationOptions':
-              rewardedInterstitial!.serverSideVerificationOptions,
         }),
       ]);
 
@@ -165,10 +160,7 @@ void main() {
                     rewardedInterstitial = ad;
                   },
                   onAdFailedToLoad: (error) => null),
-          serverSideVerificationOptions: ServerSideVerificationOptions(
-            userId: 'test-user-id',
-            customData: 'test-custom-data',
-          ));
+      );
 
       RewardedInterstitialAd createdAd =
           instanceManager.adFor(0) as RewardedInterstitialAd;
@@ -180,8 +172,6 @@ void main() {
           'adUnitId': 'test-ad-unit',
           'request': request,
           'adManagerRequest': null,
-          'serverSideVerificationOptions':
-              rewardedInterstitial!.serverSideVerificationOptions,
         }),
       ]);
 
@@ -280,10 +270,7 @@ void main() {
                     rewardedInterstitial = ad;
                   },
                   onAdFailedToLoad: (error) => null),
-          serverSideVerificationOptions: ServerSideVerificationOptions(
-            userId: 'test-user-id',
-            customData: 'test-custom-data',
-          ));
+      );
 
       RewardedInterstitialAd createdAd =
           instanceManager.adFor(0) as RewardedInterstitialAd;
@@ -295,8 +282,6 @@ void main() {
           'adUnitId': 'test-ad-unit',
           'request': null,
           'adManagerRequest': request,
-          'serverSideVerificationOptions':
-              rewardedInterstitial!.serverSideVerificationOptions,
         }),
       ]);
 
@@ -329,7 +314,6 @@ void main() {
           'adUnitId': 'test-ad-unit',
           'request': request,
           'adManagerRequest': null,
-          'serverSideVerificationOptions': null,
         })
       ]);
 
@@ -402,10 +386,7 @@ void main() {
                     rewardedInterstitial = ad;
                   },
                   onAdFailedToLoad: (error) => null),
-          serverSideVerificationOptions: ServerSideVerificationOptions(
-            userId: 'test-user-id',
-            customData: 'test-custom-data',
-          ));
+      );
 
       RewardedInterstitialAd createdAd =
           instanceManager.adFor(0) as RewardedInterstitialAd;

--- a/packages/google_mobile_ads/test/rewarded_interstitial_ad_test.dart
+++ b/packages/google_mobile_ads/test/rewarded_interstitial_ad_test.dart
@@ -438,7 +438,7 @@ void main() {
         isMethodCall('setServerSideVerificationOptions',
             arguments: <dynamic, dynamic>{
               'adId': 0,
-              'options': ssv,
+              'serverSideVerificationOptions': ssv,
             }),
       ]);
     });

--- a/packages/google_mobile_ads/test/rewarded_interstitial_ad_test.dart
+++ b/packages/google_mobile_ads/test/rewarded_interstitial_ad_test.dart
@@ -39,7 +39,7 @@ void main() {
           case 'loadRewardedInterstitialAd':
           case 'showAdWithoutView':
           case 'disposeAd':
-          case 'setSSV':
+          case 'setServerSideVerificationOptions':
             return Future<void>.value();
           default:
             assert(false);
@@ -435,10 +435,11 @@ void main() {
           ServerSideVerificationOptions(userId: 'id', customData: 'data');
       await ad.setServerSideOptions(ssv);
       expect(log, <Matcher>[
-        isMethodCall('setSSV', arguments: <dynamic, dynamic>{
-          'adId': 0,
-          'options': ssv,
-        }),
+        isMethodCall('setServerSideVerificationOptions',
+            arguments: <dynamic, dynamic>{
+              'adId': 0,
+              'options': ssv,
+            }),
       ]);
     });
   });


### PR DESCRIPTION
## Description

Changes how `serverSideVerificationOptions` gets set in Rewarded and RewardedInterstitial ads.

Previously ssv was an argument taken in when loading the ad. 
This changes it to a setter, so it can be updated after the ad is loaded - matching how the native android and iOS APIs work.

## Related Issues

https://github.com/googleads/googleads-mobile-flutter/issues/520

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
