### PR TITLE
Support new ResponseInfo APIs

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.1.0
+* Updates GMA dependencies to 21.2.0 (Android) and 9.10.0 (iOS):
+* Adds `loadedAdapterResponseInfo` to `ResponseInfo` and the following fields to
+  `AdapterResponseInfo`:
+  * adSourceID
+  * adSourceInstanceId
+  * adSourceInstanceName
+  * adSourceName
 ## 2.0.1
 * Bug fix for [issue 580](https://github.com/googleads/googleads-mobile-flutter/issues/580).
   Adds a workaround on Android to wait for the ad widget to become visible

--- a/packages/google_mobile_ads/android/build.gradle
+++ b/packages/google_mobile_ads/android/build.gradle
@@ -31,7 +31,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-      api 'com.google.android.gms:play-services-ads:21.1.0'
+      api 'com.google.android.gms:play-services-ads:21.2.0'
       implementation 'androidx.lifecycle:lifecycle-process:2.2.0'
       testImplementation 'junit:junit:4.12'
       testImplementation 'org.hamcrest:hamcrest:2.2'

--- a/packages/google_mobile_ads/android/build.gradle
+++ b/packages/google_mobile_ads/android/build.gradle
@@ -31,7 +31,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-      api 'com.google.android.gms:play-services-ads:21.0.0'
+      api 'com.google.android.gms:play-services-ads:21.1.0'
       implementation 'androidx.lifecycle:lifecycle-process:2.2.0'
       testImplementation 'junit:junit:4.12'
       testImplementation 'org.hamcrest:hamcrest:2.2'

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
@@ -119,12 +119,17 @@ class AdMessageCodec extends StandardMessageCodec {
       writeValue(stream, responseInfo.getDescription());
       writeValue(stream, responseInfo.getAdUnitMapping());
       writeValue(stream, responseInfo.getError());
+      writeValue(stream, responseInfo.getAdSourceName());
+      writeValue(stream, responseInfo.getAdSourceId());
+      writeValue(stream, responseInfo.getAdSourceInstanceName());
+      writeValue(stream, responseInfo.getAdSourceInstanceId());
     } else if (value instanceof FlutterResponseInfo) {
       stream.write(VALUE_RESPONSE_INFO);
       final FlutterResponseInfo responseInfo = (FlutterResponseInfo) value;
       writeValue(stream, responseInfo.getResponseId());
       writeValue(stream, responseInfo.getMediationAdapterClassName());
       writeValue(stream, responseInfo.getAdapterResponses());
+      writeValue(stream, responseInfo.getLoadedAdapterResponseInfo());
     } else if (value instanceof FlutterAd.FlutterLoadAdError) {
       stream.write(VALUE_LOAD_AD_ERROR);
       final FlutterAd.FlutterLoadAdError error = (FlutterAd.FlutterLoadAdError) value;
@@ -240,12 +245,17 @@ class AdMessageCodec extends StandardMessageCodec {
             (long) readValueOfType(buffer.get(), buffer),
             (String) readValueOfType(buffer.get(), buffer),
             (Map<String, String>) readValueOfType(buffer.get(), buffer),
-            (FlutterAdError) readValueOfType(buffer.get(), buffer));
+            (FlutterAdError) readValueOfType(buffer.get(), buffer),
+            (String) readValueOfType(buffer.get(), buffer),
+            (String) readValueOfType(buffer.get(), buffer),
+            (String) readValueOfType(buffer.get(), buffer),
+            (String) readValueOfType(buffer.get(), buffer));
       case VALUE_RESPONSE_INFO:
         return new FlutterResponseInfo(
             (String) readValueOfType(buffer.get(), buffer),
             (String) readValueOfType(buffer.get(), buffer),
-            (List<FlutterAdapterResponseInfo>) readValueOfType(buffer.get(), buffer));
+            (List<FlutterAdapterResponseInfo>) readValueOfType(buffer.get(), buffer),
+            (FlutterAdapterResponseInfo) readValueOfType(buffer.get(), buffer));
       case VALUE_LOAD_AD_ERROR:
         return new FlutterAd.FlutterLoadAdError(
             (Integer) readValueOfType(buffer.get(), buffer),

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
@@ -17,7 +17,7 @@ package io.flutter.plugins.googlemobileads;
 /** Constants used in the plugin. */
 public class Constants {
   /** Version request agent. Should be bumped alongside plugin versions. */
-  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-2.0.1";
+  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-2.1.0";
 
   static final String ERROR_CODE_UNEXPECTED_AD_TYPE = "unexpected_ad_type";
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAd.java
@@ -52,6 +52,7 @@ abstract class FlutterAd {
     @Nullable private final String responseId;
     @Nullable private final String mediationAdapterClassName;
     @NonNull private final List<FlutterAdapterResponseInfo> adapterResponses;
+    @Nullable private final FlutterAdapterResponseInfo loadedAdapterResponseInfo;
 
     FlutterResponseInfo(@NonNull ResponseInfo responseInfo) {
       this.responseId = responseInfo.getResponseId();
@@ -61,15 +62,22 @@ abstract class FlutterAd {
         adapterResponseInfos.add(new FlutterAdapterResponseInfo(adapterInfo));
       }
       this.adapterResponses = adapterResponseInfos;
+      if (responseInfo.getLoadedAdapterResponseInfo() != null) {
+        this.loadedAdapterResponseInfo = new FlutterAdapterResponseInfo(responseInfo.getLoadedAdapterResponseInfo());
+      } else {
+        this.loadedAdapterResponseInfo = null;
+      }
     }
 
     FlutterResponseInfo(
         @Nullable String responseId,
         @Nullable String mediationAdapterClassName,
-        @NonNull List<FlutterAdapterResponseInfo> adapterResponseInfos) {
+        @NonNull List<FlutterAdapterResponseInfo> adapterResponseInfos,
+        @Nullable FlutterAdapterResponseInfo loadedAdapterResponseInfo) {
       this.responseId = responseId;
       this.mediationAdapterClassName = mediationAdapterClassName;
       this.adapterResponses = adapterResponseInfos;
+      this.loadedAdapterResponseInfo = loadedAdapterResponseInfo;
     }
 
     @Nullable
@@ -87,6 +95,11 @@ abstract class FlutterAd {
       return adapterResponses;
     }
 
+    @Nullable
+    FlutterAdapterResponseInfo getLoadedAdapterResponseInfo() {
+      return loadedAdapterResponseInfo;
+    }
+
     @Override
     public boolean equals(@Nullable Object obj) {
       if (obj == this) {
@@ -98,12 +111,14 @@ abstract class FlutterAd {
       FlutterResponseInfo that = (FlutterResponseInfo) obj;
       return Objects.equals(responseId, that.responseId)
           && Objects.equals(mediationAdapterClassName, that.mediationAdapterClassName)
-          && Objects.equals(adapterResponses, that.adapterResponses);
+          && Objects.equals(adapterResponses, that.adapterResponses)
+          && Objects.equals(loadedAdapterResponseInfo, that.loadedAdapterResponseInfo);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(responseId, mediationAdapterClassName);
+      return Objects.hash(
+          responseId, mediationAdapterClassName, adapterResponses, loadedAdapterResponseInfo);
     }
   }
 
@@ -115,6 +130,10 @@ abstract class FlutterAd {
     @NonNull private final String description;
     @NonNull private final Map<String, String> adUnitMapping;
     @Nullable private FlutterAdError error;
+    @Nullable private String adSourceName;
+    @Nullable private String adSourceId;
+    @Nullable private String adSourceInstanceName;
+    @Nullable private String adSourceInstanceId;
 
     FlutterAdapterResponseInfo(@NonNull AdapterResponseInfo responseInfo) {
       this.adapterClassName = responseInfo.getAdapterClassName();
@@ -131,6 +150,10 @@ abstract class FlutterAd {
       if (responseInfo.getAdError() != null) {
         this.error = new FlutterAdError(responseInfo.getAdError());
       }
+      adSourceName = responseInfo.getAdSourceName();
+      adSourceId = responseInfo.getAdSourceId();
+      adSourceInstanceName = responseInfo.getAdSourceInstanceName();
+      adSourceInstanceId = responseInfo.getAdSourceInstanceId();
     }
 
     FlutterAdapterResponseInfo(
@@ -138,12 +161,20 @@ abstract class FlutterAd {
         long latencyMillis,
         @NonNull String description,
         @NonNull Map<String, String> adUnitMapping,
-        @Nullable FlutterAdError error) {
+        @Nullable FlutterAdError error,
+        @Nullable String adSourceName,
+        @Nullable String adSourceId,
+        @Nullable String adSourceInstanceName,
+        @Nullable String adSourceInstanceId) {
       this.adapterClassName = adapterClassName;
       this.latencyMillis = latencyMillis;
       this.description = description;
       this.adUnitMapping = adUnitMapping;
       this.error = error;
+      this.adSourceName = adSourceName;
+      this.adSourceId = adSourceId;
+      this.adSourceInstanceName = adSourceInstanceName;
+      this.adSourceInstanceId = adSourceInstanceId;
     }
 
     @NonNull
@@ -170,6 +201,26 @@ abstract class FlutterAd {
       return error;
     }
 
+    @Nullable
+    public String getAdSourceName() {
+      return adSourceName;
+    }
+
+    @Nullable
+    public String getAdSourceId() {
+      return adSourceId;
+    }
+
+    @Nullable
+    public String getAdSourceInstanceName() {
+      return adSourceInstanceName;
+    }
+
+    @Nullable
+    public String getAdSourceInstanceId() {
+      return adSourceInstanceId;
+    }
+
     @Override
     public boolean equals(@Nullable Object obj) {
       if (obj == this) {
@@ -183,12 +234,24 @@ abstract class FlutterAd {
           && latencyMillis == that.latencyMillis
           && Objects.equals(description, that.description)
           && Objects.equals(error, that.error)
-          && Objects.equals(adUnitMapping, that.adUnitMapping);
+          && Objects.equals(adUnitMapping, that.adUnitMapping)
+          && Objects.equals(adSourceName, that.adSourceName)
+          && Objects.equals(adSourceId, that.adSourceId)
+          && Objects.equals(adSourceInstanceName, that.adSourceInstanceName)
+          && Objects.equals(adSourceInstanceId, that.adSourceInstanceId);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(adapterClassName, latencyMillis, description, error);
+      return Objects.hash(
+          adapterClassName,
+          latencyMillis,
+          description,
+          error,
+          adSourceName,
+          adSourceId,
+          adSourceInstanceName,
+          adSourceInstanceId);
     }
   }
 

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAd.java
@@ -63,7 +63,8 @@ abstract class FlutterAd {
       }
       this.adapterResponses = adapterResponseInfos;
       if (responseInfo.getLoadedAdapterResponseInfo() != null) {
-        this.loadedAdapterResponseInfo = new FlutterAdapterResponseInfo(responseInfo.getLoadedAdapterResponseInfo());
+        this.loadedAdapterResponseInfo =
+            new FlutterAdapterResponseInfo(responseInfo.getLoadedAdapterResponseInfo());
       } else {
         this.loadedAdapterResponseInfo = null;
       }

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
@@ -319,13 +319,34 @@ public class AdMessageCodecTest {
   }
 
   @Test
-  public void encodeFlutterLoadAdError() {
+  public void encodeFlutterResponseInfo() {
     List<FlutterAdapterResponseInfo> adapterResponseInfos = new ArrayList<>();
     Map<String, String> adUnitMapping = Collections.singletonMap("key", "value");
-    adapterResponseInfos.add(
-        new FlutterAdapterResponseInfo("adapter-class", 9999, "description", adUnitMapping, null));
-    FlutterResponseInfo info =
-        new FlutterResponseInfo("responseId", "className", adapterResponseInfos);
+    adapterResponseInfos.add(new FlutterAdapterResponseInfo(
+        "adapter-class",
+        9999,
+        "description",
+        adUnitMapping,
+        null,
+        "adSourceName",
+        "adSourceId",
+        "adSourceInstanceName",
+        "adSourceInstanceId"));
+    FlutterAdapterResponseInfo loadedAdapterResponseInfo = new FlutterAdapterResponseInfo(
+        "loaded-adapter-class",
+        1234,
+        "description",
+        adUnitMapping,
+        null,
+        "adSourceName",
+        "adSourceId",
+        "adSourceInstanceName",
+        "adSourceInstanceId");
+    FlutterResponseInfo info = new FlutterResponseInfo(
+        "responseId",
+        "className",
+        adapterResponseInfos,
+        loadedAdapterResponseInfo);
     final ByteBuffer message =
         codec.encodeMessage(new FlutterBannerAd.FlutterLoadAdError(1, "domain", "message", info));
 

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
@@ -322,31 +322,31 @@ public class AdMessageCodecTest {
   public void encodeFlutterResponseInfo() {
     List<FlutterAdapterResponseInfo> adapterResponseInfos = new ArrayList<>();
     Map<String, String> adUnitMapping = Collections.singletonMap("key", "value");
-    adapterResponseInfos.add(new FlutterAdapterResponseInfo(
-        "adapter-class",
-        9999,
-        "description",
-        adUnitMapping,
-        null,
-        "adSourceName",
-        "adSourceId",
-        "adSourceInstanceName",
-        "adSourceInstanceId"));
-    FlutterAdapterResponseInfo loadedAdapterResponseInfo = new FlutterAdapterResponseInfo(
-        "loaded-adapter-class",
-        1234,
-        "description",
-        adUnitMapping,
-        null,
-        "adSourceName",
-        "adSourceId",
-        "adSourceInstanceName",
-        "adSourceInstanceId");
-    FlutterResponseInfo info = new FlutterResponseInfo(
-        "responseId",
-        "className",
-        adapterResponseInfos,
-        loadedAdapterResponseInfo);
+    adapterResponseInfos.add(
+        new FlutterAdapterResponseInfo(
+            "adapter-class",
+            9999,
+            "description",
+            adUnitMapping,
+            null,
+            "adSourceName",
+            "adSourceId",
+            "adSourceInstanceName",
+            "adSourceInstanceId"));
+    FlutterAdapterResponseInfo loadedAdapterResponseInfo =
+        new FlutterAdapterResponseInfo(
+            "loaded-adapter-class",
+            1234,
+            "description",
+            adUnitMapping,
+            null,
+            "adSourceName",
+            "adSourceId",
+            "adSourceInstanceName",
+            "adSourceInstanceId");
+    FlutterResponseInfo info =
+        new FlutterResponseInfo(
+            "responseId", "className", adapterResponseInfos, loadedAdapterResponseInfo);
     final ByteBuffer message =
         codec.encodeMessage(new FlutterBannerAd.FlutterLoadAdError(1, "domain", "message", info));
 

--- a/packages/google_mobile_ads/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/packages/google_mobile_ads/example/ios/Flutter/AppFrameworkInfo.plist
@@ -25,6 +25,6 @@
     <string>arm64</string>
   </array>
   <key>MinimumOSVersion</key>
-  <string>9.0</string>
+  <string>11.0</string>
 </dict>
 </plist>

--- a/packages/google_mobile_ads/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/google_mobile_ads/example/ios/Runner.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		5C7E63AC163134A326635FC7 /* libPods-google_mobile_ads_exampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B4B811D89E676EBD37E2E206 /* libPods-google_mobile_ads_exampleTests.a */; };
 		8FB13CDD248F07D90011A72F /* FLTGoogleMobileAdsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8FB13CDC248F07D90011A72F /* FLTGoogleMobileAdsTest.m */; };
 		8FB13CE22498136E0011A72F /* FLTGoogleMobileAdsReaderWriterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8FB13CE12498136E0011A72F /* FLTGoogleMobileAdsReaderWriterTest.m */; };
 		8FC897F52411A9F100415930 /* NativeAdView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8FC897F42411A9F100415930 /* NativeAdView.xib */; };
@@ -52,7 +53,6 @@
 		9EF4E70C26392B230007E4FE /* FLTMobileAds_Internal.h in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4E6FF26392B230007E4FE /* FLTMobileAds_Internal.h */; };
 		9EF4E7102639410D0007E4FE /* FLTRewardedAdTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4E70F2639410D0007E4FE /* FLTRewardedAdTest.m */; };
 		9EF4E7142639D4B30007E4FE /* FLTNativeAdTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4E7132639D4B30007E4FE /* FLTNativeAdTest.m */; };
-		C4247E08A145B7C14603446E /* libPods-google_mobile_ads_exampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BDCE5C673B60CB3659CEFE9 /* libPods-google_mobile_ads_exampleTests.a */; };
 		FBE669D215209F1F44CEEB21 /* libPods-Runner.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F369F228D3A43519CEE308 /* libPods-Runner.a */; };
 /* End PBXBuildFile section */
 
@@ -82,9 +82,8 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
-		185186B2D682FC21FE7F9077 /* Pods-google_mobile_ads_exampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-google_mobile_ads_exampleTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-google_mobile_ads_exampleTests/Pods-google_mobile_ads_exampleTests.release.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
-		6BDCE5C673B60CB3659CEFE9 /* libPods-google_mobile_ads_exampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-google_mobile_ads_exampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		41FDEFDDDE2EF7FC7A8F36B5 /* Pods-google_mobile_ads_exampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-google_mobile_ads_exampleTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-google_mobile_ads_exampleTests/Pods-google_mobile_ads_exampleTests.release.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		7AFFD8ED1D35381100E5BB4D /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		7AFFD8EE1D35381100E5BB4D /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -142,8 +141,9 @@
 		9EF4E6FF26392B230007E4FE /* FLTMobileAds_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FLTMobileAds_Internal.h; path = ../../ios/Classes/FLTMobileAds_Internal.h; sourceTree = "<group>"; };
 		9EF4E70F2639410D0007E4FE /* FLTRewardedAdTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FLTRewardedAdTest.m; path = ../../../ios/Tests/FLTRewardedAdTest.m; sourceTree = "<group>"; };
 		9EF4E7132639D4B30007E4FE /* FLTNativeAdTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FLTNativeAdTest.m; path = ../../../ios/Tests/FLTNativeAdTest.m; sourceTree = "<group>"; };
+		B4B811D89E676EBD37E2E206 /* libPods-google_mobile_ads_exampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-google_mobile_ads_exampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C0B22AB9B287C9F711EAAF48 /* Pods-google_mobile_ads_exampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-google_mobile_ads_exampleTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-google_mobile_ads_exampleTests/Pods-google_mobile_ads_exampleTests.debug.xcconfig"; sourceTree = "<group>"; };
 		CE82265EF05E2A9632B25E60 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
-		E7E26991231DD855BEEE69EB /* Pods-google_mobile_ads_exampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-google_mobile_ads_exampleTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-google_mobile_ads_exampleTests/Pods-google_mobile_ads_exampleTests.debug.xcconfig"; sourceTree = "<group>"; };
 		F74051031B69F8124E38352E /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -154,7 +154,7 @@
 			files = (
 				9EB9FE59280F86D100DDBB4F /* UserMessagingPlatform.xcframework in Frameworks */,
 				9EA7213725BB6517008D57E3 /* GoogleMobileAds.xcframework in Frameworks */,
-				C4247E08A145B7C14603446E /* libPods-google_mobile_ads_exampleTests.a in Frameworks */,
+				5C7E63AC163134A326635FC7 /* libPods-google_mobile_ads_exampleTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -175,8 +175,8 @@
 			children = (
 				CE82265EF05E2A9632B25E60 /* Pods-Runner.debug.xcconfig */,
 				F74051031B69F8124E38352E /* Pods-Runner.release.xcconfig */,
-				E7E26991231DD855BEEE69EB /* Pods-google_mobile_ads_exampleTests.debug.xcconfig */,
-				185186B2D682FC21FE7F9077 /* Pods-google_mobile_ads_exampleTests.release.xcconfig */,
+				C0B22AB9B287C9F711EAAF48 /* Pods-google_mobile_ads_exampleTests.debug.xcconfig */,
+				41FDEFDDDE2EF7FC7A8F36B5 /* Pods-google_mobile_ads_exampleTests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -187,7 +187,7 @@
 				9EB9FE57280F853D00DDBB4F /* UserMessagingPlatform.xcframework */,
 				9EA7213525BB6464008D57E3 /* GoogleMobileAds.xcframework */,
 				83F369F228D3A43519CEE308 /* libPods-Runner.a */,
-				6BDCE5C673B60CB3659CEFE9 /* libPods-google_mobile_ads_exampleTests.a */,
+				B4B811D89E676EBD37E2E206 /* libPods-google_mobile_ads_exampleTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -321,7 +321,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8FB13CDB248F07B80011A72F /* Build configuration list for PBXNativeTarget "google_mobile_ads_exampleTests" */;
 			buildPhases = (
-				2A2457F6E7000417AF1E283D /* [CP] Check Pods Manifest.lock */,
+				89AD8E00A7365C448495871F /* [CP] Check Pods Manifest.lock */,
 				8FB13CCE248F07B80011A72F /* Sources */,
 				8FB13CCF248F07B80011A72F /* Frameworks */,
 				8FB13CD0248F07B80011A72F /* Resources */,
@@ -363,7 +363,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1340;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "The Chromium Authors";
 				TargetAttributes = {
 					8FB13CD1248F07B80011A72F = {
@@ -419,28 +419,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		2A2457F6E7000417AF1E283D /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-google_mobile_ads_exampleTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
 		2C1A4E9A6849F7CC6B679EA5 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -472,6 +450,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed\n/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" thin\n";
+		};
+		89AD8E00A7365C448495871F /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-google_mobile_ads_exampleTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -573,7 +573,7 @@
 /* Begin XCBuildConfiguration section */
 		8FB13CD9248F07B80011A72F /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E7E26991231DD855BEEE69EB /* Pods-google_mobile_ads_exampleTests.debug.xcconfig */;
+			baseConfigurationReference = C0B22AB9B287C9F711EAAF48 /* Pods-google_mobile_ads_exampleTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -610,7 +610,7 @@
 		};
 		8FB13CDA248F07B80011A72F /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 185186B2D682FC21FE7F9077 /* Pods-google_mobile_ads_exampleTests.release.xcconfig */;
+			baseConfigurationReference = 41FDEFDDDE2EF7FC7A8F36B5 /* Pods-google_mobile_ads_exampleTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
@@ -101,6 +101,11 @@
 @property NSString *_Nullable dictionaryDescription;
 @property NSDictionary<NSString *, NSString *> *_Nullable adUnitMapping;
 @property NSError *_Nullable error;
+@property NSString *_Nullable adSourceInstanceID;
+@property NSString *_Nullable adSourceID;
+@property NSString *_Nullable adSourceName;
+@property NSString *_Nullable adSourceInstanceName;
+
 
 - (instancetype _Nonnull)initWithResponseInfo:
     (GADAdNetworkResponseInfo *_Nonnull)responseInfo;
@@ -113,6 +118,7 @@
 @property NSString *_Nullable responseIdentifier;
 @property NSString *_Nullable adNetworkClassName;
 @property NSArray<FLTGADAdNetworkResponseInfo *> *_Nullable adNetworkInfoArray;
+@property FLTGADAdNetworkResponseInfo *_Nullable loadedAdNetworkResponseInfo;
 
 - (instancetype _Nonnull)initWithResponseInfo:
     (GADResponseInfo *_Nonnull)responseInfo;

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
@@ -106,7 +106,6 @@
 @property NSString *_Nullable adSourceName;
 @property NSString *_Nullable adSourceInstanceName;
 
-
 - (instancetype _Nonnull)initWithResponseInfo:
     (GADAdNetworkResponseInfo *_Nonnull)responseInfo;
 @end

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
@@ -243,6 +243,7 @@
                                initWithResponseInfo:adNetworkInfo]];
     }
     _adNetworkInfoArray = infoArray;
+    _loadedAdNetworkResponseInfo = [[FLTGADAdNetworkResponseInfo alloc] initWithResponseInfo:responseInfo.loadedAdNetworkResponseInfo];
   }
   return self;
 }
@@ -269,6 +270,11 @@
       }
     }
     _error = responseInfo.error;
+    
+    _adSourceName = responseInfo.adSourceName;
+    _adSourceInstanceName = responseInfo.adSourceInstanceName;
+    _adSourceInstanceID = responseInfo.adSourceInstanceID;
+    _adSourceID = responseInfo.adSourceID;
   }
   return self;
 }

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
@@ -243,7 +243,8 @@
                                initWithResponseInfo:adNetworkInfo]];
     }
     _adNetworkInfoArray = infoArray;
-    _loadedAdNetworkResponseInfo = [[FLTGADAdNetworkResponseInfo alloc] initWithResponseInfo:responseInfo.loadedAdNetworkResponseInfo];
+    _loadedAdNetworkResponseInfo = [[FLTGADAdNetworkResponseInfo alloc]
+        initWithResponseInfo:responseInfo.loadedAdNetworkResponseInfo];
   }
   return self;
 }
@@ -270,7 +271,7 @@
       }
     }
     _error = responseInfo.error;
-    
+
     _adSourceName = responseInfo.adSourceName;
     _adSourceInstanceName = responseInfo.adSourceInstanceName;
     _adSourceInstanceID = responseInfo.adSourceInstanceID;

--- a/packages/google_mobile_ads/ios/Classes/FLTConstants.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTConstants.h
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /** Versioned request agent string. */
-#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-2.0.1"
+#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-2.1.0"

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
@@ -113,7 +113,8 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     NSString *adNetworkClassName = [self readValueOfType:[self readByte]];
     NSArray<FLTGADAdNetworkResponseInfo *> *adNetworkInfoArray =
         [self readValueOfType:[self readByte]];
-    FLTGADAdNetworkResponseInfo *loadedResponseInfo = [self readValueOfType:[self readByte]];
+    FLTGADAdNetworkResponseInfo *loadedResponseInfo =
+        [self readValueOfType:[self readByte]];
     FLTGADResponseInfo *gadResponseInfo = [[FLTGADResponseInfo alloc] init];
     gadResponseInfo.adNetworkClassName = adNetworkClassName;
     gadResponseInfo.responseIdentifier = responseIdentifier;

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
@@ -113,10 +113,12 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     NSString *adNetworkClassName = [self readValueOfType:[self readByte]];
     NSArray<FLTGADAdNetworkResponseInfo *> *adNetworkInfoArray =
         [self readValueOfType:[self readByte]];
+    FLTGADAdNetworkResponseInfo *loadedResponseInfo = [self readValueOfType:[self readByte]];
     FLTGADResponseInfo *gadResponseInfo = [[FLTGADResponseInfo alloc] init];
     gadResponseInfo.adNetworkClassName = adNetworkClassName;
     gadResponseInfo.responseIdentifier = responseIdentifier;
     gadResponseInfo.adNetworkInfoArray = adNetworkInfoArray;
+    gadResponseInfo.loadedAdNetworkResponseInfo = loadedResponseInfo;
     return gadResponseInfo;
   }
   case FLTAdmobFieldGADAdNetworkResponseInfo: {
@@ -126,6 +128,11 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     NSDictionary<NSString *, NSString *> *adUnitMapping =
         [self readValueOfType:[self readByte]];
     NSError *error = [self readValueOfType:[self readByte]];
+    NSString *adSourceName = [self readValueOfType:[self readByte]];
+    NSString *adSourceID = [self readValueOfType:[self readByte]];
+    NSString *adSourceInstanceName = [self readValueOfType:[self readByte]];
+    NSString *adSourceInstanceID = [self readValueOfType:[self readByte]];
+
     FLTGADAdNetworkResponseInfo *adNetworkResponseInfo =
         [[FLTGADAdNetworkResponseInfo alloc] init];
     adNetworkResponseInfo.adNetworkClassName = adNetworkClassName;
@@ -133,6 +140,10 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     adNetworkResponseInfo.dictionaryDescription = dictionaryDescription;
     adNetworkResponseInfo.adUnitMapping = adUnitMapping;
     adNetworkResponseInfo.error = error;
+    adNetworkResponseInfo.adSourceName = adSourceName;
+    adNetworkResponseInfo.adSourceID = adSourceID;
+    adNetworkResponseInfo.adSourceInstanceName = adSourceInstanceName;
+    adNetworkResponseInfo.adSourceInstanceID = adSourceInstanceID;
     return adNetworkResponseInfo;
   }
   case FLTAdMobFieldLoadError: {
@@ -312,6 +323,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     [self writeValue:responseInfo.responseIdentifier];
     [self writeValue:responseInfo.adNetworkClassName];
     [self writeValue:responseInfo.adNetworkInfoArray];
+    [self writeValue:responseInfo.loadedAdNetworkResponseInfo];
   } else if ([value isKindOfClass:[FLTGADAdNetworkResponseInfo class]]) {
     [self writeByte:FLTAdmobFieldGADAdNetworkResponseInfo];
     FLTGADAdNetworkResponseInfo *networkResponseInfo = value;
@@ -320,6 +332,10 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     [self writeValue:networkResponseInfo.dictionaryDescription];
     [self writeValue:networkResponseInfo.adUnitMapping];
     [self writeValue:networkResponseInfo.error];
+    [self writeValue:networkResponseInfo.adSourceName];
+    [self writeValue:networkResponseInfo.adSourceID];
+    [self writeValue:networkResponseInfo.adSourceInstanceName];
+    [self writeValue:networkResponseInfo.adSourceInstanceID];
   } else if ([value isKindOfClass:[FLTLoadAdError class]]) {
     [self writeByte:FLTAdMobFieldLoadError];
     FLTLoadAdError *error = value;

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
@@ -446,16 +446,34 @@
       .andReturn(descriptionsDict);
   OCMStub([mockGADResponseInfo adUnitMapping]).andReturn(adUnitMappingsDict);
   OCMStub([mockGADResponseInfo error]).andReturn(error);
+  
+  GADAdNetworkResponseInfo *mockLoadedGADResponseInfo =
+      OCMClassMock([GADAdNetworkResponseInfo class]);
+  OCMStub([mockLoadedGADResponseInfo adNetworkClassName]).andReturn(@"loaded-adapter");
+  OCMStub([mockLoadedGADResponseInfo latency]).andReturn(123.1234);
+  OCMStub([mockLoadedGADResponseInfo dictionaryRepresentation])
+      .andReturn(descriptionsDict);
+  OCMStub([mockLoadedGADResponseInfo adUnitMapping]).andReturn(adUnitMappingsDict);
+  OCMStub([mockLoadedGADResponseInfo error]).andReturn(error);
+  OCMStub([mockLoadedGADResponseInfo adSourceName]).andReturn(@"adSourceName");
+  OCMStub([mockLoadedGADResponseInfo adSourceID]).andReturn(@"adSourceID");
+  OCMStub([mockLoadedGADResponseInfo adSourceInstanceName]).andReturn(@"adSourceInstanceName");
+  OCMStub([mockLoadedGADResponseInfo adSourceInstanceID]).andReturn(@"adSourceInstanceID");
+
 
   FLTGADAdNetworkResponseInfo *adNetworkResponseInfo =
       [[FLTGADAdNetworkResponseInfo alloc]
           initWithResponseInfo:mockGADResponseInfo];
+  FLTGADAdNetworkResponseInfo *loadedNetworkResponseInfo =
+    [[FLTGADAdNetworkResponseInfo alloc]
+        initWithResponseInfo:mockLoadedGADResponseInfo];
 
   FLTGADResponseInfo *responseInfo = [[FLTGADResponseInfo alloc] init];
   responseInfo.adNetworkClassName = @"class-name";
   responseInfo.responseIdentifier = @"identifier";
   responseInfo.adNetworkInfoArray = @[ adNetworkResponseInfo ];
-
+  responseInfo.loadedAdNetworkResponseInfo = loadedNetworkResponseInfo;
+  
   NSData *encodedMessage = [_messageCodec encode:responseInfo];
   FLTGADResponseInfo *decodedResponseInfo =
       [_messageCodec decode:encodedMessage];
@@ -475,6 +493,21 @@
   XCTAssertEqual(decodedInfo.error.code, 1);
   XCTAssertEqualObjects(decodedInfo.error.domain, @"domain");
   XCTAssertEqualObjects(decodedInfo.error.localizedDescription, @"error");
+  
+  FLTGADAdNetworkResponseInfo *decodedLoadedInfo =
+    decodedResponseInfo.loadedAdNetworkResponseInfo;
+  XCTAssertEqualObjects(decodedLoadedInfo.adNetworkClassName, @"loaded-adapter");
+  XCTAssertEqualObjects(decodedLoadedInfo.latency, @(123123));
+  XCTAssertEqualObjects(decodedLoadedInfo.dictionaryDescription,
+                        @"{\n    descriptions = dict;\n}");
+  XCTAssertEqualObjects(decodedLoadedInfo.adUnitMapping, adUnitMappingsDict);
+  XCTAssertEqual(decodedLoadedInfo.error.code, 1);
+  XCTAssertEqualObjects(decodedLoadedInfo.error.domain, @"domain");
+  XCTAssertEqualObjects(decodedLoadedInfo.error.localizedDescription, @"error");
+  XCTAssertEqualObjects(decodedLoadedInfo.adSourceName, @"adSourceName");
+  XCTAssertEqualObjects(decodedLoadedInfo.adSourceID, @"adSourceID");
+  XCTAssertEqualObjects(decodedLoadedInfo.adSourceInstanceName, @"adSourceInstanceName");
+  XCTAssertEqualObjects(decodedLoadedInfo.adSourceInstanceID, @"adSourceInstanceID");
 }
 
 - (void)testEncodeDecodeFLTGADLoadErrorWithEmptyValues {

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
@@ -446,34 +446,37 @@
       .andReturn(descriptionsDict);
   OCMStub([mockGADResponseInfo adUnitMapping]).andReturn(adUnitMappingsDict);
   OCMStub([mockGADResponseInfo error]).andReturn(error);
-  
+
   GADAdNetworkResponseInfo *mockLoadedGADResponseInfo =
       OCMClassMock([GADAdNetworkResponseInfo class]);
-  OCMStub([mockLoadedGADResponseInfo adNetworkClassName]).andReturn(@"loaded-adapter");
+  OCMStub([mockLoadedGADResponseInfo adNetworkClassName])
+      .andReturn(@"loaded-adapter");
   OCMStub([mockLoadedGADResponseInfo latency]).andReturn(123.1234);
   OCMStub([mockLoadedGADResponseInfo dictionaryRepresentation])
       .andReturn(descriptionsDict);
-  OCMStub([mockLoadedGADResponseInfo adUnitMapping]).andReturn(adUnitMappingsDict);
+  OCMStub([mockLoadedGADResponseInfo adUnitMapping])
+      .andReturn(adUnitMappingsDict);
   OCMStub([mockLoadedGADResponseInfo error]).andReturn(error);
   OCMStub([mockLoadedGADResponseInfo adSourceName]).andReturn(@"adSourceName");
   OCMStub([mockLoadedGADResponseInfo adSourceID]).andReturn(@"adSourceID");
-  OCMStub([mockLoadedGADResponseInfo adSourceInstanceName]).andReturn(@"adSourceInstanceName");
-  OCMStub([mockLoadedGADResponseInfo adSourceInstanceID]).andReturn(@"adSourceInstanceID");
-
+  OCMStub([mockLoadedGADResponseInfo adSourceInstanceName])
+      .andReturn(@"adSourceInstanceName");
+  OCMStub([mockLoadedGADResponseInfo adSourceInstanceID])
+      .andReturn(@"adSourceInstanceID");
 
   FLTGADAdNetworkResponseInfo *adNetworkResponseInfo =
       [[FLTGADAdNetworkResponseInfo alloc]
           initWithResponseInfo:mockGADResponseInfo];
   FLTGADAdNetworkResponseInfo *loadedNetworkResponseInfo =
-    [[FLTGADAdNetworkResponseInfo alloc]
-        initWithResponseInfo:mockLoadedGADResponseInfo];
+      [[FLTGADAdNetworkResponseInfo alloc]
+          initWithResponseInfo:mockLoadedGADResponseInfo];
 
   FLTGADResponseInfo *responseInfo = [[FLTGADResponseInfo alloc] init];
   responseInfo.adNetworkClassName = @"class-name";
   responseInfo.responseIdentifier = @"identifier";
   responseInfo.adNetworkInfoArray = @[ adNetworkResponseInfo ];
   responseInfo.loadedAdNetworkResponseInfo = loadedNetworkResponseInfo;
-  
+
   NSData *encodedMessage = [_messageCodec encode:responseInfo];
   FLTGADResponseInfo *decodedResponseInfo =
       [_messageCodec decode:encodedMessage];
@@ -493,10 +496,11 @@
   XCTAssertEqual(decodedInfo.error.code, 1);
   XCTAssertEqualObjects(decodedInfo.error.domain, @"domain");
   XCTAssertEqualObjects(decodedInfo.error.localizedDescription, @"error");
-  
+
   FLTGADAdNetworkResponseInfo *decodedLoadedInfo =
-    decodedResponseInfo.loadedAdNetworkResponseInfo;
-  XCTAssertEqualObjects(decodedLoadedInfo.adNetworkClassName, @"loaded-adapter");
+      decodedResponseInfo.loadedAdNetworkResponseInfo;
+  XCTAssertEqualObjects(decodedLoadedInfo.adNetworkClassName,
+                        @"loaded-adapter");
   XCTAssertEqualObjects(decodedLoadedInfo.latency, @(123123));
   XCTAssertEqualObjects(decodedLoadedInfo.dictionaryDescription,
                         @"{\n    descriptions = dict;\n}");
@@ -506,8 +510,10 @@
   XCTAssertEqualObjects(decodedLoadedInfo.error.localizedDescription, @"error");
   XCTAssertEqualObjects(decodedLoadedInfo.adSourceName, @"adSourceName");
   XCTAssertEqualObjects(decodedLoadedInfo.adSourceID, @"adSourceID");
-  XCTAssertEqualObjects(decodedLoadedInfo.adSourceInstanceName, @"adSourceInstanceName");
-  XCTAssertEqualObjects(decodedLoadedInfo.adSourceInstanceID, @"adSourceInstanceID");
+  XCTAssertEqualObjects(decodedLoadedInfo.adSourceInstanceName,
+                        @"adSourceInstanceName");
+  XCTAssertEqualObjects(decodedLoadedInfo.adSourceInstanceID,
+                        @"adSourceInstanceID");
 }
 
 - (void)testEncodeDecodeFLTGADLoadErrorWithEmptyValues {

--- a/packages/google_mobile_ads/ios/google_mobile_ads.podspec
+++ b/packages/google_mobile_ads/ios/google_mobile_ads.podspec
@@ -15,7 +15,7 @@ Google Mobile Ads plugin for Flutter.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'Google-Mobile-Ads-SDK','9.6.0'
+  s.dependency 'Google-Mobile-Ads-SDK','9.10.0'
   s.ios.deployment_target = '10.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS' => 'armv7 arm64 x86_64' }
   s.static_framework = true

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -66,9 +66,9 @@ class ResponseInfo {
   @protected
   const ResponseInfo(
       {this.responseId,
-        this.mediationAdapterClassName,
-        this.adapterResponses,
-        this.loadedAdapterResponseInfo});
+      this.mediationAdapterClassName,
+      this.adapterResponses,
+      this.loadedAdapterResponseInfo});
 
   /// An identifier for the loaded ad.
   final String? responseId;

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -65,7 +65,10 @@ class ResponseInfo {
   /// Constructs a [ResponseInfo] with the [responseId] and [mediationAdapterClassName].
   @protected
   const ResponseInfo(
-      {this.responseId, this.mediationAdapterClassName, this.adapterResponses});
+      {this.responseId,
+        this.mediationAdapterClassName,
+        this.adapterResponses,
+        this.loadedAdapterResponseInfo});
 
   /// An identifier for the loaded ad.
   final String? responseId;
@@ -79,11 +82,17 @@ class ResponseInfo {
   /// Can be used to debug the mediation waterfall execution.
   final List<AdapterResponseInfo>? adapterResponses;
 
+  /// The [AdapterResponseInfo] of the adapter that was used to load the ad.
+  ///
+  /// This is null if the ad failed to load.
+  final AdapterResponseInfo? loadedAdapterResponseInfo;
+
   @override
   String toString() {
     return '$runtimeType(responseId: $responseId, '
         'mediationAdapterClassName: $mediationAdapterClassName, '
-        'adapterResponses: $adapterResponses)';
+        'adapterResponses: $adapterResponses, '
+        'loadedAdapterResponseInfo: $loadedAdapterResponseInfo)';
   }
 }
 
@@ -96,6 +105,10 @@ class AdapterResponseInfo {
     required this.latencyMillis,
     required this.description,
     required this.adUnitMapping,
+    required this.adSourceName,
+    required this.adSourceId,
+    required this.adSourceInstanceName,
+    required this.adSourceInstanceId,
     this.adError,
   });
 
@@ -116,13 +129,36 @@ class AdapterResponseInfo {
   /// The error that occurred while rendering the ad.
   final AdError? adError;
 
+  /// The ad source name associated with this adapter response.
+  ///
+  /// This is an empty string "" if the ad server did not populate this field.
+  final String adSourceName;
+
+  /// The ad source ID associated with this adapter response.
+  ///
+  /// This is an empty string "" if the ad server did not populate this field.
+  final String adSourceId;
+
+  /// The ad source instance name associated with this adapter response.
+  ///
+  /// This is an empty string "" if the ad server did not populate this field.
+  final String adSourceInstanceName;
+
+  /// The ad source instance id associated with this adapter response.
+  ///
+  /// This is an empty string "" if the ad server did not populate this field.
+  final String adSourceInstanceId;
   @override
   String toString() {
     return '$runtimeType(adapterClassName: $adapterClassName, '
-        'latencyMillis: $latencyMillis), '
+        'latencyMillis: $latencyMillis, '
         'description: $description, '
         'adUnitMapping: $adUnitMapping, '
-        'adError: $adError)';
+        'adError: $adError, '
+        'adSourceName: $adSourceName, '
+        'adSourceId: $adSourceId, '
+        'adSourceInstanceName: $adSourceInstanceName, '
+        'adSourceInstanceId: $adSourceInstanceId)';
   }
 }
 

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -860,6 +860,7 @@ class AdMessageCodec extends StandardMessageCodec {
       writeValue(buffer, value.responseId);
       writeValue(buffer, value.mediationAdapterClassName);
       writeValue(buffer, value.adapterResponses);
+      writeValue(buffer, value.loadedAdapterResponseInfo);
     } else if (value is AdapterResponseInfo) {
       buffer.putUint8(_valueAdapterResponseInfo);
       writeValue(buffer, value.adapterClassName);
@@ -867,6 +868,10 @@ class AdMessageCodec extends StandardMessageCodec {
       writeValue(buffer, value.description);
       writeValue(buffer, value.adUnitMapping);
       writeValue(buffer, value.adError);
+      writeValue(buffer, value.adSourceName);
+      writeValue(buffer, value.adSourceId);
+      writeValue(buffer, value.adSourceInstanceName);
+      writeValue(buffer, value.adSourceInstanceId);
     } else if (value is LoadAdError) {
       buffer.putUint8(_valueLoadAdError);
       writeValue(buffer, value.code);
@@ -995,6 +1000,7 @@ class AdMessageCodec extends StandardMessageCodec {
           mediationAdapterClassName: readValueOfType(buffer.getUint8(), buffer),
           adapterResponses: readValueOfType(buffer.getUint8(), buffer)
               ?.cast<AdapterResponseInfo>(),
+          loadedAdapterResponseInfo: readValueOfType(buffer.getUint8(), buffer),
         );
       case _valueAdapterResponseInfo:
         return AdapterResponseInfo(
@@ -1003,7 +1009,11 @@ class AdMessageCodec extends StandardMessageCodec {
             description: readValueOfType(buffer.getUint8(), buffer),
             adUnitMapping:
                 _deepCastStringMap(readValueOfType(buffer.getUint8(), buffer)),
-            adError: readValueOfType(buffer.getUint8(), buffer));
+            adError: readValueOfType(buffer.getUint8(), buffer),
+            adSourceName: readValueOfType(buffer.getUint8(), buffer),
+            adSourceId: readValueOfType(buffer.getUint8(), buffer),
+            adSourceInstanceName: readValueOfType(buffer.getUint8(), buffer),
+            adSourceInstanceId: readValueOfType(buffer.getUint8(), buffer));
       case _valueLoadAdError:
         return LoadAdError(
           readValueOfType(buffer.getUint8(), buffer),

--- a/packages/google_mobile_ads/pubspec.yaml
+++ b/packages/google_mobile_ads/pubspec.yaml
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 name: google_mobile_ads
-version: 2.0.1
+version: 2.1.0
 description: Flutter plugin for Google Mobile Ads, supporting
   banner, interstitial (full-screen),  rewarded and native ads
 repository: https://github.com/googleads/googleads-mobile-flutter/tree/main/packages/google_mobile_ads

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -710,7 +710,12 @@ void main() {
           latencyMillis: 500,
           description: 'message',
           adUnitMapping: {'key': 'value'},
-          adError: adError);
+          adError: adError,
+          adSourceName: 'adSourceName',
+          adSourceId: 'adSourceId',
+          adSourceInstanceName: 'adSourceInstanceName',
+          adSourceInstanceId: 'adSourceInstanceId',
+        );
 
       List<AdapterResponseInfo> adapterResponses = [adapterResponseInfo];
       ResponseInfo responseInfo = ResponseInfo(
@@ -785,7 +790,12 @@ void main() {
           latencyMillis: 500,
           description: 'message',
           adUnitMapping: {'key': 'value'},
-          adError: adError);
+          adError: adError,
+          adSourceName: 'adSourceName',
+          adSourceId: 'adSourceId',
+          adSourceInstanceName: 'adSourceInstanceName',
+          adSourceInstanceId: 'adSourceInstanceId',
+        );
 
       List<AdapterResponseInfo> adapterResponses = [adapterResponseInfo];
       ResponseInfo responseInfo = ResponseInfo(
@@ -860,7 +870,12 @@ void main() {
           latencyMillis: 500,
           description: 'message',
           adUnitMapping: {'key': 'value'},
-          adError: adError);
+          adError: adError,
+          adSourceName: 'adSourceName',
+          adSourceId: 'adSourceId',
+          adSourceInstanceName: 'adSourceInstanceName',
+          adSourceInstanceId: 'adSourceInstanceId',
+        );
 
       List<AdapterResponseInfo> adapterResponses = [adapterResponseInfo];
       ResponseInfo responseInfo = ResponseInfo(
@@ -932,6 +947,92 @@ void main() {
       );
 
       expect(adEventCompleter.future, completion(native));
+    });
+
+    test('AdapterResponseInfo encoding', () async {
+      var testAdapterResponseInfo = (adId) async {
+        final Completer<Ad> loadCompleter = Completer<Ad>();
+
+        AdRequest request = AdRequest();
+        await RewardedAd.load(
+            adUnitId: 'test-ad-unit',
+            request: request,
+            rewardedAdLoadCallback: RewardedAdLoadCallback(
+                onAdLoaded: (ad) {
+                  loadCompleter.complete(ad);
+                },
+                onAdFailedToLoad: (error) => null));
+
+        AdapterResponseInfo adapterResponseInfo = AdapterResponseInfo(
+          adapterClassName: 'adapter-name',
+          latencyMillis: 500,
+          description: 'message',
+          adUnitMapping: {'key': 'value'},
+          adSourceName: 'adSourceName',
+          adSourceId: 'adSourceId',
+          adSourceInstanceName: 'adSourceInstanceName',
+          adSourceInstanceId: 'adSourceInstanceId',
+        );
+        final loadedAdapterResponseInfo = AdapterResponseInfo(
+          adapterClassName: 'adapter-name',
+          latencyMillis: 500,
+          description: 'message',
+          adUnitMapping: {'key': 'value'},
+          adSourceName: 'adSourceName',
+          adSourceId: 'adSourceId',
+          adSourceInstanceName: 'adSourceInstanceName',
+          adSourceInstanceId: 'adSourceInstanceId',
+        );
+
+        final responseInfo = ResponseInfo(
+          mediationAdapterClassName: 'adapter',
+          adapterResponses: [adapterResponseInfo],
+          responseId: 'id',
+          loadedAdapterResponseInfo: loadedAdapterResponseInfo,
+        );
+        final methodCall = MethodCall('onAdEvent', <dynamic, dynamic>{
+          'adId': adId,
+          'eventName': 'onAdLoaded',
+          'responseInfo': responseInfo,
+        });
+
+        ByteData data =
+        instanceManager.channel.codec.encodeMethodCall(methodCall);
+
+        await instanceManager.channel.binaryMessenger.handlePlatformMessage(
+          'plugins.flutter.io/google_mobile_ads',
+          data,
+              (ByteData? data) {},
+        );
+        final ad = await loadCompleter.future;
+
+        expect(ad.responseInfo!.mediationAdapterClassName!, 'adapter');
+        expect(ad.responseInfo!.responseId!, 'id');
+        final adapterResponse = ad.responseInfo!.adapterResponses!.first;
+        expect(adapterResponse.adapterClassName, 'adapter-name');
+        expect(adapterResponse.latencyMillis, 500);
+        expect(adapterResponse.description, 'message');
+        expect(adapterResponse.adUnitMapping, {'key': 'value'});
+        expect(adapterResponse.adSourceName, 'adSourceName');
+        expect(adapterResponse.adSourceId, 'adSourceId');
+        expect(adapterResponse.adSourceInstanceName, 'adSourceInstanceName');
+        expect(adapterResponse.adSourceInstanceId, 'adSourceInstanceId');
+        final loadedResponse = ad.responseInfo!.loadedAdapterResponseInfo!;
+        expect(loadedResponse.adapterClassName, 'adapter-name');
+        expect(loadedResponse.latencyMillis, 500);
+        expect(loadedResponse.description, 'message');
+        expect(loadedResponse.adUnitMapping, {'key': 'value'});
+        expect(loadedResponse.adSourceName, 'adSourceName');
+        expect(loadedResponse.adSourceId, 'adSourceId');
+        expect(loadedResponse.adSourceInstanceName, 'adSourceInstanceName');
+        expect(loadedResponse.adSourceInstanceId, 'adSourceInstanceId');
+
+      };
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      await testAdapterResponseInfo(0);
+
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      await testAdapterResponseInfo(1);
     });
 
     test('onRewardedAdUserEarnedReward', () async {

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -706,16 +706,16 @@ void main() {
       // Simulate onAdFailedToLoad.
       AdError adError = AdError(1, 'domain', 'error-message');
       AdapterResponseInfo adapterResponseInfo = AdapterResponseInfo(
-          adapterClassName: 'adapter-name',
-          latencyMillis: 500,
-          description: 'message',
-          adUnitMapping: {'key': 'value'},
-          adError: adError,
-          adSourceName: 'adSourceName',
-          adSourceId: 'adSourceId',
-          adSourceInstanceName: 'adSourceInstanceName',
-          adSourceInstanceId: 'adSourceInstanceId',
-        );
+        adapterClassName: 'adapter-name',
+        latencyMillis: 500,
+        description: 'message',
+        adUnitMapping: {'key': 'value'},
+        adError: adError,
+        adSourceName: 'adSourceName',
+        adSourceId: 'adSourceId',
+        adSourceInstanceName: 'adSourceInstanceName',
+        adSourceInstanceId: 'adSourceInstanceId',
+      );
 
       List<AdapterResponseInfo> adapterResponses = [adapterResponseInfo];
       ResponseInfo responseInfo = ResponseInfo(
@@ -786,16 +786,16 @@ void main() {
       // Simulate onAdFailedToLoad.
       AdError adError = AdError(1, 'domain', 'error-message');
       AdapterResponseInfo adapterResponseInfo = AdapterResponseInfo(
-          adapterClassName: 'adapter-name',
-          latencyMillis: 500,
-          description: 'message',
-          adUnitMapping: {'key': 'value'},
-          adError: adError,
-          adSourceName: 'adSourceName',
-          adSourceId: 'adSourceId',
-          adSourceInstanceName: 'adSourceInstanceName',
-          adSourceInstanceId: 'adSourceInstanceId',
-        );
+        adapterClassName: 'adapter-name',
+        latencyMillis: 500,
+        description: 'message',
+        adUnitMapping: {'key': 'value'},
+        adError: adError,
+        adSourceName: 'adSourceName',
+        adSourceId: 'adSourceId',
+        adSourceInstanceName: 'adSourceInstanceName',
+        adSourceInstanceId: 'adSourceInstanceId',
+      );
 
       List<AdapterResponseInfo> adapterResponses = [adapterResponseInfo];
       ResponseInfo responseInfo = ResponseInfo(
@@ -866,16 +866,16 @@ void main() {
       // Simulate onAdFailedToLoad.
       AdError adError = AdError(1, 'domain', 'error-message');
       AdapterResponseInfo adapterResponseInfo = AdapterResponseInfo(
-          adapterClassName: 'adapter-name',
-          latencyMillis: 500,
-          description: 'message',
-          adUnitMapping: {'key': 'value'},
-          adError: adError,
-          adSourceName: 'adSourceName',
-          adSourceId: 'adSourceId',
-          adSourceInstanceName: 'adSourceInstanceName',
-          adSourceInstanceId: 'adSourceInstanceId',
-        );
+        adapterClassName: 'adapter-name',
+        latencyMillis: 500,
+        description: 'message',
+        adUnitMapping: {'key': 'value'},
+        adError: adError,
+        adSourceName: 'adSourceName',
+        adSourceId: 'adSourceId',
+        adSourceInstanceName: 'adSourceInstanceName',
+        adSourceInstanceId: 'adSourceInstanceId',
+      );
 
       List<AdapterResponseInfo> adapterResponses = [adapterResponseInfo];
       ResponseInfo responseInfo = ResponseInfo(
@@ -997,12 +997,12 @@ void main() {
         });
 
         ByteData data =
-        instanceManager.channel.codec.encodeMethodCall(methodCall);
+            instanceManager.channel.codec.encodeMethodCall(methodCall);
 
         await instanceManager.channel.binaryMessenger.handlePlatformMessage(
           'plugins.flutter.io/google_mobile_ads',
           data,
-              (ByteData? data) {},
+          (ByteData? data) {},
         );
         final ad = await loadCompleter.future;
 
@@ -1026,7 +1026,6 @@ void main() {
         expect(loadedResponse.adSourceId, 'adSourceId');
         expect(loadedResponse.adSourceInstanceName, 'adSourceInstanceName');
         expect(loadedResponse.adSourceInstanceId, 'adSourceInstanceId');
-
       };
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
       await testAdapterResponseInfo(0);

--- a/packages/google_mobile_ads/test/admanager_banner_ad_test.dart
+++ b/packages/google_mobile_ads/test/admanager_banner_ad_test.dart
@@ -147,7 +147,12 @@ void main() {
             latencyMillis: 500,
             description: 'message',
             adUnitMapping: {'key': 'value'},
-            adError: adError);
+            adError: adError,
+            adSourceName: 'adSourceName',
+            adSourceId: 'adSourceId',
+            adSourceInstanceName: 'adSourceInstanceName',
+            adSourceInstanceId: 'adSourceInstanceId',
+          );
 
         List<AdapterResponseInfo> adapterResponses = [adapterResponseInfo];
         ResponseInfo responseInfo = ResponseInfo(

--- a/packages/google_mobile_ads/test/admanager_banner_ad_test.dart
+++ b/packages/google_mobile_ads/test/admanager_banner_ad_test.dart
@@ -143,16 +143,16 @@ void main() {
         await banner.load();
         AdError adError = AdError(1, 'domain', 'error-message');
         AdapterResponseInfo adapterResponseInfo = AdapterResponseInfo(
-            adapterClassName: 'adapter-name',
-            latencyMillis: 500,
-            description: 'message',
-            adUnitMapping: {'key': 'value'},
-            adError: adError,
-            adSourceName: 'adSourceName',
-            adSourceId: 'adSourceId',
-            adSourceInstanceName: 'adSourceInstanceName',
-            adSourceInstanceId: 'adSourceInstanceId',
-          );
+          adapterClassName: 'adapter-name',
+          latencyMillis: 500,
+          description: 'message',
+          adUnitMapping: {'key': 'value'},
+          adError: adError,
+          adSourceName: 'adSourceName',
+          adSourceId: 'adSourceId',
+          adSourceInstanceName: 'adSourceInstanceName',
+          adSourceInstanceId: 'adSourceInstanceId',
+        );
 
         List<AdapterResponseInfo> adapterResponses = [adapterResponseInfo];
         ResponseInfo responseInfo = ResponseInfo(

--- a/packages/google_mobile_ads/test/banner_ad_test.dart
+++ b/packages/google_mobile_ads/test/banner_ad_test.dart
@@ -142,16 +142,16 @@ void main() {
         await banner.load();
         AdError adError = AdError(1, 'domain', 'error-message');
         AdapterResponseInfo adapterResponseInfo = AdapterResponseInfo(
-            adapterClassName: 'adapter-name',
-            latencyMillis: 500,
-            description: 'message',
-            adUnitMapping: {'key': 'value'},
-            adError: adError,
-            adSourceName: 'adSourceName',
-            adSourceId: 'adSourceId',
-            adSourceInstanceName: 'adSourceInstanceName',
-            adSourceInstanceId: 'adSourceInstanceId',
-          );
+          adapterClassName: 'adapter-name',
+          latencyMillis: 500,
+          description: 'message',
+          adUnitMapping: {'key': 'value'},
+          adError: adError,
+          adSourceName: 'adSourceName',
+          adSourceId: 'adSourceId',
+          adSourceInstanceName: 'adSourceInstanceName',
+          adSourceInstanceId: 'adSourceInstanceId',
+        );
 
         List<AdapterResponseInfo> adapterResponses = [adapterResponseInfo];
         ResponseInfo responseInfo = ResponseInfo(

--- a/packages/google_mobile_ads/test/banner_ad_test.dart
+++ b/packages/google_mobile_ads/test/banner_ad_test.dart
@@ -146,7 +146,12 @@ void main() {
             latencyMillis: 500,
             description: 'message',
             adUnitMapping: {'key': 'value'},
-            adError: adError);
+            adError: adError,
+            adSourceName: 'adSourceName',
+            adSourceId: 'adSourceId',
+            adSourceInstanceName: 'adSourceInstanceName',
+            adSourceInstanceId: 'adSourceInstanceId',
+          );
 
         List<AdapterResponseInfo> adapterResponses = [adapterResponseInfo];
         ResponseInfo responseInfo = ResponseInfo(

--- a/packages/google_mobile_ads/test/rewarded_interstitial_ad_test.dart
+++ b/packages/google_mobile_ads/test/rewarded_interstitial_ad_test.dart
@@ -324,7 +324,12 @@ void main() {
           latencyMillis: 500,
           description: 'message',
           adUnitMapping: {'key': 'value'},
-          adError: adError);
+          adError: adError,
+          adSourceName: 'adSourceName',
+          adSourceId: 'adSourceId',
+          adSourceInstanceName: 'adSourceInstanceName',
+          adSourceInstanceId: 'adSourceInstanceId',
+        );
 
       List<AdapterResponseInfo> adapterResponses = [adapterResponseInfo];
       ResponseInfo responseInfo = ResponseInfo(

--- a/packages/google_mobile_ads/test/rewarded_interstitial_ad_test.dart
+++ b/packages/google_mobile_ads/test/rewarded_interstitial_ad_test.dart
@@ -320,16 +320,16 @@ void main() {
       // Simulate onAdFailedToLoad.
       AdError adError = AdError(1, 'domain', 'error-message');
       AdapterResponseInfo adapterResponseInfo = AdapterResponseInfo(
-          adapterClassName: 'adapter-name',
-          latencyMillis: 500,
-          description: 'message',
-          adUnitMapping: {'key': 'value'},
-          adError: adError,
-          adSourceName: 'adSourceName',
-          adSourceId: 'adSourceId',
-          adSourceInstanceName: 'adSourceInstanceName',
-          adSourceInstanceId: 'adSourceInstanceId',
-        );
+        adapterClassName: 'adapter-name',
+        latencyMillis: 500,
+        description: 'message',
+        adUnitMapping: {'key': 'value'},
+        adError: adError,
+        adSourceName: 'adSourceName',
+        adSourceId: 'adSourceId',
+        adSourceInstanceName: 'adSourceInstanceName',
+        adSourceInstanceId: 'adSourceInstanceId',
+      );
 
       List<AdapterResponseInfo> adapterResponses = [adapterResponseInfo];
       ResponseInfo responseInfo = ResponseInfo(


### PR DESCRIPTION
Adds support for new APIs from the latest android and iOS GMA releases:
* `ResponseInfo.loadedAdapterResponseInfo`
* `AdapterResponse.adSourceName`
* `AdapterResponse.adSourceId`
* `AdapterResponse.adSourceInstanceName`
* `AdapterResponse.adSourceInstanceId`

b/236135467