### PR TITLE
Add ResponseInfo.responseExtras

### DIFF
--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
@@ -130,6 +130,7 @@ class AdMessageCodec extends StandardMessageCodec {
       writeValue(stream, responseInfo.getMediationAdapterClassName());
       writeValue(stream, responseInfo.getAdapterResponses());
       writeValue(stream, responseInfo.getLoadedAdapterResponseInfo());
+      writeValue(stream, responseInfo.getResponseExtras());
     } else if (value instanceof FlutterAd.FlutterLoadAdError) {
       stream.write(VALUE_LOAD_AD_ERROR);
       final FlutterAd.FlutterLoadAdError error = (FlutterAd.FlutterLoadAdError) value;
@@ -255,7 +256,8 @@ class AdMessageCodec extends StandardMessageCodec {
             (String) readValueOfType(buffer.get(), buffer),
             (String) readValueOfType(buffer.get(), buffer),
             (List<FlutterAdapterResponseInfo>) readValueOfType(buffer.get(), buffer),
-            (FlutterAdapterResponseInfo) readValueOfType(buffer.get(), buffer));
+            (FlutterAdapterResponseInfo) readValueOfType(buffer.get(), buffer),
+            (Map<String, String>) readValueOfType(buffer.get(), buffer));
       case VALUE_LOAD_AD_ERROR:
         return new FlutterAd.FlutterLoadAdError(
             (Integer) readValueOfType(buffer.get(), buffer),

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAd.java
@@ -53,6 +53,7 @@ abstract class FlutterAd {
     @Nullable private final String mediationAdapterClassName;
     @NonNull private final List<FlutterAdapterResponseInfo> adapterResponses;
     @Nullable private final FlutterAdapterResponseInfo loadedAdapterResponseInfo;
+    @NonNull private final Map<String, String> responseExtras;
 
     FlutterResponseInfo(@NonNull ResponseInfo responseInfo) {
       this.responseId = responseInfo.getResponseId();
@@ -68,17 +69,28 @@ abstract class FlutterAd {
       } else {
         this.loadedAdapterResponseInfo = null;
       }
+      Map<String, String> extras = new HashMap<>();
+      if (responseInfo.getResponseExtras() != null) {
+        for (String key : responseInfo.getResponseExtras().keySet()) {
+          Object value = responseInfo.getResponseExtras().get(key);
+          extras.put(key, value.toString());
+        }
+      }
+
+      this.responseExtras = extras;
     }
 
     FlutterResponseInfo(
         @Nullable String responseId,
         @Nullable String mediationAdapterClassName,
         @NonNull List<FlutterAdapterResponseInfo> adapterResponseInfos,
-        @Nullable FlutterAdapterResponseInfo loadedAdapterResponseInfo) {
+        @Nullable FlutterAdapterResponseInfo loadedAdapterResponseInfo,
+        @NonNull Map<String, String> responseExtras) {
       this.responseId = responseId;
       this.mediationAdapterClassName = mediationAdapterClassName;
       this.adapterResponses = adapterResponseInfos;
       this.loadedAdapterResponseInfo = loadedAdapterResponseInfo;
+      this.responseExtras = responseExtras;
     }
 
     @Nullable
@@ -99,6 +111,11 @@ abstract class FlutterAd {
     @Nullable
     FlutterAdapterResponseInfo getLoadedAdapterResponseInfo() {
       return loadedAdapterResponseInfo;
+    }
+
+    @NonNull
+    Map<String, String> getResponseExtras() {
+      return responseExtras;
     }
 
     @Override

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
@@ -344,9 +344,14 @@ public class AdMessageCodecTest {
             "adSourceId",
             "adSourceInstanceName",
             "adSourceInstanceId");
+    Map<String, String> responseExtras = Collections.singletonMap("key", "value");
     FlutterResponseInfo info =
         new FlutterResponseInfo(
-            "responseId", "className", adapterResponseInfos, loadedAdapterResponseInfo);
+            "responseId",
+            "className",
+            adapterResponseInfos,
+            loadedAdapterResponseInfo,
+            responseExtras);
     final ByteBuffer message =
         codec.encodeMessage(new FlutterBannerAd.FlutterLoadAdError(1, "domain", "message", info));
 

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.h
@@ -118,6 +118,7 @@
 @property NSString *_Nullable adNetworkClassName;
 @property NSArray<FLTGADAdNetworkResponseInfo *> *_Nullable adNetworkInfoArray;
 @property FLTGADAdNetworkResponseInfo *_Nullable loadedAdNetworkResponseInfo;
+@property NSDictionary<NSString *, id> *_Nullable extrasDictionary;
 
 - (instancetype _Nonnull)initWithResponseInfo:
     (GADResponseInfo *_Nonnull)responseInfo;

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
@@ -245,7 +245,8 @@
     _adNetworkInfoArray = infoArray;
     _loadedAdNetworkResponseInfo = [[FLTGADAdNetworkResponseInfo alloc]
         initWithResponseInfo:responseInfo.loadedAdNetworkResponseInfo];
-    _extrasDictionary = responseInfo.extrasDictionary;
+    _extrasDictionary =
+        responseInfo.extrasDictionary ? responseInfo.extrasDictionary : @{};
   }
   return self;
 }

