### PR TITLE
Update google_mobile_ads.podspec

### DIFF
--- a/packages/google_mobile_ads/ios/google_mobile_ads.podspec
+++ b/packages/google_mobile_ads/ios/google_mobile_ads.podspec
@@ -15,7 +15,7 @@ Google Mobile Ads plugin for Flutter.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'Google-Mobile-Ads-SDK','9.10.0'
+  s.dependency 'Google-Mobile-Ads-SDK','~> 9.11'
   s.ios.deployment_target = '10.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS' => 'armv7 arm64 x86_64' }
   s.static_framework = true


### PR DESCRIPTION
## Description

Firebase packages were recently updated including FirebaseAnalytics which depends on GoogleMeasurement 10.0. The current podspec depends on GoogleMobileAdsSDK pod which is < 10.0. This is a dependency update and allows users building with new Firebase SDK 10.0 to build ios without dependency error.

## Related Issues

Closes #673

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
