### PR TITLE
Add null checks to adapter response info decoding

### DIFF
--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAd.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAd.java
@@ -148,10 +148,10 @@ abstract class FlutterAd {
     @NonNull private final String description;
     @NonNull private final Map<String, String> adUnitMapping;
     @Nullable private FlutterAdError error;
-    @Nullable private String adSourceName;
-    @Nullable private String adSourceId;
-    @Nullable private String adSourceInstanceName;
-    @Nullable private String adSourceInstanceId;
+    @NonNull private final String adSourceName;
+    @NonNull private final String adSourceId;
+    @NonNull private final String adSourceInstanceName;
+    @NonNull private final String adSourceInstanceId;
 
     FlutterAdapterResponseInfo(@NonNull AdapterResponseInfo responseInfo) {
       this.adapterClassName = responseInfo.getAdapterClassName();
@@ -180,10 +180,10 @@ abstract class FlutterAd {
         @NonNull String description,
         @NonNull Map<String, String> adUnitMapping,
         @Nullable FlutterAdError error,
-        @Nullable String adSourceName,
-        @Nullable String adSourceId,
-        @Nullable String adSourceInstanceName,
-        @Nullable String adSourceInstanceId) {
+        @NonNull String adSourceName,
+        @NonNull String adSourceId,
+        @NonNull String adSourceInstanceName,
+        @NonNull String adSourceInstanceId) {
       this.adapterClassName = adapterClassName;
       this.latencyMillis = latencyMillis;
       this.description = description;
@@ -219,22 +219,22 @@ abstract class FlutterAd {
       return error;
     }
 
-    @Nullable
+    @NonNull
     public String getAdSourceName() {
       return adSourceName;
     }
 
-    @Nullable
+    @NonNull
     public String getAdSourceId() {
       return adSourceId;
     }
 
-    @Nullable
+    @NonNull
     public String getAdSourceInstanceName() {
       return adSourceInstanceName;
     }
 
-    @Nullable
+    @NonNull
     public String getAdSourceInstanceId() {
       return adSourceInstanceId;
     }

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -1007,16 +1007,16 @@ class AdMessageCodec extends StandardMessageCodec {
         );
       case _valueAdapterResponseInfo:
         return AdapterResponseInfo(
-            adapterClassName: readValueOfType(buffer.getUint8(), buffer),
+            adapterClassName: _safeReadString(buffer),
             latencyMillis: readValueOfType(buffer.getUint8(), buffer),
-            description: readValueOfType(buffer.getUint8(), buffer),
+            description: _safeReadString(buffer),
             adUnitMapping:
                 _deepCastStringMap(readValueOfType(buffer.getUint8(), buffer)),
             adError: readValueOfType(buffer.getUint8(), buffer),
-            adSourceName: readValueOfType(buffer.getUint8(), buffer),
-            adSourceId: readValueOfType(buffer.getUint8(), buffer),
-            adSourceInstanceName: readValueOfType(buffer.getUint8(), buffer),
-            adSourceInstanceId: readValueOfType(buffer.getUint8(), buffer));
+            adSourceName: _safeReadString(buffer),
+            adSourceId: _safeReadString(buffer),
+            adSourceInstanceName: _safeReadString(buffer),
+            adSourceInstanceId: _safeReadString(buffer));
       case _valueLoadAdError:
         return LoadAdError(
           readValueOfType(buffer.getUint8(), buffer),
@@ -1141,6 +1141,13 @@ class AdMessageCodec extends StandardMessageCodec {
         value,
       ),
     );
+  }
+
+  /// Reads the next value as a non-nullable string.
+  ///
+  /// Returns '' if the next value is null.
+  String _safeReadString(ReadBuffer buffer) {
+    return readValueOfType(buffer.getUint8(), buffer) ?? '';
   }
 
   void writeAdSize(WriteBuffer buffer, AdSize value) {


### PR DESCRIPTION
## Description

Fixes a bug introduced in https://github.com/googleads/googleads-mobile-flutter/pull/645. Some of the new fields in AdapterResponseInfo can be null on iOS, causing a crash.

## Related Issues

https://github.com/googleads/googleads-mobile-flutter/issues/675

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/googleads/googleads-mobile-flutter/issues). Indicate, which of these issues are resolved or fixed by this PR.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
