### PR TITLE
Use updated getVersion() API on android.

### DIFF
--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterMobileAdsWrapper.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterMobileAdsWrapper.java
@@ -49,7 +49,7 @@ public class FlutterMobileAdsWrapper {
 
   /** Wrapper for getVersionString. */
   public String getVersionString() {
-    return MobileAds.getVersionString();
+    return MobileAds.getVersion().toString();
   }
 
   /** Wrapper for getRequestConfiguration. */


### PR DESCRIPTION
## Description

Replaces the deprecated `MobileAds.getVersionString()` with `MobileAds.getVersion().toString()` on Android.
This keeps the dart API return type as a string, since iOS still only supports getting a version string as opposed to a designated VersionInfo type like android.

## Related Issues

https://github.com/googleads/googleads-mobile-flutter/issues/652

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.