### PR TITLE
Remove _Nonnull annotations.

### DIFF
--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
@@ -277,7 +277,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
   }
 }
 
-- (void)writeValue:(id _Nonnull)value {
+- (void)writeValue:(id)value {
   if ([value isKindOfClass:[FLTAdSize class]]) {
     [self writeAdSize:value];
   } else if ([value isKindOfClass:[FLTGAMAdRequest class]]) {

--- a/packages/google_mobile_ads/ios/Classes/UserMessagingPlatform/FLTUserMessagingPlatformReaderWriter.m
+++ b/packages/google_mobile_ads/ios/Classes/UserMessagingPlatform/FLTUserMessagingPlatformReaderWriter.m
@@ -73,7 +73,7 @@ typedef NS_ENUM(NSInteger, FLTUserMessagingPlatformField) {
 
 @implementation FLTUserMessagingPlatformWriter
 
-- (void)writeValue:(id _Nonnull)value {
+- (void)writeValue:(id)value {
   if ([value isKindOfClass:[UMPConsentForm class]]) {
     UMPConsentForm *form = (UMPConsentForm *)value;
     NSNumber *hash = [[NSNumber alloc] initWithInteger:form.hash];

--- a/packages/google_mobile_ads/lib/src/ump/user_messaging_codec.dart
+++ b/packages/google_mobile_ads/lib/src/ump/user_messaging_codec.dart
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import 'consent_form_impl.dart';


### PR DESCRIPTION
Remove unnecessary _Nonnull annotations. This fixes the build against https://github.com/flutter/engine/commit/08394d74c4e16d9aea517131dabe9c27d6fc2fa1, which changed the interface of  FlutterStandardWriter. This unblocks the import of flutter into Google3: cl/471706422