--- a/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTAd_Internal.m
@@ -245,6 +245,7 @@
     _adNetworkInfoArray = infoArray;
     _loadedAdNetworkResponseInfo = [[FLTGADAdNetworkResponseInfo alloc]
         initWithResponseInfo:responseInfo.loadedAdNetworkResponseInfo];
+    _extrasDictionary = responseInfo.extrasDictionary;
   }
   return self;
 }

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
@@ -116,7 +116,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     FLTGADAdNetworkResponseInfo *loadedResponseInfo =
         [self readValueOfType:[self readByte]];
     NSDictionary<NSString *, id> *extrasDictionary =
-      [self readValueOfType:[self readByte]];
+        [self readValueOfType:[self readByte]];
     FLTGADResponseInfo *gadResponseInfo = [[FLTGADResponseInfo alloc] init];
     gadResponseInfo.adNetworkClassName = adNetworkClassName;
     gadResponseInfo.responseIdentifier = responseIdentifier;
@@ -147,7 +147,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     adNetworkResponseInfo.adSourceID = adSourceID;
     adNetworkResponseInfo.adSourceInstanceName = adSourceInstanceName;
     adNetworkResponseInfo.adSourceInstanceID = adSourceInstanceID;
-    
+
     return adNetworkResponseInfo;
   }
   case FLTAdMobFieldLoadError: {

--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsReaderWriter_Internal.m
@@ -115,11 +115,14 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
         [self readValueOfType:[self readByte]];
     FLTGADAdNetworkResponseInfo *loadedResponseInfo =
         [self readValueOfType:[self readByte]];
+    NSDictionary<NSString *, id> *extrasDictionary =
+      [self readValueOfType:[self readByte]];
     FLTGADResponseInfo *gadResponseInfo = [[FLTGADResponseInfo alloc] init];
     gadResponseInfo.adNetworkClassName = adNetworkClassName;
     gadResponseInfo.responseIdentifier = responseIdentifier;
     gadResponseInfo.adNetworkInfoArray = adNetworkInfoArray;
     gadResponseInfo.loadedAdNetworkResponseInfo = loadedResponseInfo;
+    gadResponseInfo.extrasDictionary = extrasDictionary;
     return gadResponseInfo;
   }
   case FLTAdmobFieldGADAdNetworkResponseInfo: {
@@ -133,7 +136,6 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     NSString *adSourceID = [self readValueOfType:[self readByte]];
     NSString *adSourceInstanceName = [self readValueOfType:[self readByte]];
     NSString *adSourceInstanceID = [self readValueOfType:[self readByte]];
-
     FLTGADAdNetworkResponseInfo *adNetworkResponseInfo =
         [[FLTGADAdNetworkResponseInfo alloc] init];
     adNetworkResponseInfo.adNetworkClassName = adNetworkClassName;
@@ -145,6 +147,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     adNetworkResponseInfo.adSourceID = adSourceID;
     adNetworkResponseInfo.adSourceInstanceName = adSourceInstanceName;
     adNetworkResponseInfo.adSourceInstanceID = adSourceInstanceID;
+    
     return adNetworkResponseInfo;
   }
   case FLTAdMobFieldLoadError: {
@@ -320,11 +323,12 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     [self writeValue:item.type];
   } else if ([value isKindOfClass:[FLTGADResponseInfo class]]) {
     [self writeByte:FLTAdmobFieldGadResponseInfo];
-    GADResponseInfo *responseInfo = value;
+    FLTGADResponseInfo *responseInfo = value;
     [self writeValue:responseInfo.responseIdentifier];
     [self writeValue:responseInfo.adNetworkClassName];
     [self writeValue:responseInfo.adNetworkInfoArray];
     [self writeValue:responseInfo.loadedAdNetworkResponseInfo];
+    [self writeValue:responseInfo.extrasDictionary];
   } else if ([value isKindOfClass:[FLTGADAdNetworkResponseInfo class]]) {
     [self writeByte:FLTAdmobFieldGADAdNetworkResponseInfo];
     FLTGADAdNetworkResponseInfo *networkResponseInfo = value;

--- a/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
+++ b/packages/google_mobile_ads/ios/Tests/FLTGoogleMobileAdsReaderWriterTest.m
@@ -476,6 +476,7 @@
   responseInfo.responseIdentifier = @"identifier";
   responseInfo.adNetworkInfoArray = @[ adNetworkResponseInfo ];
   responseInfo.loadedAdNetworkResponseInfo = loadedNetworkResponseInfo;
+  responseInfo.extrasDictionary = @{@"key" : @"value"};
 
   NSData *encodedMessage = [_messageCodec encode:responseInfo];
   FLTGADResponseInfo *decodedResponseInfo =
@@ -483,6 +484,8 @@
 
   XCTAssertEqualObjects(decodedResponseInfo.adNetworkClassName, @"class-name");
   XCTAssertEqualObjects(decodedResponseInfo.responseIdentifier, @"identifier");
+  XCTAssertEqualObjects(decodedResponseInfo.extrasDictionary,
+                        @{@"key" : @"value"});
   XCTAssertEqual(decodedResponseInfo.adNetworkInfoArray.count, 1);
 
   FLTGADAdNetworkResponseInfo *decodedInfo =

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -68,7 +68,8 @@ class ResponseInfo {
       {this.responseId,
       this.mediationAdapterClassName,
       this.adapterResponses,
-      this.loadedAdapterResponseInfo});
+      this.loadedAdapterResponseInfo,
+      required this.responseExtras});
 
   /// An identifier for the loaded ad.
   final String? responseId;
