### PR TITLE
Visibility detector workaround for android impression issue

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -14,6 +14,9 @@
 * Removes `NativeAdListener.onNativeAdClicked`. You should use `onAdClicked`
   instead, which present on all ad listeners.
 * Removes `AdRequest.location`
+* Bug fix for [issue 580](https://github.com/googleads/googleads-mobile-flutter/issues/580).
+  Adds a workaround on Android to wait for the ad widget to become visible
+  before attaching the platform view.
 
 ## 1.3.0
 * Adds support for programmatically opening the debug options menu using`MobileAds.openDebugMenu(String adUnitId)`

--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.1
+* Bug fix for [issue 580](https://github.com/googleads/googleads-mobile-flutter/issues/580).
+  Adds a workaround on Android to wait for the ad widget to become visible
+  before attaching the platform view.
+
 ## 2.0.0
 * Updates GMA Android dependency to 21.0.0 and iOS to 9.6.0
 * Removes `credentials` from `AdapterResponseInfo`, which is replaced with
@@ -14,9 +19,6 @@
 * Removes `NativeAdListener.onNativeAdClicked`. You should use `onAdClicked`
   instead, which present on all ad listeners.
 * Removes `AdRequest.location`
-* Bug fix for [issue 580](https://github.com/googleads/googleads-mobile-flutter/issues/580).
-  Adds a workaround on Android to wait for the ad widget to become visible
-  before attaching the platform view.
 
 ## 1.3.0
 * Adds support for programmatically opening the debug options menu using`MobileAds.openDebugMenu(String adUnitId)`

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
@@ -17,7 +17,7 @@ package io.flutter.plugins.googlemobileads;
 /** Constants used in the plugin. */
 public class Constants {
   /** Version request agent. Should be bumped alongside plugin versions. */
-  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-2.0.0";
+  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-2.0.1";
 
   static final String ERROR_CODE_UNEXPECTED_AD_TYPE = "unexpected_ad_type";
 }

--- a/packages/google_mobile_ads/ios/Classes/FLTConstants.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTConstants.h
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /** Versioned request agent string. */
-#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-2.0.0"
+#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-2.0.1"

--- a/packages/google_mobile_ads/pubspec.yaml
+++ b/packages/google_mobile_ads/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   meta: ^1.0.4
   flutter:
     sdk: flutter
+  visibility_detector: ^0.3.3
 
 dev_dependencies:
   pedantic: ^1.11.0

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -18,9 +18,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:google_mobile_ads/src/ad_instance_manager.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 
@@ -372,7 +370,7 @@ void main() {
 
       // PlatformViewLink should now be present instead of VisibilityDetector
       final detectors = tester.widgetList(find.byType(VisibilityDetector));
-      // expect(detectors.isEmpty, true);
+      expect(detectors.isEmpty, true);
       final platformViewLink = tester.widget(find.byType(PlatformViewLink));
       expect(platformViewLink, isNotNull);
 


### PR DESCRIPTION
## Description
Updates `AdWidget` to wait until the widget becomes visible once before creating the `PlatformViewLink`. 
This is meant to be a temporary workaround for https://github.com/googleads/googleads-mobile-flutter/issues/580, where the android impression is being fired before the ad widget comes into view.


## Related Issues

https://github.com/googleads/googleads-mobile-flutter/issues/580

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
