### PR TITLE
Delete deprecated APIs

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -11,6 +11,8 @@
   [Admob](https://developers.google.com/admob/flutter/test-ads) and 
   [AdManager](https://developers.google.com/ad-manager/mobile-ads-sdk/flutter/test-ads)
   documentation for up to date test ad units.
+* Deletes `NativeAdListener.onNativeAdClicked`. You should use `onAdClicked`
+  instead, which present on all ad listeners.
 
 ## 1.3.0
 * Adds support for programmatically opening the debug options menu using`MobileAds.openDebugMenu(String adUnitId)`

--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -7,12 +7,13 @@
   `RewardedAd.setServerSideVerificationOptions()` and 
   `RewardedInterstitialAd.setServerSideVerificationOptions()`. This lets you
   update the ssv after the ad is loaded.
-* Deletes static `testAdUnitId` parameters. See the
+* Removes static `testAdUnitId` parameters. See the
   [Admob](https://developers.google.com/admob/flutter/test-ads) and 
   [AdManager](https://developers.google.com/ad-manager/mobile-ads-sdk/flutter/test-ads)
   documentation for up to date test ad units.
-* Deletes `NativeAdListener.onNativeAdClicked`. You should use `onAdClicked`
+* Removes `NativeAdListener.onNativeAdClicked`. You should use `onAdClicked`
   instead, which present on all ad listeners.
+* Removes `AdRequest.location`
 
 ## 1.3.0
 * Adds support for programmatically opening the debug options menu using`MobileAds.openDebugMenu(String adUnitId)`

--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -7,6 +7,10 @@
   `RewardedAd.setServerSideVerificationOptions()` and 
   `RewardedInterstitialAd.setServerSideVerificationOptions()`. This lets you
   update the ssv after the ad is loaded.
+* Deletes static `testAdUnitId` parameters. See the
+  [Admob](https://developers.google.com/admob/flutter/test-ads) and 
+  [AdManager](https://developers.google.com/ad-manager/mobile-ads-sdk/flutter/test-ads)
+  documentation for up to date test ad units.
 
 ## 1.3.0
 * Adds support for programmatically opening the debug options menu using`MobileAds.openDebugMenu(String adUnitId)`

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import 'dart:async';
-import 'dart:io' show Platform;
 import 'dart:math';
 
 import 'package:flutter/foundation.dart';
@@ -143,40 +142,6 @@ class LoadAdError extends AdError {
   }
 }
 
-/// Location parameters that can be configured in an ad request.
-class LocationParams {
-  /// Location parameters that can be configured in an ad request.
-  const LocationParams({
-    required this.accuracy,
-    required this.longitude,
-    required this.latitude,
-    this.time,
-  });
-
-  /// The accuracy in meters.
-  final double accuracy;
-
-  /// The longitude in degrees.
-  final double longitude;
-
-  /// The latitude in degrees.
-  final double latitude;
-
-  /// The UTC time, in milliseconds since epoch (January 1, 1970).
-  ///
-  /// This is required on Android, and ignored on iOS.
-  final int? time;
-
-  @override
-  bool operator ==(Object other) {
-    return other is LocationParams &&
-        accuracy == other.accuracy &&
-        longitude == other.longitude &&
-        latitude == other.latitude &&
-        time == other.time;
-  }
-}
-
 /// Targeting info per the AdMob API.
 ///
 /// This class's properties mirror the native AdRequest API. See for example:
@@ -189,7 +154,6 @@ class AdRequest {
     this.neighboringContentUrls,
     this.nonPersonalizedAds,
     this.httpTimeoutMillis,
-    this.location,
     this.mediationExtrasIdentifier,
     this.extras,
   });
@@ -215,12 +179,6 @@ class AdRequest {
   ///
   /// This is only supported in Android. This value is ignored on iOS.
   final int? httpTimeoutMillis;
-
-  /// Location data.
-  ///
-  /// Used for mediation targeting purposes.
-  @Deprecated('Location is not used and will be deleted in a future release')
-  final LocationParams? location;
 
   /// String identifier used in providing mediation extras.
   ///
@@ -258,7 +216,6 @@ class AdManagerAdRequest extends AdRequest {
     bool? nonPersonalizedAds,
     int? httpTimeoutMillis,
     this.publisherProvidedId,
-    LocationParams? location,
     String? mediationExtrasIdentifier,
     Map<String, String>? extras,
   }) : super(
@@ -267,7 +224,6 @@ class AdManagerAdRequest extends AdRequest {
           neighboringContentUrls: neighboringContentUrls,
           nonPersonalizedAds: nonPersonalizedAds,
           httpTimeoutMillis: httpTimeoutMillis,
-          location: location,
           mediationExtrasIdentifier: mediationExtrasIdentifier,
           extras: extras,
         );

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -857,15 +857,6 @@ class BannerAd extends AdWithView {
   @override
   final BannerAdListener listener;
 
-  /// Check out developer pages for [Admob](https://developers.google.com/admob/flutter/test-ads)
-  /// and [AdManager](https://developers.google.com/ad-manager/mobile-ads-sdk/flutter/test-ads) for
-  /// demo ad units that point to specific test creatives for each format.
-  @Deprecated(
-      'Use test ad unit ids from the developer page while creating the ad.')
-  static final String testAdUnitId = Platform.isAndroid
-      ? 'ca-app-pub-3940256099942544/6300978111'
-      : 'ca-app-pub-3940256099942544/2934735716';
-
   @override
   Future<void> load() async {
     await instanceManager.loadBannerAd(this);
@@ -1034,15 +1025,6 @@ class NativeAd extends AdWithView {
   /// Options to configure the native ad request.
   final NativeAdOptions? nativeAdOptions;
 
-  /// Check out developer pages for [Admob](https://developers.google.com/admob/flutter/test-ads)
-  /// and [AdManager](https://developers.google.com/ad-manager/mobile-ads-sdk/flutter/test-ads) for
-  /// demo ad units that point to specific test creatives for each format.
-  @Deprecated(
-      'Use test ad unit ids from the developer page while creating the ad.')
-  static final String testAdUnitId = Platform.isAndroid
-      ? 'ca-app-pub-3940256099942544/2247696110'
-      : 'ca-app-pub-3940256099942544/3986624511';
-
   @override
   Future<void> load() async {
     await instanceManager.loadNativeAd(this);
@@ -1069,15 +1051,6 @@ class InterstitialAd extends AdWithoutView {
 
   /// Callbacks to be invoked when ads show and dismiss full screen content.
   FullScreenContentCallback<InterstitialAd>? fullScreenContentCallback;
-
-  /// Check out developer pages for [Admob](https://developers.google.com/admob/flutter/test-ads)
-  /// and [AdManager](https://developers.google.com/ad-manager/mobile-ads-sdk/flutter/test-ads) for
-  /// demo ad units that point to specific test creatives for each format.
-  @Deprecated(
-      'Use test ad unit ids from the developer page while creating the ad.')
-  static final String testAdUnitId = Platform.isAndroid
-      ? 'ca-app-pub-3940256099942544/1033173712'
-      : 'ca-app-pub-3940256099942544/4411468910';
 
   /// Loads an [InterstitialAd] with the given [adUnitId] and [request].
   static Future<void> load({
@@ -1179,15 +1152,6 @@ class RewardedAd extends AdWithoutView {
 
   /// Callbacks for events that occur when attempting to load an ad.
   final RewardedAdLoadCallback rewardedAdLoadCallback;
-
-  /// Check out developer pages for [Admob](https://developers.google.com/admob/flutter/test-ads)
-  /// and [AdManager](https://developers.google.com/ad-manager/mobile-ads-sdk/flutter/test-ads) for
-  /// demo ad units that point to specific test creatives for each format.
-  @Deprecated(
-      'Use test ad unit ids from the developer page while creating the ad.')
-  static final String testAdUnitId = Platform.isAndroid
-      ? 'ca-app-pub-3940256099942544/5224354917'
-      : 'ca-app-pub-3940256099942544/1712485313';
 
   /// Callbacks to be invoked when ads show and dismiss full screen content.
   FullScreenContentCallback<RewardedAd>? fullScreenContentCallback;

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -363,7 +363,6 @@ class AdInstanceManager {
 
   void _invokeOnAdClicked(Ad ad, String eventName) {
     if (ad is NativeAd) {
-      ad.listener.onNativeAdClicked?.call(ad);
       ad.listener.onAdClicked?.call(ad);
     } else if (ad is AdWithView) {
       ad.listener.onAdClicked?.call(ad);

--- a/packages/google_mobile_ads/lib/src/ad_listeners.dart
+++ b/packages/google_mobile_ads/lib/src/ad_listeners.dart
@@ -219,7 +219,6 @@ class NativeAdListener extends AdWithViewListener {
             onAdImpression: onAdImpression,
             onPaidEvent: onPaidEvent,
             onAdClicked: onAdClicked);
-
 }
 
 /// Callback events for for full screen ads, such as Rewarded and Interstitial.

--- a/packages/google_mobile_ads/lib/src/ad_listeners.dart
+++ b/packages/google_mobile_ads/lib/src/ad_listeners.dart
@@ -210,7 +210,6 @@ class NativeAdListener extends AdWithViewListener {
     AdEventCallback? onAdImpression,
     OnPaidEventCallback? onPaidEvent,
     AdEventCallback? onAdClicked,
-    this.onNativeAdClicked,
   }) : super(
             onAdLoaded: onAdLoaded,
             onAdFailedToLoad: onAdFailedToLoad,
@@ -221,10 +220,6 @@ class NativeAdListener extends AdWithViewListener {
             onPaidEvent: onPaidEvent,
             onAdClicked: onAdClicked);
 
-  /// Called when a click is recorded for a [NativeAd].
-  /// @Deprecated Use [onAdClicked] instead
-  @Deprecated('Use [onAdClicked] instead')
-  final void Function(NativeAd ad)? onNativeAdClicked;
 }
 
 /// Callback events for for full screen ads, such as Rewarded and Interstitial.

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -1318,7 +1318,6 @@ void main() {
           adUnitId: 'test-ad-unit',
           factoryId: 'testId',
           listener: NativeAdListener(
-              onNativeAdClicked: (Ad ad) => nativeAdClickCompleter.complete(ad),
               onAdClicked: (ad) => adClickCompleter.complete(ad)),
           request: AdRequest(),
         );

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -1056,8 +1056,6 @@ void main() {
         nonPersonalizedAds: false,
         neighboringContentUrls: <String>['url1.com', 'url2.com'],
         httpTimeoutMillis: 12345,
-        location:
-            LocationParams(accuracy: 1.1, longitude: 25, latitude: 38, time: 1),
         mediationExtrasIdentifier: 'identifier',
         extras: {'key': 'value'},
       );
@@ -1084,8 +1082,6 @@ void main() {
         nonPersonalizedAds: false,
         neighboringContentUrls: <String>['url1.com', 'url2.com'],
         httpTimeoutMillis: 12345,
-        location:
-            LocationParams(accuracy: 1.1, longitude: 25, latitude: 38, time: 1),
         mediationExtrasIdentifier: 'identifier',
         extras: {'key': 'value'},
       );
@@ -1097,7 +1093,6 @@ void main() {
       expect(decoded.contentUrl, adRequest.contentUrl);
       expect(decoded.nonPersonalizedAds, adRequest.nonPersonalizedAds);
       expect(decoded.keywords, adRequest.keywords);
-      expect(decoded.location, null);
       expect(decoded.mediationExtrasIdentifier, 'identifier');
     });
 
@@ -1248,8 +1243,6 @@ void main() {
         neighboringContentUrls: <String>['url1.com', 'url2.com'],
         httpTimeoutMillis: 5000,
         publisherProvidedId: 'test-pub-id',
-        location:
-            LocationParams(accuracy: 1.1, longitude: 25, latitude: 38, time: 1),
         mediationExtrasIdentifier: 'identifier',
         extras: {'key': 'value'},
       );
@@ -1289,8 +1282,6 @@ void main() {
         neighboringContentUrls: <String>['url1.com', 'url2.com'],
         httpTimeoutMillis: 5000,
         publisherProvidedId: 'test-pub-id',
-        location:
-            LocationParams(accuracy: 1.1, longitude: 25, latitude: 38, time: 1),
         mediationExtrasIdentifier: 'identifier',
         extras: {'key': 'value'},
       );
@@ -1305,13 +1296,11 @@ void main() {
       expect(decoded.publisherProvidedId, request.publisherProvidedId);
       expect(decoded.customTargeting, request.customTargeting);
       expect(decoded.customTargetingLists, request.customTargetingLists);
-      expect(decoded.location, null);
       expect(decoded.mediationExtrasIdentifier, 'identifier');
     });
 
     test('ad click native', () async {
       var testNativeClick = (eventName, adId) async {
-        final Completer<Ad> nativeAdClickCompleter = Completer<Ad>();
         final Completer<Ad> adClickCompleter = Completer<Ad>();
 
         final NativeAd native = NativeAd(
@@ -1336,7 +1325,6 @@ void main() {
           (ByteData? data) {},
         );
 
-        expect(nativeAdClickCompleter.future, completion(native));
         expect(adClickCompleter.future, completion(native));
       };
 


### PR DESCRIPTION
## Description

Deletes the following deprecates APIs:
* `AdRequest.location`
* Various `testAdUnitId` params
* `NativeAdListener.onNativeAdClicked`

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