@@ -87,12 +88,16 @@ class ResponseInfo {
   /// This is null if the ad failed to load.
   final AdapterResponseInfo? loadedAdapterResponseInfo;
 
+  /// Map of extra information about the ad response.
+  final Map<String, dynamic> responseExtras;
+
   @override
   String toString() {
     return '$runtimeType(responseId: $responseId, '
         'mediationAdapterClassName: $mediationAdapterClassName, '
         'adapterResponses: $adapterResponses, '
-        'loadedAdapterResponseInfo: $loadedAdapterResponseInfo)';
+        'loadedAdapterResponseInfo: $loadedAdapterResponseInfo), '
+        'responseExtras: $responseExtras';
   }
 }
 

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -861,6 +861,7 @@ class AdMessageCodec extends StandardMessageCodec {
       writeValue(buffer, value.mediationAdapterClassName);
       writeValue(buffer, value.adapterResponses);
       writeValue(buffer, value.loadedAdapterResponseInfo);
+      writeValue(buffer, value.responseExtras);
     } else if (value is AdapterResponseInfo) {
       buffer.putUint8(_valueAdapterResponseInfo);
       writeValue(buffer, value.adapterClassName);
@@ -1001,6 +1002,8 @@ class AdMessageCodec extends StandardMessageCodec {
           adapterResponses: readValueOfType(buffer.getUint8(), buffer)
               ?.cast<AdapterResponseInfo>(),
           loadedAdapterResponseInfo: readValueOfType(buffer.getUint8(), buffer),
+          responseExtras: _deepCastStringKeyDynamicValueMap(
+              readValueOfType(buffer.getUint8(), buffer)),
         );
       case _valueAdapterResponseInfo:
         return AdapterResponseInfo(
@@ -1123,6 +1126,17 @@ class AdMessageCodec extends StandardMessageCodec {
     if (map == null) return {};
     return map.map<String, String>(
       (dynamic key, dynamic value) => MapEntry<String, String>(
+        key,
+        value,
+      ),
+    );
+  }
+
+  Map<String, dynamic> _deepCastStringKeyDynamicValueMap(
+      Map<dynamic, dynamic>? map) {
+    if (map == null) return {};
+    return map.map<String, dynamic>(
+      (dynamic key, dynamic value) => MapEntry<String, dynamic>(
         key,
         value,
       ),

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -722,6 +722,7 @@ void main() {
         responseId: 'id',
         mediationAdapterClassName: 'className',
         adapterResponses: adapterResponses,
+        responseExtras: {'key1': 'value1'},
       );
 
       final MethodCall methodCall = MethodCall('onAdEvent', <dynamic, dynamic>{
@@ -750,6 +751,7 @@ void main() {
       expect(result.responseInfo!.responseId, responseInfo.responseId);
       expect(result.responseInfo!.mediationAdapterClassName,
           responseInfo.mediationAdapterClassName);
+      expect(result.responseInfo!.responseExtras, responseInfo.responseExtras);
       List<AdapterResponseInfo> responses =
           result.responseInfo!.adapterResponses!;
       expect(responses.first.adapterClassName, 'adapter-name');
@@ -802,6 +804,7 @@ void main() {
         responseId: 'id',
         mediationAdapterClassName: 'className',
         adapterResponses: adapterResponses,
+        responseExtras: {},
       );
 
       final MethodCall methodCall = MethodCall('onAdEvent', <dynamic, dynamic>{
@@ -830,6 +833,7 @@ void main() {
       expect(result.responseInfo!.responseId, responseInfo.responseId);
       expect(result.responseInfo!.mediationAdapterClassName,
           responseInfo.mediationAdapterClassName);
+      expect(result.responseInfo!.responseExtras, responseInfo.responseExtras);
       List<AdapterResponseInfo> responses =
           result.responseInfo!.adapterResponses!;
       expect(responses.first.adapterClassName, 'adapter-name');
@@ -882,6 +886,7 @@ void main() {
         responseId: 'id',
         mediationAdapterClassName: 'className',
         adapterResponses: adapterResponses,
+        responseExtras: {'key1': 1234},
       );
 
       final MethodCall methodCall = MethodCall('onAdEvent', <dynamic, dynamic>{
@@ -910,6 +915,7 @@ void main() {
       expect(result.responseInfo!.responseId, responseInfo.responseId);
       expect(result.responseInfo!.mediationAdapterClassName,
           responseInfo.mediationAdapterClassName);
+      expect(result.responseInfo!.responseExtras, responseInfo.responseExtras);
       List<AdapterResponseInfo> responses =
           result.responseInfo!.adapterResponses!;
       expect(responses.first.adapterClassName, 'adapter-name');
@@ -989,6 +995,7 @@ void main() {
           adapterResponses: [adapterResponseInfo],
           responseId: 'id',
           loadedAdapterResponseInfo: loadedAdapterResponseInfo,
+          responseExtras: {},
         );
         final methodCall = MethodCall('onAdEvent', <dynamic, dynamic>{
           'adId': adId,
@@ -1008,6 +1015,7 @@ void main() {
 
         expect(ad.responseInfo!.mediationAdapterClassName!, 'adapter');
         expect(ad.responseInfo!.responseId!, 'id');
+        expect(ad.responseInfo!.responseExtras, responseInfo.responseExtras);
         final adapterResponse = ad.responseInfo!.adapterResponses!.first;
         expect(adapterResponse.adapterClassName, 'adapter-name');
         expect(adapterResponse.latencyMillis, 500);
@@ -1247,9 +1255,11 @@ void main() {
 
     test('encode/decode $LoadAdError', () async {
       final ResponseInfo responseInfo = ResponseInfo(
-          responseId: 'id',
-          mediationAdapterClassName: 'class',
-          adapterResponses: null);
+        responseId: 'id',
+        mediationAdapterClassName: 'class',
+        adapterResponses: null,
+        responseExtras: {},
+      );
       final ByteData byteData = codec.encodeMessage(
         LoadAdError(1, 'domain', 'message', responseInfo),
       )!;
@@ -1258,6 +1268,7 @@ void main() {
       expect(error.domain, 'domain');
       expect(error.message, 'message');
       expect(error.responseInfo?.responseId, responseInfo.responseId);
+      expect(error.responseInfo?.responseExtras, responseInfo.responseExtras);
       expect(error.responseInfo?.mediationAdapterClassName,
           responseInfo.mediationAdapterClassName);
       expect(error.responseInfo?.adapterResponses, null);

--- a/packages/google_mobile_ads/test/admanager_banner_ad_test.dart
+++ b/packages/google_mobile_ads/test/admanager_banner_ad_test.dart
@@ -159,6 +159,7 @@ void main() {
           responseId: 'id',
           mediationAdapterClassName: 'className',
           adapterResponses: adapterResponses,
+          responseExtras: {'key': 'value'},
         );
 
         final MethodCall methodCall =
@@ -185,6 +186,8 @@ void main() {
         expect(results[1].responseInfo.responseId, responseInfo.responseId);
         expect(results[1].responseInfo.mediationAdapterClassName,
             responseInfo.mediationAdapterClassName);
+        expect(results[1].responseInfo.responseExtras,
+            responseInfo.responseExtras);
         List<AdapterResponseInfo> responses =
             results[1].responseInfo.adapterResponses;
         expect(responses.first.adapterClassName, 'adapter-name');

--- a/packages/google_mobile_ads/test/banner_ad_test.dart
+++ b/packages/google_mobile_ads/test/banner_ad_test.dart
@@ -158,6 +158,7 @@ void main() {
           responseId: 'id',
           mediationAdapterClassName: 'className',
           adapterResponses: adapterResponses,
+          responseExtras: {'key': 'value'},
         );
 
         final MethodCall methodCall =
@@ -184,6 +185,8 @@ void main() {
         expect(results[1].responseInfo.responseId, responseInfo.responseId);
         expect(results[1].responseInfo.mediationAdapterClassName,
             responseInfo.mediationAdapterClassName);
+        expect(results[1].responseInfo.responseExtras,
+            responseInfo.responseExtras);
         List<AdapterResponseInfo> responses =
             results[1].responseInfo.adapterResponses;
         expect(responses.first.adapterClassName, 'adapter-name');

--- a/packages/google_mobile_ads/test/rewarded_interstitial_ad_test.dart
+++ b/packages/google_mobile_ads/test/rewarded_interstitial_ad_test.dart
@@ -336,6 +336,7 @@ void main() {
         responseId: 'id',
         mediationAdapterClassName: 'className',
         adapterResponses: adapterResponses,
+        responseExtras: {'key': 12345},
       );
 
       final MethodCall methodCall = MethodCall('onAdEvent', <dynamic, dynamic>{
@@ -364,6 +365,7 @@ void main() {
       expect(result.responseInfo!.responseId, responseInfo.responseId);
       expect(result.responseInfo!.mediationAdapterClassName,
           responseInfo.mediationAdapterClassName);
+      expect(result.responseInfo!.responseExtras, responseInfo.responseExtras);
       List<AdapterResponseInfo> responses =
           result.responseInfo!.adapterResponses!;
       expect(responses.first.adapterClassName, 'adapter-name');


### PR DESCRIPTION
## Description

Add support for `ResponseInfo.responseExtras`: 
* https://developers.google.com/android/reference/com/google/android/gms/ads/ResponseInfo#getResponseExtras()
* https://developers.google.com/admob/ios/api/reference/Classes/GADResponseInfo#extrasdictionary

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.