### PR TITLE
Serve multiple ad types with a single AdLoaderAd widget

### DIFF
--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/CustomAdFactory.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/CustomAdFactory.java
@@ -1,0 +1,12 @@
+package io.flutter.plugins.googlemobileads;
+
+import android.view.View;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.google.android.libraries.ads.mobile.sdk.nativead.CustomNativeAd;
+import java.util.Map;
+
+public interface CustomAdFactory {
+  View createCustomAd(
+      @NonNull CustomNativeAd customNativeAd, @Nullable Map<String, Object> customOptions);
+}

--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAd.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAd.java
@@ -335,7 +335,10 @@ abstract class FlutterAd {
 
       if (error.getResponseInfo() != null) {
         responseInfo = new FlutterResponseInfo(error.getResponseInfo());
-        domain = responseInfo.getMediationAdapterClassName();
+        String adapterClassName = responseInfo.getMediationAdapterClassName();
+        domain = adapterClassName != null
+            ? adapterClassName
+            : "com.google.android.libraries.ads.mobile.sdk";
       } else {
         domain = "com.google.android.libraries.ads.mobile.sdk";
       }

--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdListener.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdListener.java
@@ -180,4 +180,11 @@ class FlutterAdLoaderAdLoadedListener implements NativeAdLoaderCallback {
       callbackWeakReference.get().onCustomNativeAdLoaded(customNativeAd);
     }
   }
+
+  @Override
+  public void onNativeAdLoaded(@NonNull NativeAd nativeAd) {
+    if (callbackWeakReference.get() != null) {
+      callbackWeakReference.get().onNativeAdLoaded(nativeAd);
+    }
+  }
 }

--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdListener.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdListener.java
@@ -150,3 +150,19 @@ class FlutterNativeAdLoadedListener implements NativeAdLoaderCallback {
     }
   }
 }
+
+class FlutterAdLoaderAdLoadedListener implements NativeAdLoaderCallback {
+
+  private final WeakReference<NativeAdLoaderCallback> callbackWeakReference;
+
+  FlutterAdLoaderAdLoadedListener(NativeAdLoaderCallback callback) {
+    callbackWeakReference = new WeakReference<>(callback);
+  }
+
+  @Override
+  public void onAdFailedToLoad(@NonNull LoadAdError loadAdError) {
+    if (callbackWeakReference.get() != null) {
+      callbackWeakReference.get().onAdFailedToLoad(loadAdError);
+    }
+  }
+}

--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdListener.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdListener.java
@@ -165,4 +165,11 @@ class FlutterAdLoaderAdLoadedListener implements NativeAdLoaderCallback {
       callbackWeakReference.get().onAdFailedToLoad(loadAdError);
     }
   }
+
+  @Override
+  public void onBannerAdLoaded(@NonNull BannerAd bannerAd) {
+    if (callbackWeakReference.get() != null) {
+      callbackWeakReference.get().onBannerAdLoaded(bannerAd);
+    }
+  }
 }

--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdListener.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdListener.java
@@ -21,6 +21,7 @@ import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback;
 import com.google.android.libraries.ads.mobile.sdk.common.AdValue;
 import com.google.android.libraries.ads.mobile.sdk.common.FullScreenContentError;
 import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError;
+import com.google.android.libraries.ads.mobile.sdk.nativead.CustomNativeAd;
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd;
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdEventCallback;
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoaderCallback;
@@ -170,6 +171,13 @@ class FlutterAdLoaderAdLoadedListener implements NativeAdLoaderCallback {
   public void onBannerAdLoaded(@NonNull BannerAd bannerAd) {
     if (callbackWeakReference.get() != null) {
       callbackWeakReference.get().onBannerAdLoaded(bannerAd);
+    }
+  }
+
+  @Override
+  public void onCustomNativeAdLoaded(@NonNull CustomNativeAd customNativeAd) {
+    if (callbackWeakReference.get() != null) {
+      callbackWeakReference.get().onCustomNativeAdLoaded(customNativeAd);
     }
   }
 }

--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdLoader.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdLoader.java
@@ -17,6 +17,7 @@ package io.flutter.plugins.googlemobileads;
 import android.content.Context;
 import android.util.Log;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.google.android.gms.ads.nativead.NativeAdOptions;
 import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAd;
 import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback;
@@ -124,19 +125,33 @@ public class FlutterAdLoader {
   /** Load an ad loader ad. */
   public void loadAdLoaderAd(
       @NonNull String adUnitId,
-      @NonNull NativeAdLoaderCallback adLoaderAdLoaderCallback) {
+      @NonNull NativeAdLoaderCallback adLoaderAdLoaderCallback,
+      @Nullable FlutterAdLoaderAd.BannerParameters bannerParameters) {
     List<NativeAdType> nativeAdTypes = new ArrayList<>();
 
+    if (bannerParameters != null) {
+      nativeAdTypes.add(NativeAdType.BANNER);
+    }
+
+    NativeAdRequest.Builder builder = new NativeAdRequest.Builder(adUnitId, nativeAdTypes);
+
+    if (bannerParameters != null) {
+      builder.setAdSizes(bannerParameters.adSizes);
+      if (bannerParameters.adManagerAdViewOptions != null) {
+        builder.setManualImpressionEnabled(bannerParameters.adManagerAdViewOptions.manualImpressionsEnabled);
+      }
+    }
+
     NativeAdLoader.load(
-        new NativeAdRequest.Builder(adUnitId, nativeAdTypes)
-            .build(),
+        builder.build(),
         adLoaderAdLoaderCallback);
   }
 
   /** Load an ad manager ad loader ad. */
   public void loadAdManagerAdLoaderAd(
       @NonNull String adUnitId,
-      @NonNull NativeAdLoaderCallback adLoaderAdLoaderCallback) {
-    loadAdLoaderAd(adUnitId, adLoaderAdLoaderCallback);
+      @NonNull NativeAdLoaderCallback adLoaderAdLoaderCallback,
+      @Nullable FlutterAdLoaderAd.BannerParameters bannerParameters) {
+    loadAdLoaderAd(adUnitId, adLoaderAdLoaderCallback, bannerParameters);
   }
 }

--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdLoader.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdLoader.java
@@ -20,11 +20,13 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.gms.ads.nativead.NativeAdOptions;
 import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAd;
+import com.google.android.libraries.ads.mobile.sdk.common.AdChoicesPlacement;
 import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback;
 import com.google.android.libraries.ads.mobile.sdk.common.AdRequest;
 import com.google.android.libraries.ads.mobile.sdk.common.VideoOptions;
 import com.google.android.libraries.ads.mobile.sdk.interstitial.InterstitialAd;
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd.NativeAdType;
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd.NativeMediaAspectRatio;
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoader;
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoaderCallback;
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdRequest;
@@ -127,7 +129,8 @@ public class FlutterAdLoader {
       @NonNull String adUnitId,
       @NonNull NativeAdLoaderCallback adLoaderAdLoaderCallback,
       @Nullable FlutterAdLoaderAd.BannerParameters bannerParameters,
-      @Nullable FlutterAdLoaderAd.CustomParameters customParameters) {
+      @Nullable FlutterAdLoaderAd.CustomParameters customParameters,
+      @Nullable FlutterAdLoaderAd.NativeParameters nativeParameters) {
     List<NativeAdType> nativeAdTypes = new ArrayList<>();
 
     if (bannerParameters != null) {
@@ -136,6 +139,10 @@ public class FlutterAdLoader {
 
     if (customParameters != null) {
       nativeAdTypes.add(NativeAdType.CUSTOM_NATIVE);
+    }
+
+    if (nativeParameters != null) {
+      nativeAdTypes.add(NativeAdType.NATIVE);
     }
 
     NativeAdRequest.Builder builder = new NativeAdRequest.Builder(adUnitId, nativeAdTypes);
@@ -151,6 +158,15 @@ public class FlutterAdLoader {
       builder.setCustomFormatIds(new ArrayList<>(customParameters.factories.keySet()));
     }
 
+    if (nativeParameters != null && nativeParameters.nativeAdOptions != null) {
+      builder.setAdChoicesPlacement(convertAdChoicesPlacement(nativeParameters.nativeAdOptions.getAdChoicesPlacement()));
+      builder.setMediaAspectRatio(convertMediaAspectRatio(nativeParameters.nativeAdOptions.getMediaAspectRatio()));
+      com.google.android.gms.ads.VideoOptions videoOptions = nativeParameters.nativeAdOptions.getVideoOptions();
+      if (videoOptions != null) {
+        builder.setVideoOptions(convertVideoOptions(videoOptions));
+      }
+    }
+
     NativeAdLoader.load(
         builder.build(),
         adLoaderAdLoaderCallback);
@@ -161,7 +177,48 @@ public class FlutterAdLoader {
       @NonNull String adUnitId,
       @NonNull NativeAdLoaderCallback adLoaderAdLoaderCallback,
       @Nullable FlutterAdLoaderAd.BannerParameters bannerParameters,
-      @Nullable FlutterAdLoaderAd.CustomParameters customParameters) {
-    loadAdLoaderAd(adUnitId, adLoaderAdLoaderCallback, bannerParameters, customParameters);
+      @Nullable FlutterAdLoaderAd.CustomParameters customParameters,
+      @Nullable FlutterAdLoaderAd.NativeParameters nativeParameters) {
+    loadAdLoaderAd(adUnitId, adLoaderAdLoaderCallback, bannerParameters, customParameters, nativeParameters);
+  }
+
+  static AdChoicesPlacement convertAdChoicesPlacement(int adChoicesPlacement) {
+    switch(adChoicesPlacement) {
+    case NativeAdOptions.ADCHOICES_BOTTOM_LEFT:
+      return AdChoicesPlacement.BOTTOM_LEFT;
+    case NativeAdOptions.ADCHOICES_BOTTOM_RIGHT:
+      return AdChoicesPlacement.BOTTOM_RIGHT;
+    case NativeAdOptions.ADCHOICES_TOP_LEFT:
+      return AdChoicesPlacement.TOP_LEFT;
+    case NativeAdOptions.ADCHOICES_TOP_RIGHT:
+      return AdChoicesPlacement.TOP_RIGHT;
+    default:
+      return AdChoicesPlacement.TOP_RIGHT;
+    }
+  }
+
+  static NativeMediaAspectRatio convertMediaAspectRatio(int mediaAspectRatio) {
+    switch(mediaAspectRatio) {
+    case NativeAdOptions.NATIVE_MEDIA_ASPECT_RATIO_ANY:
+      return NativeMediaAspectRatio.ANY;
+    case NativeAdOptions.NATIVE_MEDIA_ASPECT_RATIO_LANDSCAPE:
+      return NativeMediaAspectRatio.LANDSCAPE;
+    case NativeAdOptions.NATIVE_MEDIA_ASPECT_RATIO_PORTRAIT:
+      return NativeMediaAspectRatio.PORTRAIT;
+    case NativeAdOptions.NATIVE_MEDIA_ASPECT_RATIO_SQUARE:
+      return NativeMediaAspectRatio.SQUARE;
+    case NativeAdOptions.NATIVE_MEDIA_ASPECT_RATIO_UNKNOWN:
+      return NativeMediaAspectRatio.UNKNOWN;
+    default:
+      return NativeMediaAspectRatio.UNKNOWN;
+    }
+  }
+
+  static VideoOptions convertVideoOptions(com.google.android.gms.ads.VideoOptions videoOptions) {
+    return new VideoOptions.Builder()
+      .setClickToExpandRequested(videoOptions.getClickToExpandRequested())
+      .setCustomControlsRequested(videoOptions.getCustomControlsRequested())
+      .setStartMuted(videoOptions.getStartMuted())
+      .build();
   }
 }

--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdLoader.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdLoader.java
@@ -126,11 +126,16 @@ public class FlutterAdLoader {
   public void loadAdLoaderAd(
       @NonNull String adUnitId,
       @NonNull NativeAdLoaderCallback adLoaderAdLoaderCallback,
-      @Nullable FlutterAdLoaderAd.BannerParameters bannerParameters) {
+      @Nullable FlutterAdLoaderAd.BannerParameters bannerParameters,
+      @Nullable FlutterAdLoaderAd.CustomParameters customParameters) {
     List<NativeAdType> nativeAdTypes = new ArrayList<>();
 
     if (bannerParameters != null) {
       nativeAdTypes.add(NativeAdType.BANNER);
+    }
+
+    if (customParameters != null) {
+      nativeAdTypes.add(NativeAdType.CUSTOM_NATIVE);
     }
 
     NativeAdRequest.Builder builder = new NativeAdRequest.Builder(adUnitId, nativeAdTypes);
@@ -142,6 +147,10 @@ public class FlutterAdLoader {
       }
     }
 
+    if (customParameters != null) {
+      builder.setCustomFormatIds(new ArrayList<>(customParameters.factories.keySet()));
+    }
+
     NativeAdLoader.load(
         builder.build(),
         adLoaderAdLoaderCallback);
@@ -151,7 +160,8 @@ public class FlutterAdLoader {
   public void loadAdManagerAdLoaderAd(
       @NonNull String adUnitId,
       @NonNull NativeAdLoaderCallback adLoaderAdLoaderCallback,
-      @Nullable FlutterAdLoaderAd.BannerParameters bannerParameters) {
-    loadAdLoaderAd(adUnitId, adLoaderAdLoaderCallback, bannerParameters);
+      @Nullable FlutterAdLoaderAd.BannerParameters bannerParameters,
+      @Nullable FlutterAdLoaderAd.CustomParameters customParameters) {
+    loadAdLoaderAd(adUnitId, adLoaderAdLoaderCallback, bannerParameters, customParameters);
   }
 }

--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdLoader.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdLoader.java
@@ -29,6 +29,7 @@ import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoaderCallba
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdRequest;
 import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAd;
 import com.google.android.libraries.ads.mobile.sdk.rewardedinterstitial.RewardedInterstitialAd;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -118,5 +119,24 @@ public class FlutterAdLoader {
       @NonNull NativeAdLoaderCallback nativeAdLoaderCallback,
       @NonNull NativeAdOptions nativeAdOptions) {
     loadNativeAd(adUnitId, nativeAdLoaderCallback, nativeAdOptions);
+  }
+
+  /** Load an ad loader ad. */
+  public void loadAdLoaderAd(
+      @NonNull String adUnitId,
+      @NonNull NativeAdLoaderCallback adLoaderAdLoaderCallback) {
+    List<NativeAdType> nativeAdTypes = new ArrayList<>();
+
+    NativeAdLoader.load(
+        new NativeAdRequest.Builder(adUnitId, nativeAdTypes)
+            .build(),
+        adLoaderAdLoaderCallback);
+  }
+
+  /** Load an ad manager ad loader ad. */
+  public void loadAdManagerAdLoaderAd(
+      @NonNull String adUnitId,
+      @NonNull NativeAdLoaderCallback adLoaderAdLoaderCallback) {
+    loadAdLoaderAd(adUnitId, adLoaderAdLoaderCallback);
   }
 }

--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdLoader.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdLoader.java
@@ -127,6 +127,7 @@ public class FlutterAdLoader {
   /** Load an ad loader ad. */
   public void loadAdLoaderAd(
       @NonNull String adUnitId,
+      @NonNull FlutterAdRequest request,
       @NonNull NativeAdLoaderCallback adLoaderAdLoaderCallback,
       @Nullable FlutterAdLoaderAd.BannerParameters bannerParameters,
       @Nullable FlutterAdLoaderAd.CustomParameters customParameters,
@@ -167,6 +168,8 @@ public class FlutterAdLoader {
       }
     }
 
+    request.configureNativeAdRequestBuilder(builder, adUnitId);
+
     NativeAdLoader.load(
         builder.build(),
         adLoaderAdLoaderCallback);
@@ -175,11 +178,12 @@ public class FlutterAdLoader {
   /** Load an ad manager ad loader ad. */
   public void loadAdManagerAdLoaderAd(
       @NonNull String adUnitId,
+      @NonNull FlutterAdManagerAdRequest adManagerRequest,
       @NonNull NativeAdLoaderCallback adLoaderAdLoaderCallback,
       @Nullable FlutterAdLoaderAd.BannerParameters bannerParameters,
       @Nullable FlutterAdLoaderAd.CustomParameters customParameters,
       @Nullable FlutterAdLoaderAd.NativeParameters nativeParameters) {
-    loadAdLoaderAd(adUnitId, adLoaderAdLoaderCallback, bannerParameters, customParameters, nativeParameters);
+    loadAdLoaderAd(adUnitId, adManagerRequest, adLoaderAdLoaderCallback, bannerParameters, customParameters, nativeParameters);
   }
 
   static AdChoicesPlacement convertAdChoicesPlacement(int adChoicesPlacement) {

--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAd.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAd.java
@@ -4,11 +4,13 @@ import android.util.Log;
 import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import com.google.android.gms.ads.nativead.NativeAdOptions;
 import com.google.android.libraries.ads.mobile.sdk.banner.AdSize;
 import com.google.android.libraries.ads.mobile.sdk.banner.AdView;
 import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd;
 import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError;
 import com.google.android.libraries.ads.mobile.sdk.nativead.CustomNativeAd;
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd;
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoaderCallback;
 import io.flutter.plugin.platform.PlatformView;
 import java.util.List;
@@ -27,6 +29,7 @@ class FlutterAdLoaderAd extends FlutterAd implements FlutterAdLoadedListener, Na
   @Nullable private View view;
   @Nullable protected BannerParameters bannerParameters;
   @Nullable protected CustomParameters customParameters;
+  @Nullable protected NativeParameters nativeParameters;
 
   static class Builder {
     @Nullable private AdInstanceManager manager;
@@ -38,6 +41,8 @@ class FlutterAdLoaderAd extends FlutterAd implements FlutterAdLoadedListener, Na
     @Nullable private FlutterBannerParameters bannerParameters;
     @Nullable private FlutterCustomParameters customParameters;
     @Nullable private Map<String, CustomAdFactory> customFactories;
+    @Nullable private FlutterNativeParameters nativeParameters;
+    @Nullable private Map<String, NativeAdFactory> nativeFactories;
 
     public Builder setId(int id) {
       this.id = id;
@@ -85,6 +90,17 @@ class FlutterAdLoaderAd extends FlutterAd implements FlutterAdLoadedListener, Na
       return this;
     }
 
+    public Builder setNative(@Nullable FlutterNativeParameters nativeParameters) {
+      this.nativeParameters = nativeParameters;
+      return this;
+    }
+
+    public Builder withAvailableNativeFactories(
+        @NonNull Map<String, NativeAdFactory> nativeFactories) {
+      this.nativeFactories = nativeFactories;
+      return this;
+    }
+
     FlutterAdLoaderAd build() {
       if (manager == null) {
         throw new IllegalStateException("manager must be provided");
@@ -114,6 +130,10 @@ class FlutterAdLoaderAd extends FlutterAd implements FlutterAdLoadedListener, Na
         adLoaderAd.customParameters = customParameters.asCustomParameters(customFactories);
       }
 
+      if (nativeParameters != null) {
+        adLoaderAd.nativeParameters = nativeParameters.asNativeParameters(nativeFactories);
+      }
+
       return adLoaderAd;
     }
   }
@@ -138,6 +158,21 @@ class FlutterAdLoaderAd extends FlutterAd implements FlutterAdLoadedListener, Na
         @NonNull Map<String, CustomAdFactory> factories,
         @Nullable Map<String, Object> viewOptions) {
       this.factories = factories;
+      this.viewOptions = viewOptions;
+    }
+  }
+
+  static class NativeParameters {
+    @NonNull final NativeAdFactory factory;
+    @Nullable final NativeAdOptions nativeAdOptions;
+    @Nullable final Map<String, Object> viewOptions;
+
+    NativeParameters(
+        @NonNull NativeAdFactory factory,
+        @Nullable NativeAdOptions nativeAdOptions,
+        @Nullable Map<String, Object> viewOptions) {
+      this.factory = factory;
+      this.nativeAdOptions = nativeAdOptions;
       this.viewOptions = viewOptions;
     }
   }
@@ -182,10 +217,11 @@ class FlutterAdLoaderAd extends FlutterAd implements FlutterAdLoadedListener, Na
     // Note we delegate loading the ad to FlutterAdLoader mainly for testing purposes.
     // As of 20.0.0 of GMA, mockito is unable to mock AdLoader.
     if (request != null) {
-      adLoader.loadAdLoaderAd(adUnitId, loadedListener, bannerParameters, customParameters);
+      adLoader.loadAdLoaderAd(
+          adUnitId, loadedListener, bannerParameters, customParameters, nativeParameters);
     } else if (adManagerRequest != null) {
       adLoader.loadAdManagerAdLoaderAd(
-          adUnitId, loadedListener, bannerParameters, customParameters);
+          adUnitId, loadedListener, bannerParameters, customParameters, nativeParameters);
     } else {
       Log.e(TAG, "A null or invalid ad request was provided.");
     }
@@ -252,6 +288,16 @@ class FlutterAdLoaderAd extends FlutterAd implements FlutterAdLoadedListener, Na
     customNativeAd.setAdEventCallback(new FlutterNativeAdListener(adId, manager));
 
     manager.onAdLoaded(adId, customNativeAd.getResponseInfo());
+  }
+
+  @Override
+  public void onNativeAdLoaded(@NonNull NativeAd nativeAd) {
+    view = nativeParameters.factory.createNativeAd(nativeAd, nativeParameters.viewOptions);
+    type = AdLoaderAdType.NATIVE;
+
+    nativeAd.setAdEventCallback(new FlutterNativeAdListener(adId, manager));
+
+    manager.onAdLoaded(adId, nativeAd.getResponseInfo());
   }
 
   @Override

--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAd.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAd.java
@@ -1,0 +1,155 @@
+package io.flutter.plugins.googlemobileads;
+
+import android.util.Log;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError;
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoaderCallback;
+
+class FlutterAdLoaderAd extends FlutterAd implements FlutterAdLoadedListener, NativeAdLoaderCallback {
+  private static final String TAG = "FlutterAdLoaderAd";
+
+  @NonNull private final AdInstanceManager manager;
+  @NonNull private final String adUnitId;
+  @NonNull private final FlutterAdLoader adLoader;
+  @Nullable private FlutterAdRequest request;
+  @Nullable private FlutterAdManagerAdRequest adManagerRequest;
+  @Nullable private AdLoaderAdType type;
+  @Nullable private String formatId;
+
+  static class Builder {
+    @Nullable private AdInstanceManager manager;
+    @Nullable private String adUnitId;
+    @Nullable private FlutterAdRequest request;
+    @Nullable private FlutterAdManagerAdRequest adManagerRequest;
+    @Nullable private Integer id;
+    @Nullable private FlutterAdLoader adLoader;
+
+    public Builder setId(int id) {
+      this.id = id;
+      return this;
+    }
+
+    public Builder setManager(@NonNull AdInstanceManager manager) {
+      this.manager = manager;
+      return this;
+    }
+
+    public Builder setAdUnitId(@NonNull String adUnitId) {
+      this.adUnitId = adUnitId;
+      return this;
+    }
+
+    public Builder setRequest(@NonNull FlutterAdRequest request) {
+      this.request = request;
+      return this;
+    }
+
+    public Builder setAdManagerRequest(@NonNull FlutterAdManagerAdRequest adManagerRequest) {
+      this.adManagerRequest = adManagerRequest;
+      return this;
+    }
+
+    public Builder setFlutterAdLoader(@NonNull FlutterAdLoader adLoader) {
+      this.adLoader = adLoader;
+      return this;
+    }
+
+    FlutterAdLoaderAd build() {
+      if (manager == null) {
+        throw new IllegalStateException("manager must be provided");
+      }
+
+      if (adUnitId == null) {
+        throw new IllegalStateException("adUnitId must be provided");
+      }
+
+      if (request == null && adManagerRequest == null) {
+        throw new IllegalStateException("Either request or adManagerRequest must be provided");
+      }
+
+      final FlutterAdLoaderAd adLoaderAd;
+
+      if (request == null) {
+        adLoaderAd = new FlutterAdLoaderAd(id, manager, adUnitId, adManagerRequest, adLoader);
+      } else {
+        adLoaderAd = new FlutterAdLoaderAd(id, manager, adUnitId, request, adLoader);
+      }
+      return adLoaderAd;
+    }
+  }
+
+  protected FlutterAdLoaderAd(
+      int adId,
+      @NonNull AdInstanceManager manager,
+      @NonNull String adUnitId,
+      @NonNull FlutterAdRequest request,
+      @NonNull FlutterAdLoader adLoader) {
+    super(adId);
+
+    this.type = AdLoaderAdType.UNKNOWN;
+    this.formatId = null;
+
+    this.manager = manager;
+    this.adUnitId = adUnitId;
+    this.request = request;
+    this.adLoader = adLoader;
+  }
+
+  protected FlutterAdLoaderAd(
+      int adId,
+      @NonNull AdInstanceManager manager,
+      @NonNull String adUnitId,
+      @NonNull FlutterAdManagerAdRequest adManagerRequest,
+      @NonNull FlutterAdLoader adLoader) {
+    super(adId);
+
+    this.type = AdLoaderAdType.UNKNOWN;
+    this.formatId = null;
+
+    this.manager = manager;
+    this.adUnitId = adUnitId;
+    this.adManagerRequest = adManagerRequest;
+    this.adLoader = adLoader;
+  }
+
+  @Override
+  void load() {
+    final NativeAdLoaderCallback loadedListener = new FlutterAdLoaderAdLoadedListener(this);
+    // Note we delegate loading the ad to FlutterAdLoader mainly for testing purposes.
+    // As of 20.0.0 of GMA, mockito is unable to mock AdLoader.
+    if (request != null) {
+      adLoader.loadAdLoaderAd(adUnitId, loadedListener);
+    } else if (adManagerRequest != null) {
+      adLoader.loadAdManagerAdLoaderAd(adUnitId, loadedListener);
+    } else {
+      Log.e(TAG, "A null or invalid ad request was provided.");
+    }
+  }
+
+  @Nullable
+  AdLoaderAdType getAdLoaderAdType() {
+    return type;
+  }
+
+  @Nullable
+  FlutterAdSize getAdSize() {
+    return null;
+  }
+
+  @Nullable
+  String getFormatId() {
+    return formatId;
+  }
+
+  @Override
+  public void onAdLoaded() {}
+
+  @Override
+  public void onAdFailedToLoad(@NonNull LoadAdError loadAdError) {
+    manager.onAdFailedToLoad(adId, new FlutterAd.FlutterLoadAdError(loadAdError));
+  }
+
+  @Override
+  void dispose() {}
+}

--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAd.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAd.java
@@ -1,10 +1,16 @@
 package io.flutter.plugins.googlemobileads;
 
 import android.util.Log;
+import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import com.google.android.libraries.ads.mobile.sdk.banner.AdSize;
+import com.google.android.libraries.ads.mobile.sdk.banner.AdView;
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd;
 import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError;
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoaderCallback;
+import io.flutter.plugin.platform.PlatformView;
+import java.util.List;
 
 class FlutterAdLoaderAd extends FlutterAd implements FlutterAdLoadedListener, NativeAdLoaderCallback {
   private static final String TAG = "FlutterAdLoaderAd";
@@ -16,6 +22,8 @@ class FlutterAdLoaderAd extends FlutterAd implements FlutterAdLoadedListener, Na
   @Nullable private FlutterAdManagerAdRequest adManagerRequest;
   @Nullable private AdLoaderAdType type;
   @Nullable private String formatId;
+  @Nullable private View view;
+  @Nullable protected BannerParameters bannerParameters;
 
   static class Builder {
     @Nullable private AdInstanceManager manager;
@@ -24,6 +32,7 @@ class FlutterAdLoaderAd extends FlutterAd implements FlutterAdLoadedListener, Na
     @Nullable private FlutterAdManagerAdRequest adManagerRequest;
     @Nullable private Integer id;
     @Nullable private FlutterAdLoader adLoader;
+    @Nullable private FlutterBannerParameters bannerParameters;
 
     public Builder setId(int id) {
       this.id = id;
@@ -47,6 +56,11 @@ class FlutterAdLoaderAd extends FlutterAd implements FlutterAdLoadedListener, Na
 
     public Builder setAdManagerRequest(@NonNull FlutterAdManagerAdRequest adManagerRequest) {
       this.adManagerRequest = adManagerRequest;
+      return this;
+    }
+
+    public Builder setBanner(@Nullable FlutterBannerParameters bannerParameters) {
+      this.bannerParameters = bannerParameters;
       return this;
     }
 
@@ -75,7 +89,24 @@ class FlutterAdLoaderAd extends FlutterAd implements FlutterAdLoadedListener, Na
       } else {
         adLoaderAd = new FlutterAdLoaderAd(id, manager, adUnitId, request, adLoader);
       }
+
+      if (bannerParameters != null) {
+        adLoaderAd.bannerParameters = bannerParameters.asBannerParameters();
+      }
+
       return adLoaderAd;
+    }
+  }
+
+  static class BannerParameters {
+    @NonNull final List<AdSize> adSizes;
+    @Nullable final FlutterAdManagerAdViewOptions adManagerAdViewOptions;
+
+    BannerParameters(
+        @NonNull List<AdSize> adSizes,
+        @Nullable FlutterAdManagerAdViewOptions adManagerAdViewOptions) {
+      this.adSizes = adSizes;
+      this.adManagerAdViewOptions = adManagerAdViewOptions;
     }
   }
 
@@ -119,9 +150,9 @@ class FlutterAdLoaderAd extends FlutterAd implements FlutterAdLoadedListener, Na
     // Note we delegate loading the ad to FlutterAdLoader mainly for testing purposes.
     // As of 20.0.0 of GMA, mockito is unable to mock AdLoader.
     if (request != null) {
-      adLoader.loadAdLoaderAd(adUnitId, loadedListener);
+      adLoader.loadAdLoaderAd(adUnitId, loadedListener, bannerParameters);
     } else if (adManagerRequest != null) {
-      adLoader.loadAdManagerAdLoaderAd(adUnitId, loadedListener);
+      adLoader.loadAdManagerAdLoaderAd(adUnitId, loadedListener, bannerParameters);
     } else {
       Log.e(TAG, "A null or invalid ad request was provided.");
     }
@@ -143,7 +174,19 @@ class FlutterAdLoaderAd extends FlutterAd implements FlutterAdLoadedListener, Na
   }
 
   @Override
-  public void onAdLoaded() {}
+  @Nullable
+  public PlatformView getPlatformView() {
+    if (view == null) {
+      return null;
+    }
+
+    return new FlutterPlatformView(view);
+  }
+
+  @Override
+  public void onAdLoaded() {
+    //  handled by onBannerAdLoaded
+  }
 
   @Override
   public void onAdFailedToLoad(@NonNull LoadAdError loadAdError) {
@@ -151,5 +194,28 @@ class FlutterAdLoaderAd extends FlutterAd implements FlutterAdLoadedListener, Na
   }
 
   @Override
-  void dispose() {}
+  public void onBannerAdLoaded(@NonNull BannerAd bannerAd) {
+    AdView adView = new AdView(manager.getActivity());
+    adView.registerBannerAd(bannerAd, manager.getActivity());
+
+    view = adView;
+    type = AdLoaderAdType.BANNER;
+
+    bannerAd.setAdEventCallback(new FlutterBannerAdListener(adId, manager, this));
+
+    manager.onAdLoaded(adId, bannerAd.getResponseInfo());
+  }
+
+  @Override
+  void dispose() {
+    if (view == null) {
+      return;
+    }
+
+    if (view instanceof AdView) {
+      ((AdView) view).destroy();
+    }
+
+    view = null;
+  }
 }

--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAd.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAd.java
@@ -8,9 +8,11 @@ import com.google.android.libraries.ads.mobile.sdk.banner.AdSize;
 import com.google.android.libraries.ads.mobile.sdk.banner.AdView;
 import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd;
 import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError;
+import com.google.android.libraries.ads.mobile.sdk.nativead.CustomNativeAd;
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoaderCallback;
 import io.flutter.plugin.platform.PlatformView;
 import java.util.List;
+import java.util.Map;
 
 class FlutterAdLoaderAd extends FlutterAd implements FlutterAdLoadedListener, NativeAdLoaderCallback {
   private static final String TAG = "FlutterAdLoaderAd";
@@ -24,6 +26,7 @@ class FlutterAdLoaderAd extends FlutterAd implements FlutterAdLoadedListener, Na
   @Nullable private String formatId;
   @Nullable private View view;
   @Nullable protected BannerParameters bannerParameters;
+  @Nullable protected CustomParameters customParameters;
 
   static class Builder {
     @Nullable private AdInstanceManager manager;
@@ -33,6 +36,8 @@ class FlutterAdLoaderAd extends FlutterAd implements FlutterAdLoadedListener, Na
     @Nullable private Integer id;
     @Nullable private FlutterAdLoader adLoader;
     @Nullable private FlutterBannerParameters bannerParameters;
+    @Nullable private FlutterCustomParameters customParameters;
+    @Nullable private Map<String, CustomAdFactory> customFactories;
 
     public Builder setId(int id) {
       this.id = id;
@@ -64,8 +69,19 @@ class FlutterAdLoaderAd extends FlutterAd implements FlutterAdLoadedListener, Na
       return this;
     }
 
+    public Builder setCustom(@Nullable FlutterCustomParameters customParameters) {
+      this.customParameters = customParameters;
+      return this;
+    }
+
     public Builder setFlutterAdLoader(@NonNull FlutterAdLoader adLoader) {
       this.adLoader = adLoader;
+      return this;
+    }
+
+    public Builder withAvailableCustomFactories(
+        @NonNull Map<String, CustomAdFactory> customFactories) {
+      this.customFactories = customFactories;
       return this;
     }
 
@@ -94,6 +110,10 @@ class FlutterAdLoaderAd extends FlutterAd implements FlutterAdLoadedListener, Na
         adLoaderAd.bannerParameters = bannerParameters.asBannerParameters();
       }
 
+      if (customParameters != null) {
+        adLoaderAd.customParameters = customParameters.asCustomParameters(customFactories);
+      }
+
       return adLoaderAd;
     }
   }
@@ -107,6 +127,18 @@ class FlutterAdLoaderAd extends FlutterAd implements FlutterAdLoadedListener, Na
         @Nullable FlutterAdManagerAdViewOptions adManagerAdViewOptions) {
       this.adSizes = adSizes;
       this.adManagerAdViewOptions = adManagerAdViewOptions;
+    }
+  }
+
+  static class CustomParameters {
+    @NonNull final Map<String, CustomAdFactory> factories;
+    @Nullable final Map<String, Object> viewOptions;
+
+    CustomParameters(
+        @NonNull Map<String, CustomAdFactory> factories,
+        @Nullable Map<String, Object> viewOptions) {
+      this.factories = factories;
+      this.viewOptions = viewOptions;
     }
   }
 
@@ -150,9 +182,10 @@ class FlutterAdLoaderAd extends FlutterAd implements FlutterAdLoadedListener, Na
     // Note we delegate loading the ad to FlutterAdLoader mainly for testing purposes.
     // As of 20.0.0 of GMA, mockito is unable to mock AdLoader.
     if (request != null) {
-      adLoader.loadAdLoaderAd(adUnitId, loadedListener, bannerParameters);
+      adLoader.loadAdLoaderAd(adUnitId, loadedListener, bannerParameters, customParameters);
     } else if (adManagerRequest != null) {
-      adLoader.loadAdManagerAdLoaderAd(adUnitId, loadedListener, bannerParameters);
+      adLoader.loadAdManagerAdLoaderAd(
+          adUnitId, loadedListener, bannerParameters, customParameters);
     } else {
       Log.e(TAG, "A null or invalid ad request was provided.");
     }
@@ -204,6 +237,21 @@ class FlutterAdLoaderAd extends FlutterAd implements FlutterAdLoadedListener, Na
     bannerAd.setAdEventCallback(new FlutterBannerAdListener(adId, manager, this));
 
     manager.onAdLoaded(adId, bannerAd.getResponseInfo());
+  }
+
+  @Override
+  public void onCustomNativeAdLoaded(@NonNull CustomNativeAd customNativeAd) {
+    formatId = customNativeAd.getCustomFormatId();
+    view =
+        customParameters
+            .factories
+            .get(formatId)
+            .createCustomAd(customNativeAd, customParameters.viewOptions);
+    type = AdLoaderAdType.CUSTOM;
+
+    customNativeAd.setAdEventCallback(new FlutterNativeAdListener(adId, manager));
+
+    manager.onAdLoaded(adId, customNativeAd.getResponseInfo());
   }
 
   @Override

--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAd.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAd.java
@@ -218,10 +218,10 @@ class FlutterAdLoaderAd extends FlutterAd implements FlutterAdLoadedListener, Na
     // As of 20.0.0 of GMA, mockito is unable to mock AdLoader.
     if (request != null) {
       adLoader.loadAdLoaderAd(
-          adUnitId, loadedListener, bannerParameters, customParameters, nativeParameters);
+          adUnitId, request, loadedListener, bannerParameters, customParameters, nativeParameters);
     } else if (adManagerRequest != null) {
       adLoader.loadAdManagerAdLoaderAd(
-          adUnitId, loadedListener, bannerParameters, customParameters, nativeParameters);
+          adUnitId, adManagerRequest, loadedListener, bannerParameters, customParameters, nativeParameters);
     } else {
       Log.e(TAG, "A null or invalid ad request was provided.");
     }

--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequest.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequest.java
@@ -19,6 +19,7 @@ import androidx.annotation.Nullable;
 import com.google.android.libraries.ads.mobile.sdk.banner.AdSize;
 import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRequest;
 import com.google.android.libraries.ads.mobile.sdk.common.AdRequest;
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdRequest;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.List;
 import java.util.Map;
@@ -133,6 +134,26 @@ class FlutterAdManagerAdRequest extends FlutterAdRequest {
   protected BannerAdRequest.Builder toBannerAdRequestBuilder(String adUnitId,
       List<AdSize> allSizes) {
     BannerAdRequest.Builder builder = super.toBannerAdRequestBuilder(adUnitId, allSizes);
+    if (customTargeting != null) {
+      for (final Map.Entry<String, String> entry : customTargeting.entrySet()) {
+        builder.putCustomTargeting(entry.getKey(), entry.getValue());
+      }
+    }
+    if (customTargetingLists != null) {
+      for (final Map.Entry<String, List<String>> entry : customTargetingLists.entrySet()) {
+        builder.putCustomTargeting(entry.getKey(), entry.getValue());
+      }
+    }
+    if (publisherProvidedId != null) {
+      builder.setPublisherProvidedId(publisherProvidedId);
+    }
+    return builder;
+  }
+
+  @Override
+  protected NativeAdRequest.Builder configureNativeAdRequestBuilder(
+      NativeAdRequest.Builder builder, String adUnitId) {
+    super.configureNativeAdRequestBuilder(builder, adUnitId);
     if (customTargeting != null) {
       for (final Map.Entry<String, String> entry : customTargeting.entrySet()) {
         builder.putCustomTargeting(entry.getKey(), entry.getValue());

--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdViewOptions.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdViewOptions.java
@@ -1,0 +1,12 @@
+package io.flutter.plugins.googlemobileads;
+
+import androidx.annotation.Nullable;
+
+class FlutterAdManagerAdViewOptions {
+
+  @Nullable final Boolean manualImpressionsEnabled;
+
+  FlutterAdManagerAdViewOptions(@Nullable Boolean manualImpressionsEnabled) {
+    this.manualImpressionsEnabled = manualImpressionsEnabled;
+  }
+}

--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdRequest.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdRequest.java
@@ -23,6 +23,7 @@ import com.google.android.gms.ads.mediation.admob.AdMobAdapter;
 import com.google.android.libraries.ads.mobile.sdk.banner.AdSize;
 import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRequest;
 import com.google.android.libraries.ads.mobile.sdk.common.AdRequest;
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdRequest;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -317,6 +318,24 @@ class FlutterAdRequest {
       builder.putAdSourceExtrasBundle(entry.getKey(), entry.getValue());
     }
 
+    if (neighboringContentUrls != null) {
+      builder.setNeighboringContentUrls(new HashSet<String>(neighboringContentUrls));
+    }
+    builder.setRequestAgent(requestAgent);
+    return builder;
+  }
+
+  /** Applies the common request properties onto a next-gen {@link NativeAdRequest.Builder}. */
+  protected NativeAdRequest.Builder configureNativeAdRequestBuilder(
+      NativeAdRequest.Builder builder, String adUnitId) {
+    if (keywords != null) {
+      for (final String keyword : keywords) {
+        builder.addKeyword(keyword);
+      }
+    }
+    if (contentUrl != null) {
+      builder.setContentUrl(contentUrl);
+    }
     if (neighboringContentUrls != null) {
       builder.setNeighboringContentUrls(new HashSet<String>(neighboringContentUrls));
     }

--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterBannerParameters.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterBannerParameters.java
@@ -1,0 +1,29 @@
+package io.flutter.plugins.googlemobileads;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.google.android.libraries.ads.mobile.sdk.banner.AdSize;
+import java.util.ArrayList;
+import java.util.List;
+
+class FlutterBannerParameters {
+  @NonNull final List<FlutterAdSize> sizes;
+  @Nullable final FlutterAdManagerAdViewOptions adManagerAdViewOptions;
+
+  FlutterBannerParameters(
+      @NonNull List<FlutterAdSize> sizes,
+      @Nullable FlutterAdManagerAdViewOptions adManagerAdViewOptions) {
+    this.sizes = sizes;
+    this.adManagerAdViewOptions = adManagerAdViewOptions;
+  }
+
+  FlutterAdLoaderAd.BannerParameters asBannerParameters() {
+    List<AdSize> adSizes = new ArrayList<>(sizes.size());
+    for (FlutterAdSize size : sizes) {
+      adSizes.add(size.getAdSize());
+    }
+    return new FlutterAdLoaderAd.BannerParameters(
+        adSizes,
+        adManagerAdViewOptions);
+  }
+}

--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterCustomParameters.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterCustomParameters.java
@@ -1,0 +1,28 @@
+package io.flutter.plugins.googlemobileads;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.flutter.plugins.googlemobileads.CustomAdFactory;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class FlutterCustomParameters {
+  @NonNull final List<String> formatIds;
+  @Nullable final Map<String, Object> viewOptions;
+
+  FlutterCustomParameters(
+      @NonNull List<String> formatIds, @Nullable Map<String, Object> viewOptions) {
+    this.formatIds = formatIds;
+    this.viewOptions = viewOptions;
+  }
+
+  FlutterAdLoaderAd.CustomParameters asCustomParameters(
+      @NonNull Map<String, CustomAdFactory> availableFactories) {
+    Map<String, CustomAdFactory> factories = new HashMap<>();
+    for (String formatId : formatIds) {
+      factories.put(formatId, availableFactories.get(formatId));
+    }
+    return new FlutterAdLoaderAd.CustomParameters(factories, viewOptions);
+  }
+}

--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterNativeParameters.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterNativeParameters.java
@@ -1,0 +1,32 @@
+package io.flutter.plugins.googlemobileads;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.google.android.gms.ads.nativead.NativeAdOptions;
+import io.flutter.plugins.googlemobileads.NativeAdFactory;
+import java.util.Map;
+
+class FlutterNativeParameters {
+  @NonNull final String factoryId;
+  @Nullable final FlutterNativeAdOptions nativeAdOptions;
+  @Nullable final Map<String, Object> viewOptions;
+
+  FlutterNativeParameters(
+      @NonNull String factoryId,
+      @Nullable FlutterNativeAdOptions nativeAdOptions,
+      @Nullable Map<String, Object> viewOptions) {
+    this.factoryId = factoryId;
+    this.nativeAdOptions = nativeAdOptions;
+    this.viewOptions = viewOptions;
+  }
+
+  FlutterAdLoaderAd.NativeParameters asNativeParameters(
+      @NonNull Map<String, NativeAdFactory> registeredFactories) {
+    NativeAdOptions nativeAdOptions = null;
+    if (this.nativeAdOptions != null) {
+      nativeAdOptions = this.nativeAdOptions.asNativeAdOptions();
+    }
+    return new FlutterAdLoaderAd.NativeParameters(
+        registeredFactories.get(factoryId), nativeAdOptions, viewOptions);
+  }
+}

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdLoaderAdType.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdLoaderAdType.java
@@ -2,4 +2,5 @@ package io.flutter.plugins.googlemobileads;
 
 enum AdLoaderAdType {
   UNKNOWN,
+  BANNER,
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdLoaderAdType.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdLoaderAdType.java
@@ -3,4 +3,5 @@ package io.flutter.plugins.googlemobileads;
 enum AdLoaderAdType {
   UNKNOWN,
   BANNER,
+  CUSTOM,
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdLoaderAdType.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdLoaderAdType.java
@@ -4,4 +4,5 @@ enum AdLoaderAdType {
   UNKNOWN,
   BANNER,
   CUSTOM,
+  NATIVE,
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdLoaderAdType.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdLoaderAdType.java
@@ -1,0 +1,5 @@
+package io.flutter.plugins.googlemobileads;
+
+enum AdLoaderAdType {
+  UNKNOWN,
+}

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
@@ -70,6 +70,7 @@ class AdMessageCodec extends StandardMessageCodec {
   private static final byte VALUE_AD_MANAGER_AD_VIEW_OPTIONS = (byte) 155;
   private static final byte VALUE_BANNER_PARAMETERS = (byte) 156;
   private static final byte VALUE_CUSTOM_PARAMETERS = (byte) 157;
+  private static final byte VALUE_NATIVE_PARAMETERS = (byte) 158;
 
   @NonNull Context context;
   @NonNull final FlutterAdSize.AdSizeFactory adSizeFactory;
@@ -274,6 +275,12 @@ class AdMessageCodec extends StandardMessageCodec {
       FlutterCustomParameters customParameters = (FlutterCustomParameters) value;
       writeValue(stream, customParameters.formatIds);
       writeValue(stream, customParameters.viewOptions);
+    } else if (value instanceof FlutterNativeParameters) {
+      stream.write(VALUE_NATIVE_PARAMETERS);
+      FlutterNativeParameters nativeParameters = (FlutterNativeParameters) value;
+      writeValue(stream, nativeParameters.factoryId);
+      writeValue(stream, nativeParameters.nativeAdOptions);
+      writeValue(stream, nativeParameters.viewOptions);
     } else {
       super.writeValue(stream, value);
     }
@@ -469,6 +476,11 @@ class AdMessageCodec extends StandardMessageCodec {
       case VALUE_CUSTOM_PARAMETERS:
         return new FlutterCustomParameters(
             (List<String>) readValueOfType(buffer.get(), buffer),
+            (Map<String, Object>) readValueOfType(buffer.get(), buffer));
+      case VALUE_NATIVE_PARAMETERS:
+        return new FlutterNativeParameters(
+            (String) readValueOfType(buffer.get(), buffer),
+            (FlutterNativeAdOptions) readValueOfType(buffer.get(), buffer),
             (Map<String, Object>) readValueOfType(buffer.get(), buffer));
       default:
         return super.readValueOfType(type, buffer);

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
@@ -69,6 +69,7 @@ class AdMessageCodec extends StandardMessageCodec {
   private static final byte VALUE_MEDIATION_EXTRAS = (byte) 154;
   private static final byte VALUE_AD_MANAGER_AD_VIEW_OPTIONS = (byte) 155;
   private static final byte VALUE_BANNER_PARAMETERS = (byte) 156;
+  private static final byte VALUE_CUSTOM_PARAMETERS = (byte) 157;
 
   @NonNull Context context;
   @NonNull final FlutterAdSize.AdSizeFactory adSizeFactory;
@@ -268,6 +269,11 @@ class AdMessageCodec extends StandardMessageCodec {
       FlutterBannerParameters bannerParameters = (FlutterBannerParameters) value;
       writeValue(stream, bannerParameters.sizes);
       writeValue(stream, bannerParameters.adManagerAdViewOptions);
+    } else if (value instanceof FlutterCustomParameters) {
+      stream.write(VALUE_CUSTOM_PARAMETERS);
+      FlutterCustomParameters customParameters = (FlutterCustomParameters) value;
+      writeValue(stream, customParameters.formatIds);
+      writeValue(stream, customParameters.viewOptions);
     } else {
       super.writeValue(stream, value);
     }
@@ -460,6 +466,10 @@ class AdMessageCodec extends StandardMessageCodec {
         return new FlutterBannerParameters(
             (List<FlutterAdSize>) readValueOfType(buffer.get(), buffer),
             (FlutterAdManagerAdViewOptions) readValueOfType(buffer.get(), buffer));
+      case VALUE_CUSTOM_PARAMETERS:
+        return new FlutterCustomParameters(
+            (List<String>) readValueOfType(buffer.get(), buffer),
+            (Map<String, Object>) readValueOfType(buffer.get(), buffer));
       default:
         return super.readValueOfType(type, buffer);
     }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
@@ -67,6 +67,8 @@ class AdMessageCodec extends StandardMessageCodec {
   private static final byte VALUE_NATIVE_TEMPLATE_TYPE = (byte) 152;
   private static final byte VALUE_COLOR = (byte) 153;
   private static final byte VALUE_MEDIATION_EXTRAS = (byte) 154;
+  private static final byte VALUE_AD_MANAGER_AD_VIEW_OPTIONS = (byte) 155;
+  private static final byte VALUE_BANNER_PARAMETERS = (byte) 156;
 
   @NonNull Context context;
   @NonNull final FlutterAdSize.AdSizeFactory adSizeFactory;
@@ -257,6 +259,15 @@ class AdMessageCodec extends StandardMessageCodec {
       writeValue(stream, Color.red(colorValue));
       writeValue(stream, Color.green(colorValue));
       writeValue(stream, Color.blue(colorValue));
+    } else if (value instanceof FlutterAdManagerAdViewOptions) {
+      stream.write(VALUE_AD_MANAGER_AD_VIEW_OPTIONS);
+      FlutterAdManagerAdViewOptions options = (FlutterAdManagerAdViewOptions) value;
+      writeValue(stream, options.manualImpressionsEnabled);
+    } else if (value instanceof FlutterBannerParameters) {
+      stream.write(VALUE_BANNER_PARAMETERS);
+      FlutterBannerParameters bannerParameters = (FlutterBannerParameters) value;
+      writeValue(stream, bannerParameters.sizes);
+      writeValue(stream, bannerParameters.adManagerAdViewOptions);
     } else {
       super.writeValue(stream, value);
     }
@@ -443,6 +454,12 @@ class AdMessageCodec extends StandardMessageCodec {
         final Integer green = (Integer) readValueOfType(buffer.get(), buffer);
         final Integer blue = (Integer) readValueOfType(buffer.get(), buffer);
         return new ColorDrawable(Color.argb(alpha, red, green, blue));
+      case VALUE_AD_MANAGER_AD_VIEW_OPTIONS:
+        return new FlutterAdManagerAdViewOptions((Boolean) readValueOfType(buffer.get(), buffer));
+      case VALUE_BANNER_PARAMETERS:
+        return new FlutterBannerParameters(
+            (List<FlutterAdSize>) readValueOfType(buffer.get(), buffer),
+            (FlutterAdManagerAdViewOptions) readValueOfType(buffer.get(), buffer));
       default:
         return super.readValueOfType(type, buffer);
     }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -60,6 +60,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
   @Nullable private AppStateNotifier appStateNotifier;
   @Nullable private UserMessagingPlatformManager userMessagingPlatformManager;
   private final Map<String, NativeAdFactory> nativeAdFactories = new HashMap<>();
+  private final Map<String, CustomAdFactory> customAdFactories = new HashMap<>();
 
   @SuppressWarnings("deprecation") // Keeping for compatibility
   @Nullable
@@ -123,6 +124,13 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
     return registerNativeAdFactory(gmaPlugin, factoryId, nativeAdFactory);
   }
 
+  public static boolean registerCustomAdFactory(
+      FlutterEngine engine, String formatId, CustomAdFactory customAdFactory) {
+    final GoogleMobileAdsPlugin gmaPlugin =
+        (GoogleMobileAdsPlugin) engine.getPlugins().get(GoogleMobileAdsPlugin.class);
+    return registerCustomAdFactory(gmaPlugin, formatId, customAdFactory);
+  }
+
   /**
    * Registers a {@link MediationNetworkExtrasProvider} used to provide network extras to the plugin
    * when it creates ad requests.
@@ -183,6 +191,19 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
     return plugin.addNativeAdFactory(factoryId, nativeAdFactory);
   }
 
+  private static boolean registerCustomAdFactory(
+      GoogleMobileAdsPlugin plugin, String formatId, CustomAdFactory customAdFactory) {
+    if (plugin == null) {
+      final String message =
+          String.format(
+              "Could not find a %s instance. The plugin may have not been registered.",
+              GoogleMobileAdsPlugin.class.getSimpleName());
+      throw new IllegalStateException(message);
+    }
+
+    return plugin.addCustomAdFactory(formatId, customAdFactory);
+  }
+
   /**
    * Unregisters a {@link NativeAdFactory}
    * used to create {@link NativeAdView}s from a Native Ad
@@ -205,6 +226,16 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
     return null;
   }
 
+  @Nullable
+  public static CustomAdFactory unregisterCustomAdFactory(FlutterEngine engine, String formatId) {
+    final FlutterPlugin gmaPlugin = engine.getPlugins().get(GoogleMobileAdsPlugin.class);
+    if (gmaPlugin != null) {
+      return ((GoogleMobileAdsPlugin) gmaPlugin).removeCustomAdFactory(formatId);
+    }
+
+    return null;
+  }
+
   private boolean addNativeAdFactory(String factoryId, NativeAdFactory nativeAdFactory) {
     if (nativeAdFactories.containsKey(factoryId)) {
       final String errorMessage =
@@ -220,6 +251,23 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
 
   private NativeAdFactory removeNativeAdFactory(String factoryId) {
     return nativeAdFactories.remove(factoryId);
+  }
+
+  private boolean addCustomAdFactory(String formatId, CustomAdFactory customAdFactory) {
+    if (customAdFactories.containsKey(formatId)) {
+      final String errorMessage =
+          String.format(
+              "A CustomAdFactory with the following formatId already exists: %s", formatId);
+      Log.e(GoogleMobileAdsPlugin.class.getSimpleName(), errorMessage);
+      return false;
+    }
+
+    customAdFactories.put(formatId, customAdFactory);
+    return true;
+  }
+
+  private CustomAdFactory removeCustomAdFactory(String formatId) {
+    return customAdFactories.remove(formatId);
   }
 
   @Override
@@ -390,6 +438,19 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
         result.success(null);
         break;
       case "loadAdLoaderAd":
+        final FlutterCustomParameters customParameters =
+            call.<FlutterCustomParameters>argument("custom");
+        if (customParameters != null) {
+          for (String formatId : customParameters.formatIds) {
+            if (customAdFactories.get(formatId) == null) {
+              final String message =
+                  String.format("Can't find CustomAdFactory with id: %s", formatId);
+              result.error("AdLoaderAdError", message, null);
+              return;
+            }
+          }
+        }
+
         final FlutterAdLoaderAd adLoaderAd =
             new FlutterAdLoaderAd.Builder()
                 .setManager(instanceManager)
@@ -402,6 +463,8 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
                         ? adLoaderSupplier.get()
                         : new FlutterAdLoader(context))
                 .setBanner(call.<FlutterBannerParameters>argument("banner"))
+                .setCustom(customParameters)
+                .withAvailableCustomFactories(customAdFactories)
                 .build();
         instanceManager.trackAd(adLoaderAd, call.<Integer>argument("adId"));
         adLoaderAd.load();

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -389,6 +389,23 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
         nativeAd.load();
         result.success(null);
         break;
+      case "loadAdLoaderAd":
+        final FlutterAdLoaderAd adLoaderAd =
+            new FlutterAdLoaderAd.Builder()
+                .setManager(instanceManager)
+                .setAdUnitId(call.<String>argument("adUnitId"))
+                .setRequest(call.<FlutterAdRequest>argument("request"))
+                .setAdManagerRequest(call.<FlutterAdManagerAdRequest>argument("adManagerRequest"))
+                .setId(call.<Integer>argument("adId"))
+                .setFlutterAdLoader(
+                    adLoaderSupplier != null
+                        ? adLoaderSupplier.get()
+                        : new FlutterAdLoader(context))
+                .build();
+        instanceManager.trackAd(adLoaderAd, call.<Integer>argument("adId"));
+        adLoaderAd.load();
+        result.success(null);
+        break;
       case "loadInterstitialAd":
         final FlutterInterstitialAd interstitial =
             new FlutterInterstitialAd(
@@ -583,6 +600,22 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
         flutterMobileAds.openDebugMenu(context, adUnitId);
         result.success(null);
         break;
+      case "getAdLoaderAdType":
+        {
+          FlutterAd ad = instanceManager.adForId(call.<Integer>argument("adId"));
+          if (ad == null) {
+            // This was called on a dart ad container that hasn't been loaded yet.
+            result.success(null);
+          } else if (ad instanceof FlutterAdLoaderAd) {
+            result.success(((FlutterAdLoaderAd) ad).getAdLoaderAdType().ordinal());
+          } else {
+            result.error(
+                Constants.ERROR_CODE_UNEXPECTED_AD_TYPE,
+                "Unexpected ad type for getAdLoaderAdType: " + ad,
+                null);
+          }
+          break;
+        }
       case "getAdSize":
         {
           FlutterAd ad = instanceManager.adForId(call.<Integer>argument("adId"));
@@ -593,10 +626,28 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
             result.success(((FlutterBannerAd) ad).getAdSize());
           } else if (ad instanceof FlutterAdManagerBannerAd) {
             result.success(((FlutterAdManagerBannerAd) ad).getAdSize());
+          } else if (ad instanceof FlutterAdLoaderAd) {
+            result.success(((FlutterAdLoaderAd) ad).getAdSize());
           } else {
             result.error(
                 Constants.ERROR_CODE_UNEXPECTED_AD_TYPE,
                 "Unexpected ad type for getAdSize: " + ad,
+                null);
+          }
+          break;
+        }
+      case "getFormatId":
+        {
+          FlutterAd ad = instanceManager.adForId(call.<Integer>argument("adId"));
+          if (ad == null) {
+            // This was called on a dart ad container that hasn't been loaded yet.
+            result.success(null);
+          } else if (ad instanceof FlutterAdLoaderAd) {
+            result.success(((FlutterAdLoaderAd) ad).getFormatId());
+          } else {
+            result.error(
+                Constants.ERROR_CODE_UNEXPECTED_AD_TYPE,
+                "Unexpected ad type for getFormatId: " + ad,
                 null);
           }
           break;

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -451,6 +451,17 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
           }
         }
 
+        final FlutterNativeParameters nativeParameters =
+            call.<FlutterNativeParameters>argument("native");
+        if (nativeParameters != null) {
+          if (nativeAdFactories.get(nativeParameters.factoryId) == null) {
+            final String message =
+                String.format("Can't find NativeAdFactory with id: %s", nativeParameters.factoryId);
+            result.error("AdLoaderAdError", message, null);
+            return;
+          }
+        }
+
         final FlutterAdLoaderAd adLoaderAd =
             new FlutterAdLoaderAd.Builder()
                 .setManager(instanceManager)
@@ -465,6 +476,8 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
                 .setBanner(call.<FlutterBannerParameters>argument("banner"))
                 .setCustom(customParameters)
                 .withAvailableCustomFactories(customAdFactories)
+                .setNative(nativeParameters)
+                .withAvailableNativeFactories(nativeAdFactories)
                 .build();
         instanceManager.trackAd(adLoaderAd, call.<Integer>argument("adId"));
         adLoaderAd.load();

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -401,6 +401,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
                     adLoaderSupplier != null
                         ? adLoaderSupplier.get()
                         : new FlutterAdLoader(context))
+                .setBanner(call.<FlutterBannerParameters>argument("banner"))
                 .build();
         instanceManager.trackAd(adLoaderAd, call.<Integer>argument("adId"));
         adLoaderAd.load();

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -35,6 +35,7 @@ import io.flutter.plugins.googlemobileads.usermessagingplatform.UserMessagingPla
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * Flutter plugin accessing Google Mobile Ads API.
@@ -66,6 +67,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
 
   private final FlutterMobileAdsWrapper flutterMobileAds;
 
+  @Nullable private Supplier<FlutterAdLoader> adLoaderSupplier;
   /**
    * Public constructor for the plugin. Dependency initialization is handled in lifecycle methods
    * below.
@@ -91,7 +93,16 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
     this.flutterMobileAds = new FlutterMobileAdsWrapper();
   }
 
+  @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+  protected GoogleMobileAdsPlugin(
+      @Nullable FlutterPluginBinding pluginBinding,
+      @Nullable AdInstanceManager instanceManager,
+      @NonNull FlutterMobileAdsWrapper flutterMobileAds,
+      @NonNull Supplier<FlutterAdLoader> adLoaderSupplier) {
+    this(pluginBinding, instanceManager, flutterMobileAds);
 
+    this.adLoaderSupplier = adLoaderSupplier;
+  }
 
   /**
    * Registers a {@link NativeAdFactory}

--- a/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/CustomAdFactory.java
+++ b/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/CustomAdFactory.java
@@ -1,0 +1,12 @@
+package io.flutter.plugins.googlemobileads;
+
+import android.view.View;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.google.android.gms.ads.nativead.NativeCustomFormatAd;
+import java.util.Map;
+
+public interface CustomAdFactory {
+  View createCustomAd(
+      @NonNull NativeCustomFormatAd nativeAd, @Nullable Map<String, Object> customOptions);
+}

--- a/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdListener.java
+++ b/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdListener.java
@@ -16,6 +16,8 @@ package io.flutter.plugins.googlemobileads;
 import androidx.annotation.NonNull;
 import com.google.android.gms.ads.AdListener;
 import com.google.android.gms.ads.LoadAdError;
+import com.google.android.gms.ads.admanager.AdManagerAdView;
+import com.google.android.gms.ads.formats.OnAdManagerAdViewLoadedListener;
 import com.google.android.gms.ads.nativead.NativeAd;
 import com.google.android.gms.ads.nativead.NativeAd.OnNativeAdLoadedListener;
 import java.lang.ref.WeakReference;
@@ -115,6 +117,23 @@ class FlutterNativeAdLoadedListener implements OnNativeAdLoadedListener {
   public void onNativeAdLoaded(@NonNull NativeAd nativeAd) {
     if (listenerWeakReference.get() != null) {
       listenerWeakReference.get().onNativeAdLoaded(nativeAd);
+    }
+  }
+}
+
+/** {@link OnAdManagerAdViewLoadedListener} for banner ads. */
+class FlutterAdManagerAdViewLoadedListener implements OnAdManagerAdViewLoadedListener {
+
+  private final WeakReference<OnAdManagerAdViewLoadedListener> reference;
+
+  FlutterAdManagerAdViewLoadedListener(OnAdManagerAdViewLoadedListener listener) {
+    reference = new WeakReference<>(listener);
+  }
+
+  @Override
+  public void onAdManagerAdViewLoaded(AdManagerAdView adView) {
+    if (reference.get() != null) {
+      reference.get().onAdManagerAdViewLoaded(adView);
     }
   }
 }

--- a/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdListener.java
+++ b/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdListener.java
@@ -20,6 +20,8 @@ import com.google.android.gms.ads.admanager.AdManagerAdView;
 import com.google.android.gms.ads.formats.OnAdManagerAdViewLoadedListener;
 import com.google.android.gms.ads.nativead.NativeAd;
 import com.google.android.gms.ads.nativead.NativeAd.OnNativeAdLoadedListener;
+import com.google.android.gms.ads.nativead.NativeCustomFormatAd;
+import com.google.android.gms.ads.nativead.NativeCustomFormatAd.OnCustomFormatAdLoadedListener;
 import java.lang.ref.WeakReference;
 
 /** Callback type to notify when an ad successfully loads. */
@@ -134,6 +136,23 @@ class FlutterAdManagerAdViewLoadedListener implements OnAdManagerAdViewLoadedLis
   public void onAdManagerAdViewLoaded(AdManagerAdView adView) {
     if (reference.get() != null) {
       reference.get().onAdManagerAdViewLoaded(adView);
+    }
+  }
+}
+
+/** {@link OnCustomFormatAdLoadedListener} for custom ads. */
+class FlutterCustomFormatAdLoadedListener implements OnCustomFormatAdLoadedListener {
+
+  private final WeakReference<OnCustomFormatAdLoadedListener> reference;
+
+  FlutterCustomFormatAdLoadedListener(OnCustomFormatAdLoadedListener listener) {
+    reference = new WeakReference<>(listener);
+  }
+
+  @Override
+  public void onCustomFormatAdLoaded(NativeCustomFormatAd ad) {
+    if (reference.get() != null) {
+      reference.get().onCustomFormatAdLoaded(ad);
     }
   }
 }

--- a/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdListener.java
+++ b/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdListener.java
@@ -94,6 +94,14 @@ class FlutterNativeAdListener extends FlutterAdListener {
   }
 }
 
+/** Listener for adloader ads. */
+class FlutterAdLoaderAdListener extends FlutterAdListener {
+
+  FlutterAdLoaderAdListener(int adId, AdInstanceManager manager) {
+    super(adId, manager);
+  }
+}
+
 /** {@link OnNativeAdLoadedListener} for native ads. */
 class FlutterNativeAdLoadedListener implements OnNativeAdLoadedListener {
 

--- a/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdListener.java
+++ b/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdListener.java
@@ -97,16 +97,16 @@ class FlutterNativeAdListener extends FlutterAdListener {
 /** {@link OnNativeAdLoadedListener} for native ads. */
 class FlutterNativeAdLoadedListener implements OnNativeAdLoadedListener {
 
-  private final WeakReference<FlutterNativeAd> nativeAdWeakReference;
+  private final WeakReference<OnNativeAdLoadedListener> listenerWeakReference;
 
-  FlutterNativeAdLoadedListener(FlutterNativeAd flutterNativeAd) {
-    nativeAdWeakReference = new WeakReference<>(flutterNativeAd);
+  FlutterNativeAdLoadedListener(OnNativeAdLoadedListener listener) {
+    listenerWeakReference = new WeakReference<>(listener);
   }
 
   @Override
   public void onNativeAdLoaded(@NonNull NativeAd nativeAd) {
-    if (nativeAdWeakReference.get() != null) {
-      nativeAdWeakReference.get().onNativeAdLoaded(nativeAd);
+    if (listenerWeakReference.get() != null) {
+      listenerWeakReference.get().onNativeAdLoaded(nativeAd);
     }
   }
 }

--- a/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdLoader.java
+++ b/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdLoader.java
@@ -144,12 +144,18 @@ public class FlutterAdLoader {
       @NonNull String adUnitId,
       @NonNull AdListener adListener,
       @NonNull AdRequest request,
-      @Nullable FlutterAdLoaderAd.BannerParameters bannerParameters) {
+      @Nullable FlutterAdLoaderAd.BannerParameters bannerParameters,
+      @Nullable FlutterAdLoaderAd.CustomParameters customParameters) {
     AdLoader.Builder builder = new AdLoader.Builder(context, adUnitId);
     if (bannerParameters != null) {
       builder = builder.forAdManagerAdView(bannerParameters.listener, bannerParameters.adSizes);
       if (bannerParameters.adManagerAdViewOptions != null) {
         builder.withAdManagerAdViewOptions(bannerParameters.adManagerAdViewOptions);
+      }
+    }
+    if (customParameters != null) {
+      for (String formatId : customParameters.factories.keySet()) {
+        builder = builder.forCustomFormatAd(formatId, customParameters.listener, null);
       }
     }
     builder.withAdListener(adListener).build().loadAd(request);
@@ -160,12 +166,18 @@ public class FlutterAdLoader {
       @NonNull String adUnitId,
       @NonNull AdListener adListener,
       @NonNull AdManagerAdRequest adManagerAdRequest,
-      @Nullable FlutterAdLoaderAd.BannerParameters bannerParameters) {
+      @Nullable FlutterAdLoaderAd.BannerParameters bannerParameters,
+      @Nullable FlutterAdLoaderAd.CustomParameters customParameters) {
     AdLoader.Builder builder = new AdLoader.Builder(context, adUnitId);
     if (bannerParameters != null) {
       builder = builder.forAdManagerAdView(bannerParameters.listener, bannerParameters.adSizes);
       if (bannerParameters.adManagerAdViewOptions != null) {
         builder.withAdManagerAdViewOptions(bannerParameters.adManagerAdViewOptions);
+      }
+    }
+    if (customParameters != null) {
+      for (String formatId : customParameters.factories.keySet()) {
+        builder = builder.forCustomFormatAd(formatId, customParameters.listener, null);
       }
     }
     builder.withAdListener(adListener).build().loadAd(adManagerAdRequest);

--- a/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdLoader.java
+++ b/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdLoader.java
@@ -137,4 +137,21 @@ public class FlutterAdLoader {
         .build()
         .loadAd(adManagerAdRequest);
   }
+
+  /** Load an ad loader ad. */
+  public void loadAdLoaderAd(
+      @NonNull String adUnitId, @NonNull AdListener adListener, @NonNull AdRequest request) {
+    new AdLoader.Builder(context, adUnitId).withAdListener(adListener).build().loadAd(request);
+  }
+
+  /** Load an ad manager ad loader ad. */
+  public void loadAdManagerAdLoaderAd(
+      @NonNull String adUnitId,
+      @NonNull AdListener adListener,
+      @NonNull AdManagerAdRequest adManagerAdRequest) {
+    new AdLoader.Builder(context, adUnitId)
+        .withAdListener(adListener)
+        .build()
+        .loadAd(adManagerAdRequest);
+  }
 }

--- a/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdLoader.java
+++ b/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdLoader.java
@@ -145,7 +145,8 @@ public class FlutterAdLoader {
       @NonNull AdListener adListener,
       @NonNull AdRequest request,
       @Nullable FlutterAdLoaderAd.BannerParameters bannerParameters,
-      @Nullable FlutterAdLoaderAd.CustomParameters customParameters) {
+      @Nullable FlutterAdLoaderAd.CustomParameters customParameters,
+      @Nullable FlutterAdLoaderAd.NativeParameters nativeParameters) {
     AdLoader.Builder builder = new AdLoader.Builder(context, adUnitId);
     if (bannerParameters != null) {
       builder = builder.forAdManagerAdView(bannerParameters.listener, bannerParameters.adSizes);
@@ -156,6 +157,12 @@ public class FlutterAdLoader {
     if (customParameters != null) {
       for (String formatId : customParameters.factories.keySet()) {
         builder = builder.forCustomFormatAd(formatId, customParameters.listener, null);
+      }
+    }
+    if (nativeParameters != null) {
+      builder = builder.forNativeAd(nativeParameters.listener);
+      if (nativeParameters.nativeAdOptions != null) {
+        builder = builder.withNativeAdOptions(nativeParameters.nativeAdOptions);
       }
     }
     builder.withAdListener(adListener).build().loadAd(request);
@@ -167,7 +174,8 @@ public class FlutterAdLoader {
       @NonNull AdListener adListener,
       @NonNull AdManagerAdRequest adManagerAdRequest,
       @Nullable FlutterAdLoaderAd.BannerParameters bannerParameters,
-      @Nullable FlutterAdLoaderAd.CustomParameters customParameters) {
+      @Nullable FlutterAdLoaderAd.CustomParameters customParameters,
+      @Nullable FlutterAdLoaderAd.NativeParameters nativeParameters) {
     AdLoader.Builder builder = new AdLoader.Builder(context, adUnitId);
     if (bannerParameters != null) {
       builder = builder.forAdManagerAdView(bannerParameters.listener, bannerParameters.adSizes);
@@ -178,6 +186,12 @@ public class FlutterAdLoader {
     if (customParameters != null) {
       for (String formatId : customParameters.factories.keySet()) {
         builder = builder.forCustomFormatAd(formatId, customParameters.listener, null);
+      }
+    }
+    if (nativeParameters != null) {
+      builder = builder.forNativeAd(nativeParameters.listener);
+      if (nativeParameters.nativeAdOptions != null) {
+        builder = builder.withNativeAdOptions(nativeParameters.nativeAdOptions);
       }
     }
     builder.withAdListener(adListener).build().loadAd(adManagerAdRequest);

--- a/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdLoader.java
+++ b/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdLoader.java
@@ -16,6 +16,7 @@ package io.flutter.plugins.googlemobileads;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.google.android.gms.ads.AdListener;
 import com.google.android.gms.ads.AdLoader;
 import com.google.android.gms.ads.AdRequest;
@@ -140,18 +141,33 @@ public class FlutterAdLoader {
 
   /** Load an ad loader ad. */
   public void loadAdLoaderAd(
-      @NonNull String adUnitId, @NonNull AdListener adListener, @NonNull AdRequest request) {
-    new AdLoader.Builder(context, adUnitId).withAdListener(adListener).build().loadAd(request);
+      @NonNull String adUnitId,
+      @NonNull AdListener adListener,
+      @NonNull AdRequest request,
+      @Nullable FlutterAdLoaderAd.BannerParameters bannerParameters) {
+    AdLoader.Builder builder = new AdLoader.Builder(context, adUnitId);
+    if (bannerParameters != null) {
+      builder = builder.forAdManagerAdView(bannerParameters.listener, bannerParameters.adSizes);
+      if (bannerParameters.adManagerAdViewOptions != null) {
+        builder.withAdManagerAdViewOptions(bannerParameters.adManagerAdViewOptions);
+      }
+    }
+    builder.withAdListener(adListener).build().loadAd(request);
   }
 
   /** Load an ad manager ad loader ad. */
   public void loadAdManagerAdLoaderAd(
       @NonNull String adUnitId,
       @NonNull AdListener adListener,
-      @NonNull AdManagerAdRequest adManagerAdRequest) {
-    new AdLoader.Builder(context, adUnitId)
-        .withAdListener(adListener)
-        .build()
-        .loadAd(adManagerAdRequest);
+      @NonNull AdManagerAdRequest adManagerAdRequest,
+      @Nullable FlutterAdLoaderAd.BannerParameters bannerParameters) {
+    AdLoader.Builder builder = new AdLoader.Builder(context, adUnitId);
+    if (bannerParameters != null) {
+      builder = builder.forAdManagerAdView(bannerParameters.listener, bannerParameters.adSizes);
+      if (bannerParameters.adManagerAdViewOptions != null) {
+        builder.withAdManagerAdViewOptions(bannerParameters.adManagerAdViewOptions);
+      }
+    }
+    builder.withAdListener(adListener).build().loadAd(adManagerAdRequest);
   }
 }

--- a/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAd.java
+++ b/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAd.java
@@ -24,13 +24,17 @@ import com.google.android.gms.ads.BaseAdView;
 import com.google.android.gms.ads.admanager.AdManagerAdView;
 import com.google.android.gms.ads.formats.AdManagerAdViewOptions;
 import com.google.android.gms.ads.formats.OnAdManagerAdViewLoadedListener;
+import com.google.android.gms.ads.nativead.NativeCustomFormatAd;
+import com.google.android.gms.ads.nativead.NativeCustomFormatAd.OnCustomFormatAdLoadedListener;
 import io.flutter.plugin.platform.PlatformView;
+import java.util.Map;
 
 /**
  * A central wrapper for {@link AdManagerAdView}, {@link NativeCustomFormatAd} and {@link NativeAd}
  * instances served for a single {@link AdRequest} or {@link AdManagerAdRequest}
  */
-class FlutterAdLoaderAd extends FlutterAd implements OnAdManagerAdViewLoadedListener {
+class FlutterAdLoaderAd extends FlutterAd
+    implements OnAdManagerAdViewLoadedListener, OnCustomFormatAdLoadedListener {
   private static final String TAG = "FlutterAdLoaderAd";
 
   @NonNull private final AdInstanceManager manager;
@@ -42,6 +46,7 @@ class FlutterAdLoaderAd extends FlutterAd implements OnAdManagerAdViewLoadedList
   @Nullable private String formatId;
   @Nullable private View view;
   @Nullable protected BannerParameters bannerParameters;
+  @Nullable protected CustomParameters customParameters;
 
   static class Builder {
     @Nullable private AdInstanceManager manager;
@@ -51,6 +56,8 @@ class FlutterAdLoaderAd extends FlutterAd implements OnAdManagerAdViewLoadedList
     @Nullable private Integer id;
     @Nullable private FlutterAdLoader adLoader;
     @Nullable private FlutterBannerParameters bannerParameters;
+    @Nullable private FlutterCustomParameters customParameters;
+    @Nullable private Map<String, CustomAdFactory> customFactories;
 
     public Builder setId(int id) {
       this.id = id;
@@ -87,6 +94,17 @@ class FlutterAdLoaderAd extends FlutterAd implements OnAdManagerAdViewLoadedList
       return this;
     }
 
+    public Builder setCustom(@Nullable FlutterCustomParameters customParameters) {
+      this.customParameters = customParameters;
+      return this;
+    }
+
+    public Builder withAvailableCustomFactories(
+        @NonNull Map<String, CustomAdFactory> customFactories) {
+      this.customFactories = customFactories;
+      return this;
+    }
+
     FlutterAdLoaderAd build() {
       if (manager == null) {
         throw new IllegalStateException("manager must be provided");
@@ -114,6 +132,12 @@ class FlutterAdLoaderAd extends FlutterAd implements OnAdManagerAdViewLoadedList
                 new FlutterAdManagerAdViewLoadedListener(adLoaderAd));
       }
 
+      if (customParameters != null) {
+        adLoaderAd.customParameters =
+            customParameters.asCustomParameters(
+                new FlutterCustomFormatAdLoadedListener(adLoaderAd), customFactories);
+      }
+
       return adLoaderAd;
     }
   }
@@ -130,6 +154,21 @@ class FlutterAdLoaderAd extends FlutterAd implements OnAdManagerAdViewLoadedList
       this.listener = listener;
       this.adSizes = adSizes;
       this.adManagerAdViewOptions = adManagerAdViewOptions;
+    }
+  }
+
+  static class CustomParameters {
+    @NonNull final OnCustomFormatAdLoadedListener listener;
+    @NonNull final Map<String, CustomAdFactory> factories;
+    @Nullable final Map<String, Object> viewOptions;
+
+    CustomParameters(
+        @NonNull OnCustomFormatAdLoadedListener listener,
+        @NonNull Map<String, CustomAdFactory> factories,
+        @Nullable Map<String, Object> viewOptions) {
+      this.listener = listener;
+      this.factories = factories;
+      this.viewOptions = viewOptions;
     }
   }
 
@@ -174,13 +213,17 @@ class FlutterAdLoaderAd extends FlutterAd implements OnAdManagerAdViewLoadedList
     // As of 20.0.0 of GMA, mockito is unable to mock AdLoader.
     if (request != null) {
       adLoader.loadAdLoaderAd(
-          adUnitId, adListener, request.asAdRequest(adUnitId), bannerParameters);
+          adUnitId, adListener, request.asAdRequest(adUnitId), bannerParameters, customParameters);
       return;
     }
 
     if (adManagerRequest != null) {
       adLoader.loadAdManagerAdLoaderAd(
-          adUnitId, adListener, adManagerRequest.asAdManagerAdRequest(adUnitId), bannerParameters);
+          adUnitId,
+          adListener,
+          adManagerRequest.asAdManagerAdRequest(adUnitId),
+          bannerParameters,
+          customParameters);
       return;
     }
 
@@ -220,6 +263,15 @@ class FlutterAdLoaderAd extends FlutterAd implements OnAdManagerAdViewLoadedList
     view = adView;
     type = AdLoaderAdType.BANNER;
     manager.onAdLoaded(adId, adView.getResponseInfo());
+  }
+
+  @Override
+  public void onCustomFormatAdLoaded(@NonNull NativeCustomFormatAd ad) {
+    formatId = ad.getCustomFormatId();
+    view =
+        customParameters.factories.get(formatId).createCustomAd(ad, customParameters.viewOptions);
+    type = AdLoaderAdType.CUSTOM;
+    manager.onAdLoaded(adId, null);
   }
 
   @Override

--- a/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAd.java
+++ b/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAd.java
@@ -24,6 +24,9 @@ import com.google.android.gms.ads.BaseAdView;
 import com.google.android.gms.ads.admanager.AdManagerAdView;
 import com.google.android.gms.ads.formats.AdManagerAdViewOptions;
 import com.google.android.gms.ads.formats.OnAdManagerAdViewLoadedListener;
+import com.google.android.gms.ads.nativead.NativeAd;
+import com.google.android.gms.ads.nativead.NativeAd.OnNativeAdLoadedListener;
+import com.google.android.gms.ads.nativead.NativeAdOptions;
 import com.google.android.gms.ads.nativead.NativeCustomFormatAd;
 import com.google.android.gms.ads.nativead.NativeCustomFormatAd.OnCustomFormatAdLoadedListener;
 import io.flutter.plugin.platform.PlatformView;
@@ -34,7 +37,9 @@ import java.util.Map;
  * instances served for a single {@link AdRequest} or {@link AdManagerAdRequest}
  */
 class FlutterAdLoaderAd extends FlutterAd
-    implements OnAdManagerAdViewLoadedListener, OnCustomFormatAdLoadedListener {
+    implements OnAdManagerAdViewLoadedListener,
+        OnCustomFormatAdLoadedListener,
+        OnNativeAdLoadedListener {
   private static final String TAG = "FlutterAdLoaderAd";
 
   @NonNull private final AdInstanceManager manager;
@@ -47,6 +52,7 @@ class FlutterAdLoaderAd extends FlutterAd
   @Nullable private View view;
   @Nullable protected BannerParameters bannerParameters;
   @Nullable protected CustomParameters customParameters;
+  @Nullable protected NativeParameters nativeParameters;
 
   static class Builder {
     @Nullable private AdInstanceManager manager;
@@ -58,6 +64,8 @@ class FlutterAdLoaderAd extends FlutterAd
     @Nullable private FlutterBannerParameters bannerParameters;
     @Nullable private FlutterCustomParameters customParameters;
     @Nullable private Map<String, CustomAdFactory> customFactories;
+    @Nullable private FlutterNativeParameters nativeParameters;
+    @Nullable private Map<String, NativeAdFactory> nativeFactories;
 
     public Builder setId(int id) {
       this.id = id;
@@ -105,6 +113,17 @@ class FlutterAdLoaderAd extends FlutterAd
       return this;
     }
 
+    public Builder setNative(@Nullable FlutterNativeParameters nativeParameters) {
+      this.nativeParameters = nativeParameters;
+      return this;
+    }
+
+    public Builder withAvailableNativeFactories(
+        @NonNull Map<String, NativeAdFactory> nativeFactories) {
+      this.nativeFactories = nativeFactories;
+      return this;
+    }
+
     FlutterAdLoaderAd build() {
       if (manager == null) {
         throw new IllegalStateException("manager must be provided");
@@ -138,6 +157,12 @@ class FlutterAdLoaderAd extends FlutterAd
                 new FlutterCustomFormatAdLoadedListener(adLoaderAd), customFactories);
       }
 
+      if (nativeParameters != null) {
+        adLoaderAd.nativeParameters =
+            nativeParameters.asNativeParameters(
+                new FlutterNativeAdLoadedListener(adLoaderAd), nativeFactories);
+      }
+
       return adLoaderAd;
     }
   }
@@ -168,6 +193,24 @@ class FlutterAdLoaderAd extends FlutterAd
         @Nullable Map<String, Object> viewOptions) {
       this.listener = listener;
       this.factories = factories;
+      this.viewOptions = viewOptions;
+    }
+  }
+
+  static class NativeParameters {
+    @NonNull final OnNativeAdLoadedListener listener;
+    @NonNull final NativeAdFactory factory;
+    @Nullable final NativeAdOptions nativeAdOptions;
+    @Nullable final Map<String, Object> viewOptions;
+
+    NativeParameters(
+        @NonNull OnNativeAdLoadedListener listener,
+        @NonNull NativeAdFactory factory,
+        @Nullable NativeAdOptions nativeAdOptions,
+        @Nullable Map<String, Object> viewOptions) {
+      this.listener = listener;
+      this.factory = factory;
+      this.nativeAdOptions = nativeAdOptions;
       this.viewOptions = viewOptions;
     }
   }
@@ -213,7 +256,12 @@ class FlutterAdLoaderAd extends FlutterAd
     // As of 20.0.0 of GMA, mockito is unable to mock AdLoader.
     if (request != null) {
       adLoader.loadAdLoaderAd(
-          adUnitId, adListener, request.asAdRequest(adUnitId), bannerParameters, customParameters);
+          adUnitId,
+          adListener,
+          request.asAdRequest(adUnitId),
+          bannerParameters,
+          customParameters,
+          nativeParameters);
       return;
     }
 
@@ -223,7 +271,8 @@ class FlutterAdLoaderAd extends FlutterAd
           adListener,
           adManagerRequest.asAdManagerAdRequest(adUnitId),
           bannerParameters,
-          customParameters);
+          customParameters,
+          nativeParameters);
       return;
     }
 
@@ -272,6 +321,14 @@ class FlutterAdLoaderAd extends FlutterAd
         customParameters.factories.get(formatId).createCustomAd(ad, customParameters.viewOptions);
     type = AdLoaderAdType.CUSTOM;
     manager.onAdLoaded(adId, null);
+  }
+
+  @Override
+  public void onNativeAdLoaded(@NonNull NativeAd ad) {
+    view = nativeParameters.factory.createNativeAd(ad, nativeParameters.viewOptions);
+    type = AdLoaderAdType.NATIVE;
+    ad.setOnPaidEventListener(new FlutterPaidEventListener(manager, this));
+    manager.onAdLoaded(adId, ad.getResponseInfo());
   }
 
   @Override

--- a/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAd.java
+++ b/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAd.java
@@ -15,15 +15,22 @@
 package io.flutter.plugins.googlemobileads;
 
 import android.util.Log;
+import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.gms.ads.AdListener;
+import com.google.android.gms.ads.AdSize;
+import com.google.android.gms.ads.BaseAdView;
+import com.google.android.gms.ads.admanager.AdManagerAdView;
+import com.google.android.gms.ads.formats.AdManagerAdViewOptions;
+import com.google.android.gms.ads.formats.OnAdManagerAdViewLoadedListener;
+import io.flutter.plugin.platform.PlatformView;
 
 /**
  * A central wrapper for {@link AdManagerAdView}, {@link NativeCustomFormatAd} and {@link NativeAd}
  * instances served for a single {@link AdRequest} or {@link AdManagerAdRequest}
  */
-class FlutterAdLoaderAd extends FlutterAd {
+class FlutterAdLoaderAd extends FlutterAd implements OnAdManagerAdViewLoadedListener {
   private static final String TAG = "FlutterAdLoaderAd";
 
   @NonNull private final AdInstanceManager manager;
@@ -33,6 +40,8 @@ class FlutterAdLoaderAd extends FlutterAd {
   @Nullable private FlutterAdManagerAdRequest adManagerRequest;
   @Nullable private AdLoaderAdType type;
   @Nullable private String formatId;
+  @Nullable private View view;
+  @Nullable protected BannerParameters bannerParameters;
 
   static class Builder {
     @Nullable private AdInstanceManager manager;
@@ -41,6 +50,7 @@ class FlutterAdLoaderAd extends FlutterAd {
     @Nullable private FlutterAdManagerAdRequest adManagerRequest;
     @Nullable private Integer id;
     @Nullable private FlutterAdLoader adLoader;
+    @Nullable private FlutterBannerParameters bannerParameters;
 
     public Builder setId(int id) {
       this.id = id;
@@ -72,6 +82,11 @@ class FlutterAdLoaderAd extends FlutterAd {
       return this;
     }
 
+    public Builder setBanner(@Nullable FlutterBannerParameters bannerParameters) {
+      this.bannerParameters = bannerParameters;
+      return this;
+    }
+
     FlutterAdLoaderAd build() {
       if (manager == null) {
         throw new IllegalStateException("manager must be provided");
@@ -92,7 +107,29 @@ class FlutterAdLoaderAd extends FlutterAd {
       } else {
         adLoaderAd = new FlutterAdLoaderAd(id, manager, adUnitId, request, adLoader);
       }
+
+      if (bannerParameters != null) {
+        adLoaderAd.bannerParameters =
+            bannerParameters.asBannerParameters(
+                new FlutterAdManagerAdViewLoadedListener(adLoaderAd));
+      }
+
       return adLoaderAd;
+    }
+  }
+
+  static class BannerParameters {
+    @NonNull final OnAdManagerAdViewLoadedListener listener;
+    @NonNull final AdSize[] adSizes;
+    @Nullable final AdManagerAdViewOptions adManagerAdViewOptions;
+
+    BannerParameters(
+        @NonNull OnAdManagerAdViewLoadedListener listener,
+        @NonNull AdSize[] adSizes,
+        @Nullable AdManagerAdViewOptions adManagerAdViewOptions) {
+      this.listener = listener;
+      this.adSizes = adSizes;
+      this.adManagerAdViewOptions = adManagerAdViewOptions;
     }
   }
 
@@ -136,13 +173,14 @@ class FlutterAdLoaderAd extends FlutterAd {
     // Note we delegate loading the ad to FlutterAdLoader mainly for testing purposes.
     // As of 20.0.0 of GMA, mockito is unable to mock AdLoader.
     if (request != null) {
-      adLoader.loadAdLoaderAd(adUnitId, adListener, request.asAdRequest(adUnitId));
+      adLoader.loadAdLoaderAd(
+          adUnitId, adListener, request.asAdRequest(adUnitId), bannerParameters);
       return;
     }
 
     if (adManagerRequest != null) {
       adLoader.loadAdManagerAdLoaderAd(
-          adUnitId, adListener, adManagerRequest.asAdManagerAdRequest(adUnitId));
+          adUnitId, adListener, adManagerRequest.asAdManagerAdRequest(adUnitId), bannerParameters);
       return;
     }
 
@@ -156,7 +194,10 @@ class FlutterAdLoaderAd extends FlutterAd {
 
   @Nullable
   FlutterAdSize getAdSize() {
-    return null;
+    if (view == null || !(view instanceof AdManagerAdView)) {
+      return null;
+    }
+    return new FlutterAdSize(((AdManagerAdView) view).getAdSize());
   }
 
   @Nullable
@@ -165,5 +206,32 @@ class FlutterAdLoaderAd extends FlutterAd {
   }
 
   @Override
-  void dispose() {}
+  @Nullable
+  public PlatformView getPlatformView() {
+    if (view == null) {
+      return null;
+    }
+
+    return new FlutterPlatformView(view);
+  }
+
+  @Override
+  public void onAdManagerAdViewLoaded(@NonNull AdManagerAdView adView) {
+    view = adView;
+    type = AdLoaderAdType.BANNER;
+    manager.onAdLoaded(adId, adView.getResponseInfo());
+  }
+
+  @Override
+  void dispose() {
+    if (view == null) {
+      return;
+    }
+
+    if (view instanceof BaseAdView) {
+      ((BaseAdView) view).destroy();
+    }
+
+    view = null;
+  }
 }

--- a/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAd.java
+++ b/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAd.java
@@ -1,0 +1,169 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.flutter.plugins.googlemobileads;
+
+import android.util.Log;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.google.android.gms.ads.AdListener;
+
+/**
+ * A central wrapper for {@link AdManagerAdView}, {@link NativeCustomFormatAd} and {@link NativeAd}
+ * instances served for a single {@link AdRequest} or {@link AdManagerAdRequest}
+ */
+class FlutterAdLoaderAd extends FlutterAd {
+  private static final String TAG = "FlutterAdLoaderAd";
+
+  @NonNull private final AdInstanceManager manager;
+  @NonNull private final String adUnitId;
+  @NonNull private final FlutterAdLoader adLoader;
+  @Nullable private FlutterAdRequest request;
+  @Nullable private FlutterAdManagerAdRequest adManagerRequest;
+  @Nullable private AdLoaderAdType type;
+  @Nullable private String formatId;
+
+  static class Builder {
+    @Nullable private AdInstanceManager manager;
+    @Nullable private String adUnitId;
+    @Nullable private FlutterAdRequest request;
+    @Nullable private FlutterAdManagerAdRequest adManagerRequest;
+    @Nullable private Integer id;
+    @Nullable private FlutterAdLoader adLoader;
+
+    public Builder setId(int id) {
+      this.id = id;
+      return this;
+    }
+
+    public Builder setManager(@NonNull AdInstanceManager manager) {
+      this.manager = manager;
+      return this;
+    }
+
+    public Builder setAdUnitId(@NonNull String adUnitId) {
+      this.adUnitId = adUnitId;
+      return this;
+    }
+
+    public Builder setRequest(@NonNull FlutterAdRequest request) {
+      this.request = request;
+      return this;
+    }
+
+    public Builder setAdManagerRequest(@NonNull FlutterAdManagerAdRequest adManagerRequest) {
+      this.adManagerRequest = adManagerRequest;
+      return this;
+    }
+
+    public Builder setFlutterAdLoader(@NonNull FlutterAdLoader adLoader) {
+      this.adLoader = adLoader;
+      return this;
+    }
+
+    FlutterAdLoaderAd build() {
+      if (manager == null) {
+        throw new IllegalStateException("manager must be provided");
+      }
+
+      if (adUnitId == null) {
+        throw new IllegalStateException("adUnitId must be provided");
+      }
+
+      if (request == null && adManagerRequest == null) {
+        throw new IllegalStateException("Either request or adManagerRequest must be provided");
+      }
+
+      final FlutterAdLoaderAd adLoaderAd;
+
+      if (request == null) {
+        adLoaderAd = new FlutterAdLoaderAd(id, manager, adUnitId, adManagerRequest, adLoader);
+      } else {
+        adLoaderAd = new FlutterAdLoaderAd(id, manager, adUnitId, request, adLoader);
+      }
+      return adLoaderAd;
+    }
+  }
+
+  protected FlutterAdLoaderAd(
+      int adId,
+      @NonNull AdInstanceManager manager,
+      @NonNull String adUnitId,
+      @NonNull FlutterAdRequest request,
+      @NonNull FlutterAdLoader adLoader) {
+    super(adId);
+
+    this.type = AdLoaderAdType.UNKNOWN;
+    this.formatId = null;
+
+    this.manager = manager;
+    this.adUnitId = adUnitId;
+    this.request = request;
+    this.adLoader = adLoader;
+  }
+
+  protected FlutterAdLoaderAd(
+      int adId,
+      @NonNull AdInstanceManager manager,
+      @NonNull String adUnitId,
+      @NonNull FlutterAdManagerAdRequest adManagerRequest,
+      @NonNull FlutterAdLoader adLoader) {
+    super(adId);
+
+    this.type = AdLoaderAdType.UNKNOWN;
+    this.formatId = null;
+
+    this.manager = manager;
+    this.adUnitId = adUnitId;
+    this.adManagerRequest = adManagerRequest;
+    this.adLoader = adLoader;
+  }
+
+  @Override
+  void load() {
+    final AdListener adListener = new FlutterAdLoaderAdListener(adId, manager);
+    // Note we delegate loading the ad to FlutterAdLoader mainly for testing purposes.
+    // As of 20.0.0 of GMA, mockito is unable to mock AdLoader.
+    if (request != null) {
+      adLoader.loadAdLoaderAd(adUnitId, adListener, request.asAdRequest(adUnitId));
+      return;
+    }
+
+    if (adManagerRequest != null) {
+      adLoader.loadAdManagerAdLoaderAd(
+          adUnitId, adListener, adManagerRequest.asAdManagerAdRequest(adUnitId));
+      return;
+    }
+
+    Log.e(TAG, "A null or invalid ad request was provided.");
+  }
+
+  @Nullable
+  AdLoaderAdType getAdLoaderAdType() {
+    return type;
+  }
+
+  @Nullable
+  FlutterAdSize getAdSize() {
+    return null;
+  }
+
+  @Nullable
+  String getFormatId() {
+    return formatId;
+  }
+
+  @Override
+  void dispose() {}
+}

--- a/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdViewOptions.java
+++ b/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdViewOptions.java
@@ -1,0 +1,37 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.c language governing permissions and
+//   limitations under the License.
+
+package io.flutter.plugins.googlemobileads;
+
+import androidx.annotation.Nullable;
+import com.google.android.gms.ads.formats.AdManagerAdViewOptions;
+
+/** A wrapper for {@link com.google.android.gms.ads.formats.AdManagerAdViewOptions}. */
+class FlutterAdManagerAdViewOptions {
+
+  @Nullable final Boolean manualImpressionsEnabled;
+
+  FlutterAdManagerAdViewOptions(@Nullable Boolean manualImpressionsEnabled) {
+    this.manualImpressionsEnabled = manualImpressionsEnabled;
+  }
+
+  AdManagerAdViewOptions asAdManagerAdViewOptions() {
+    AdManagerAdViewOptions.Builder builder = new AdManagerAdViewOptions.Builder();
+    if (manualImpressionsEnabled != null) {
+      builder.setManualImpressionsEnabled(manualImpressionsEnabled);
+    }
+    return builder.build();
+  }
+}

--- a/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterBannerParameters.java
+++ b/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterBannerParameters.java
@@ -1,0 +1,46 @@
+// Copyright 20222 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.flutter.plugins.googlemobileads;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.google.android.gms.ads.AdSize;
+import com.google.android.gms.ads.formats.OnAdManagerAdViewLoadedListener;
+import java.util.List;
+
+class FlutterBannerParameters {
+  @NonNull final List<FlutterAdSize> sizes;
+  @Nullable final FlutterAdManagerAdViewOptions adManagerAdViewOptions;
+
+  FlutterBannerParameters(
+      @NonNull List<FlutterAdSize> sizes,
+      @Nullable FlutterAdManagerAdViewOptions adManagerAdViewOptions) {
+    this.sizes = sizes;
+    this.adManagerAdViewOptions = adManagerAdViewOptions;
+  }
+
+  FlutterAdLoaderAd.BannerParameters asBannerParameters(
+      @NonNull OnAdManagerAdViewLoadedListener listener) {
+    AdSize[] adSizes = new AdSize[sizes.size()];
+    int i = 0;
+    for (FlutterAdSize size : sizes) {
+      adSizes[i++] = size.getAdSize();
+    }
+    return new FlutterAdLoaderAd.BannerParameters(
+        listener,
+        adSizes,
+        adManagerAdViewOptions != null ? adManagerAdViewOptions.asAdManagerAdViewOptions() : null);
+  }
+}

--- a/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterCustomParameters.java
+++ b/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterCustomParameters.java
@@ -20,10 +20,10 @@ class FlutterCustomParameters {
 
   FlutterAdLoaderAd.CustomParameters asCustomParameters(
       @NonNull OnCustomFormatAdLoadedListener listener,
-      @NonNull Map<String, CustomAdFactory> availableFactories) {
+      @NonNull Map<String, CustomAdFactory> registeredFactories) {
     Map<String, CustomAdFactory> factories = new HashMap<>();
     for (String formatId : formatIds) {
-      factories.put(formatId, availableFactories.get(formatId));
+      factories.put(formatId, registeredFactories.get(formatId));
     }
     return new FlutterAdLoaderAd.CustomParameters(listener, factories, viewOptions);
   }

--- a/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterCustomParameters.java
+++ b/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterCustomParameters.java
@@ -1,0 +1,30 @@
+package io.flutter.plugins.googlemobileads;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.google.android.gms.ads.nativead.NativeCustomFormatAd.OnCustomFormatAdLoadedListener;
+import io.flutter.plugins.googlemobileads.CustomAdFactory;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class FlutterCustomParameters {
+  @NonNull final List<String> formatIds;
+  @Nullable final Map<String, Object> viewOptions;
+
+  FlutterCustomParameters(
+      @NonNull List<String> formatIds, @Nullable Map<String, Object> viewOptions) {
+    this.formatIds = formatIds;
+    this.viewOptions = viewOptions;
+  }
+
+  FlutterAdLoaderAd.CustomParameters asCustomParameters(
+      @NonNull OnCustomFormatAdLoadedListener listener,
+      @NonNull Map<String, CustomAdFactory> availableFactories) {
+    Map<String, CustomAdFactory> factories = new HashMap<>();
+    for (String formatId : formatIds) {
+      factories.put(formatId, availableFactories.get(formatId));
+    }
+    return new FlutterAdLoaderAd.CustomParameters(listener, factories, viewOptions);
+  }
+}

--- a/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterNativeAd.java
+++ b/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterNativeAd.java
@@ -31,7 +31,7 @@ import io.flutter.plugins.googlemobileads.nativetemplates.FlutterNativeTemplateS
 import java.util.Map;
 
 /** A wrapper for {@link NativeAd}. */
-class FlutterNativeAd extends FlutterAd {
+class FlutterNativeAd extends FlutterAd implements OnNativeAdLoadedListener {
   private static final String TAG = "FlutterNativeAd";
 
   @NonNull private final AdInstanceManager manager;
@@ -247,7 +247,8 @@ class FlutterNativeAd extends FlutterAd {
     return null;
   }
 
-  void onNativeAdLoaded(@NonNull NativeAd nativeAd) {
+  @Override
+  public void onNativeAdLoaded(@NonNull NativeAd nativeAd) {
     if (nativeTemplateStyle != null) {
       templateView = nativeTemplateStyle.asTemplateView(context);
       templateView.setNativeAd(nativeAd);

--- a/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterNativeParameters.java
+++ b/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterNativeParameters.java
@@ -1,0 +1,47 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.flutter.plugins.googlemobileads;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.google.android.gms.ads.nativead.NativeAd.OnNativeAdLoadedListener;
+import com.google.android.gms.ads.nativead.NativeAdOptions;
+import java.util.Map;
+
+class FlutterNativeParameters {
+  @NonNull final String factoryId;
+  @Nullable final FlutterNativeAdOptions nativeAdOptions;
+  @Nullable final Map<String, Object> viewOptions;
+
+  FlutterNativeParameters(
+      @NonNull String factoryId,
+      @Nullable FlutterNativeAdOptions nativeAdOptions,
+      @Nullable Map<String, Object> viewOptions) {
+    this.factoryId = factoryId;
+    this.nativeAdOptions = nativeAdOptions;
+    this.viewOptions = viewOptions;
+  }
+
+  FlutterAdLoaderAd.NativeParameters asNativeParameters(
+      @NonNull OnNativeAdLoadedListener listener,
+      @NonNull Map<String, NativeAdFactory> registeredFactories) {
+    NativeAdOptions nativeAdOptions = null;
+    if (this.nativeAdOptions != null) {
+      nativeAdOptions = this.nativeAdOptions.asNativeAdOptions();
+    }
+    return new FlutterAdLoaderAd.NativeParameters(
+        listener, registeredFactories.get(factoryId), nativeAdOptions, viewOptions);
+  }
+}

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
@@ -581,6 +581,22 @@ public class AdMessageCodecTest {
     assertEquals(result.sizes.get(0).height, 2);
     assertNull(result.adManagerAdViewOptions.manualImpressionsEnabled);
   }
+
+  @Test
+  public void encodeCustomParameters() {
+    final ByteBuffer data =
+        codec.encodeMessage(
+            new FlutterCustomParameters(
+                Collections.singletonList("format-id"), Collections.singletonMap("key", "value")));
+
+    final FlutterCustomParameters result =
+        (FlutterCustomParameters) codec.decodeMessage((ByteBuffer) data.position(0));
+
+    assertEquals(result.formatIds.size(), 1);
+    assertEquals(result.formatIds.get(0), "format-id");
+    assertEquals(result.viewOptions.size(), 1);
+    assertEquals(result.viewOptions.get("key"), "value");
+  }
 }
 
 class DummyMediationExtras extends FlutterMediationExtras {

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
@@ -597,6 +597,29 @@ public class AdMessageCodecTest {
     assertEquals(result.viewOptions.size(), 1);
     assertEquals(result.viewOptions.get("key"), "value");
   }
+
+  @Test
+  public void encodeNativeParameters() {
+    final ByteBuffer data =
+        codec.encodeMessage(
+            new FlutterNativeParameters(
+                "factory-id",
+                new FlutterNativeAdOptions(1, 1, null, true, true, true),
+                Collections.singletonMap("key", "value")));
+
+    final FlutterNativeParameters result =
+        (FlutterNativeParameters) codec.decodeMessage((ByteBuffer) data.position(0));
+
+    assertEquals(result.factoryId, "factory-id");
+    assertEquals(result.nativeAdOptions.adChoicesPlacement, Integer.valueOf(1));
+    assertEquals(result.nativeAdOptions.mediaAspectRatio, Integer.valueOf(1));
+    assertNull(result.nativeAdOptions.videoOptions);
+    assertTrue(result.nativeAdOptions.requestCustomMuteThisAd);
+    assertTrue(result.nativeAdOptions.shouldRequestMultipleImages);
+    assertTrue(result.nativeAdOptions.shouldReturnUrlsForImageAssets);
+    assertEquals(result.viewOptions.size(), 1);
+    assertEquals(result.viewOptions.get("key"), "value");
+  }
 }
 
 class DummyMediationExtras extends FlutterMediationExtras {

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
@@ -537,6 +537,50 @@ public class AdMessageCodecTest {
         RequestConfiguration.TAG_FOR_UNDER_AGE_OF_CONSENT_FALSE);
     assertEquals(result.getTestDeviceIds(), Arrays.asList("test-device-id"));
   }
+
+  @Test
+  public void encodeAdManagerAdViewOptionsNull() {
+    final ByteBuffer data = codec.encodeMessage(new FlutterAdManagerAdViewOptions(null));
+
+    final FlutterAdManagerAdViewOptions result =
+        (FlutterAdManagerAdViewOptions) codec.decodeMessage((ByteBuffer) data.position(0));
+    assertNull(result.manualImpressionsEnabled);
+  }
+
+  @Test
+  public void encodeAdManagerAdViewOptionsTrue() {
+    final ByteBuffer data = codec.encodeMessage(new FlutterAdManagerAdViewOptions(true));
+
+    final FlutterAdManagerAdViewOptions result =
+        (FlutterAdManagerAdViewOptions) codec.decodeMessage((ByteBuffer) data.position(0));
+    assertTrue(result.manualImpressionsEnabled);
+  }
+
+  @Test
+  public void encodeAdManagerAdViewOptionsFalse() {
+    final ByteBuffer data = codec.encodeMessage(new FlutterAdManagerAdViewOptions(false));
+
+    final FlutterAdManagerAdViewOptions result =
+        (FlutterAdManagerAdViewOptions) codec.decodeMessage((ByteBuffer) data.position(0));
+    assertFalse(result.manualImpressionsEnabled);
+  }
+
+  @Test
+  public void encodeBannerParameters() {
+    final ByteBuffer data =
+        codec.encodeMessage(
+            new FlutterBannerParameters(
+                Collections.singletonList(new FlutterAdSize(1, 2)),
+                new FlutterAdManagerAdViewOptions(null)));
+
+    final FlutterBannerParameters result =
+        (FlutterBannerParameters) codec.decodeMessage((ByteBuffer) data.position(0));
+
+    assertEquals(result.sizes.size(), 1);
+    assertEquals(result.sizes.get(0).width, 1);
+    assertEquals(result.sizes.get(0).height, 2);
+    assertNull(result.adManagerAdViewOptions.manualImpressionsEnabled);
+  }
 }
 
 class DummyMediationExtras extends FlutterMediationExtras {

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAdTest.java
@@ -1,0 +1,164 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.flutter.plugins.googlemobileads;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.app.Activity;
+import com.google.android.gms.ads.AdListener;
+import com.google.android.gms.ads.AdRequest;
+import com.google.android.gms.ads.LoadAdError;
+import com.google.android.gms.ads.admanager.AdManagerAdRequest;
+import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugins.googlemobileads.FlutterAd.FlutterLoadAdError;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.robolectric.RobolectricTestRunner;
+
+/** Tests for {@link FlutterAdLoaderAd} */
+@RunWith(RobolectricTestRunner.class)
+public class FlutterAdLoaderAdTest {
+
+  private AdInstanceManager testManager;
+  private final FlutterAdRequest request = new FlutterAdRequest.Builder().build();
+
+  @Before
+  public void setup() {
+    testManager = spy(new AdInstanceManager(mock(MethodChannel.class)));
+    when(testManager.getActivity()).thenReturn(mock(Activity.class));
+  }
+
+  @Test
+  public void loadAdLoaderAdWithAdManagerAdRequest() {
+    final FlutterAdManagerAdRequest mockFlutterRequest = mock(FlutterAdManagerAdRequest.class);
+    final AdManagerAdRequest mockRequest = mock(AdManagerAdRequest.class);
+    when(mockFlutterRequest.asAdManagerAdRequest(anyString())).thenReturn(mockRequest);
+    FlutterAdLoader mockLoader = mock(FlutterAdLoader.class);
+    final FlutterAdLoaderAd adLoaderAd =
+        new FlutterAdLoaderAd(1, testManager, "testId", mockFlutterRequest, mockLoader);
+
+    final LoadAdError mockLoadAdError = mock(LoadAdError.class);
+    when(mockLoadAdError.getCode()).thenReturn(1);
+    when(mockLoadAdError.getDomain()).thenReturn("2");
+    when(mockLoadAdError.getMessage()).thenReturn("3");
+
+    doAnswer(
+            new Answer() {
+              @Override
+              public Object answer(InvocationOnMock invocation) {
+                AdListener listener = invocation.getArgument(1);
+                listener.onAdClicked();
+                listener.onAdClosed();
+                listener.onAdFailedToLoad(mockLoadAdError);
+                listener.onAdImpression();
+                listener.onAdOpened();
+                return null;
+              }
+            })
+        .when(mockLoader)
+        .loadAdManagerAdLoaderAd(eq("testId"), any(AdListener.class), eq(mockRequest));
+
+    adLoaderAd.load();
+
+    verify(mockLoader)
+        .loadAdManagerAdLoaderAd(eq("testId"), any(AdListener.class), eq(mockRequest));
+
+    verify(testManager).onAdClicked(eq(1));
+    verify(testManager).onAdClosed(eq(1));
+    FlutterLoadAdError expectedError = new FlutterLoadAdError(mockLoadAdError);
+    verify(testManager).onAdFailedToLoad(eq(1), eq(expectedError));
+    verify(testManager).onAdImpression(eq(1));
+    verify(testManager).onAdOpened(eq(1));
+  }
+
+  @Test
+  public void loadAdLoaderAdWithAdRequest() {
+    final FlutterAdRequest mockFlutterRequest = mock(FlutterAdRequest.class);
+    final AdRequest mockRequest = mock(AdRequest.class);
+    when(mockFlutterRequest.asAdRequest(anyString())).thenReturn(mockRequest);
+    FlutterAdLoader mockLoader = mock(FlutterAdLoader.class);
+    final FlutterAdLoaderAd adLoaderAd =
+        new FlutterAdLoaderAd(1, testManager, "testId", mockFlutterRequest, mockLoader);
+
+    final LoadAdError mockLoadAdError = mock(LoadAdError.class);
+    when(mockLoadAdError.getCode()).thenReturn(1);
+    when(mockLoadAdError.getDomain()).thenReturn("2");
+    when(mockLoadAdError.getMessage()).thenReturn("3");
+
+    doAnswer(
+            new Answer() {
+              @Override
+              public Object answer(InvocationOnMock invocation) {
+                AdListener listener = invocation.getArgument(1);
+                listener.onAdClicked();
+                listener.onAdClosed();
+                listener.onAdFailedToLoad(mockLoadAdError);
+                listener.onAdImpression();
+                listener.onAdOpened();
+                return null;
+              }
+            })
+        .when(mockLoader)
+        .loadAdLoaderAd(eq("testId"), any(AdListener.class), eq(mockRequest));
+
+    adLoaderAd.load();
+
+    verify(mockLoader).loadAdLoaderAd(eq("testId"), any(AdListener.class), eq(mockRequest));
+
+    verify(testManager).onAdClicked(eq(1));
+    verify(testManager).onAdClosed(eq(1));
+    FlutterLoadAdError expectedError = new FlutterLoadAdError(mockLoadAdError);
+    verify(testManager).onAdFailedToLoad(eq(1), eq(expectedError));
+    verify(testManager).onAdImpression(eq(1));
+    verify(testManager).onAdOpened(eq(1));
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void adLoaderAdBuilderNullManager() {
+    new FlutterAdLoaderAd.Builder()
+        .setManager(null)
+        .setAdUnitId("testId")
+        .setRequest(request)
+        .build();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void adLoaderAdBuilderNullAdUnitId() {
+    new FlutterAdLoaderAd.Builder()
+        .setManager(testManager)
+        .setAdUnitId(null)
+        .setRequest(request)
+        .build();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void adLoaderAdBuilderNullRequest() {
+    new FlutterAdLoaderAd.Builder()
+        .setManager(testManager)
+        .setAdUnitId("testId")
+        .setRequest(null)
+        .build();
+  }
+}

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAdTest.java
@@ -14,20 +14,26 @@
 
 package io.flutter.plugins.googlemobileads;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
 import com.google.android.gms.ads.AdListener;
 import com.google.android.gms.ads.AdRequest;
+import com.google.android.gms.ads.AdSize;
 import com.google.android.gms.ads.LoadAdError;
+import com.google.android.gms.ads.ResponseInfo;
 import com.google.android.gms.ads.admanager.AdManagerAdRequest;
+import com.google.android.gms.ads.admanager.AdManagerAdView;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugins.googlemobileads.FlutterAd.FlutterLoadAdError;
 import org.junit.Before;
@@ -78,12 +84,12 @@ public class FlutterAdLoaderAdTest {
               }
             })
         .when(mockLoader)
-        .loadAdManagerAdLoaderAd(eq("testId"), any(AdListener.class), eq(mockRequest));
+        .loadAdManagerAdLoaderAd(eq("testId"), any(AdListener.class), eq(mockRequest), isNull());
 
     adLoaderAd.load();
 
     verify(mockLoader)
-        .loadAdManagerAdLoaderAd(eq("testId"), any(AdListener.class), eq(mockRequest));
+        .loadAdManagerAdLoaderAd(eq("testId"), any(AdListener.class), eq(mockRequest), isNull());
 
     verify(testManager).onAdClicked(eq(1));
     verify(testManager).onAdClosed(eq(1));
@@ -121,11 +127,12 @@ public class FlutterAdLoaderAdTest {
               }
             })
         .when(mockLoader)
-        .loadAdLoaderAd(eq("testId"), any(AdListener.class), eq(mockRequest));
+        .loadAdLoaderAd(eq("testId"), any(AdListener.class), eq(mockRequest), isNull());
 
     adLoaderAd.load();
 
-    verify(mockLoader).loadAdLoaderAd(eq("testId"), any(AdListener.class), eq(mockRequest));
+    verify(mockLoader)
+        .loadAdLoaderAd(eq("testId"), any(AdListener.class), eq(mockRequest), isNull());
 
     verify(testManager).onAdClicked(eq(1));
     verify(testManager).onAdClosed(eq(1));
@@ -133,6 +140,73 @@ public class FlutterAdLoaderAdTest {
     verify(testManager).onAdFailedToLoad(eq(1), eq(expectedError));
     verify(testManager).onAdImpression(eq(1));
     verify(testManager).onAdOpened(eq(1));
+  }
+
+  @Test
+  public void loadAdLoaderAdBannerWithAdManagerAdRequest() {
+    final FlutterAdManagerAdRequest mockFlutterRequest = mock(FlutterAdManagerAdRequest.class);
+    final AdManagerAdRequest mockRequest = mock(AdManagerAdRequest.class);
+    when(mockFlutterRequest.asAdManagerAdRequest(anyString())).thenReturn(mockRequest);
+    FlutterAdLoader mockLoader = mock(FlutterAdLoader.class);
+    final FlutterAdLoaderAd adLoaderAd =
+        new FlutterAdLoaderAd(1, testManager, "testId", mockFlutterRequest, mockLoader);
+    final FlutterAdManagerAdViewLoadedListener listener =
+        new FlutterAdManagerAdViewLoadedListener(adLoaderAd);
+    final FlutterAdLoaderAd.BannerParameters bannerParameters =
+        new FlutterAdLoaderAd.BannerParameters(listener, new AdSize[] {AdSize.BANNER}, null);
+    adLoaderAd.bannerParameters = bannerParameters;
+
+    final LoadAdError mockLoadAdError = mock(LoadAdError.class);
+    when(mockLoadAdError.getCode()).thenReturn(1);
+    when(mockLoadAdError.getDomain()).thenReturn("2");
+    when(mockLoadAdError.getMessage()).thenReturn("3");
+
+    final AdManagerAdView mockAdView = mock(AdManagerAdView.class);
+    when(mockAdView.getAdSize()).thenReturn(new AdSize(0, 0));
+    final ResponseInfo mockResponseInfo = mock(ResponseInfo.class);
+    when(mockAdView.getResponseInfo()).thenReturn(mockResponseInfo);
+
+    doAnswer(
+            new Answer() {
+              @Override
+              public Object answer(InvocationOnMock invocation) {
+                AdListener listener = invocation.getArgument(1);
+                listener.onAdClicked();
+                listener.onAdClosed();
+                listener.onAdFailedToLoad(mockLoadAdError);
+                listener.onAdImpression();
+                listener.onAdOpened();
+
+                FlutterAdLoaderAd.BannerParameters bannerParameters = invocation.getArgument(3);
+                bannerParameters.listener.onAdManagerAdViewLoaded(mockAdView);
+                return null;
+              }
+            })
+        .when(mockLoader)
+        .loadAdManagerAdLoaderAd(
+            eq("testId"), any(AdListener.class), eq(mockRequest), eq(bannerParameters));
+
+    adLoaderAd.load();
+
+    assertEquals(adLoaderAd.getAdLoaderAdType(), AdLoaderAdType.BANNER);
+
+    final FlutterAdSize adSize = adLoaderAd.getAdSize();
+    assertEquals(adSize.width, 0);
+    assertEquals(adSize.height, 0);
+
+    verify(mockAdView, times(1)).getAdSize();
+
+    verify(mockLoader)
+        .loadAdManagerAdLoaderAd(
+            eq("testId"), any(AdListener.class), eq(mockRequest), eq(bannerParameters));
+
+    verify(testManager).onAdClicked(eq(1));
+    verify(testManager).onAdClosed(eq(1));
+    FlutterLoadAdError expectedError = new FlutterLoadAdError(mockLoadAdError);
+    verify(testManager).onAdFailedToLoad(eq(1), eq(expectedError));
+    verify(testManager).onAdImpression(eq(1));
+    verify(testManager).onAdOpened(eq(1));
+    verify(testManager).onAdLoaded(eq(1), eq(mockResponseInfo));
   }
 
   @Test(expected = IllegalStateException.class)

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAdTest.java
@@ -34,8 +34,10 @@ import com.google.android.gms.ads.LoadAdError;
 import com.google.android.gms.ads.ResponseInfo;
 import com.google.android.gms.ads.admanager.AdManagerAdRequest;
 import com.google.android.gms.ads.admanager.AdManagerAdView;
+import com.google.android.gms.ads.nativead.NativeCustomFormatAd;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugins.googlemobileads.FlutterAd.FlutterLoadAdError;
+import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -84,12 +86,14 @@ public class FlutterAdLoaderAdTest {
               }
             })
         .when(mockLoader)
-        .loadAdManagerAdLoaderAd(eq("testId"), any(AdListener.class), eq(mockRequest), isNull());
+        .loadAdManagerAdLoaderAd(
+            eq("testId"), any(AdListener.class), eq(mockRequest), isNull(), isNull());
 
     adLoaderAd.load();
 
     verify(mockLoader)
-        .loadAdManagerAdLoaderAd(eq("testId"), any(AdListener.class), eq(mockRequest), isNull());
+        .loadAdManagerAdLoaderAd(
+            eq("testId"), any(AdListener.class), eq(mockRequest), isNull(), isNull());
 
     verify(testManager).onAdClicked(eq(1));
     verify(testManager).onAdClosed(eq(1));
@@ -127,12 +131,12 @@ public class FlutterAdLoaderAdTest {
               }
             })
         .when(mockLoader)
-        .loadAdLoaderAd(eq("testId"), any(AdListener.class), eq(mockRequest), isNull());
+        .loadAdLoaderAd(eq("testId"), any(AdListener.class), eq(mockRequest), isNull(), isNull());
 
     adLoaderAd.load();
 
     verify(mockLoader)
-        .loadAdLoaderAd(eq("testId"), any(AdListener.class), eq(mockRequest), isNull());
+        .loadAdLoaderAd(eq("testId"), any(AdListener.class), eq(mockRequest), isNull(), isNull());
 
     verify(testManager).onAdClicked(eq(1));
     verify(testManager).onAdClosed(eq(1));
@@ -184,7 +188,7 @@ public class FlutterAdLoaderAdTest {
             })
         .when(mockLoader)
         .loadAdManagerAdLoaderAd(
-            eq("testId"), any(AdListener.class), eq(mockRequest), eq(bannerParameters));
+            eq("testId"), any(AdListener.class), eq(mockRequest), eq(bannerParameters), isNull());
 
     adLoaderAd.load();
 
@@ -198,7 +202,7 @@ public class FlutterAdLoaderAdTest {
 
     verify(mockLoader)
         .loadAdManagerAdLoaderAd(
-            eq("testId"), any(AdListener.class), eq(mockRequest), eq(bannerParameters));
+            eq("testId"), any(AdListener.class), eq(mockRequest), eq(bannerParameters), isNull());
 
     verify(testManager).onAdClicked(eq(1));
     verify(testManager).onAdClosed(eq(1));
@@ -207,6 +211,69 @@ public class FlutterAdLoaderAdTest {
     verify(testManager).onAdImpression(eq(1));
     verify(testManager).onAdOpened(eq(1));
     verify(testManager).onAdLoaded(eq(1), eq(mockResponseInfo));
+  }
+
+  @Test
+  public void loadAdLoaderAdCustomWithAdManagerAdRequest() {
+    final FlutterAdManagerAdRequest mockFlutterRequest = mock(FlutterAdManagerAdRequest.class);
+    final AdManagerAdRequest mockRequest = mock(AdManagerAdRequest.class);
+    when(mockFlutterRequest.asAdManagerAdRequest(anyString())).thenReturn(mockRequest);
+    FlutterAdLoader mockLoader = mock(FlutterAdLoader.class);
+    final FlutterAdLoaderAd adLoaderAd =
+        new FlutterAdLoaderAd(1, testManager, "testId", mockFlutterRequest, mockLoader);
+    final FlutterCustomFormatAdLoadedListener listener =
+        new FlutterCustomFormatAdLoadedListener(adLoaderAd);
+    final CustomAdFactory mockCustomAdFactory = mock(CustomAdFactory.class);
+    final FlutterAdLoaderAd.CustomParameters customParameters =
+        new FlutterAdLoaderAd.CustomParameters(
+            listener, Collections.singletonMap("formatId", mockCustomAdFactory), null);
+    adLoaderAd.customParameters = customParameters;
+
+    final LoadAdError mockLoadAdError = mock(LoadAdError.class);
+    when(mockLoadAdError.getCode()).thenReturn(1);
+    when(mockLoadAdError.getDomain()).thenReturn("2");
+    when(mockLoadAdError.getMessage()).thenReturn("3");
+
+    final NativeCustomFormatAd mockNativeCustomFormatAd = mock(NativeCustomFormatAd.class);
+    when(mockNativeCustomFormatAd.getCustomFormatId()).thenReturn("formatId");
+
+    doAnswer(
+            new Answer() {
+              @Override
+              public Object answer(InvocationOnMock invocation) {
+                AdListener listener = invocation.getArgument(1);
+                listener.onAdClicked();
+                listener.onAdClosed();
+                listener.onAdFailedToLoad(mockLoadAdError);
+                listener.onAdImpression();
+                listener.onAdOpened();
+
+                FlutterAdLoaderAd.CustomParameters customParameters = invocation.getArgument(4);
+                customParameters.listener.onCustomFormatAdLoaded(mockNativeCustomFormatAd);
+                return null;
+              }
+            })
+        .when(mockLoader)
+        .loadAdManagerAdLoaderAd(
+            eq("testId"), any(AdListener.class), eq(mockRequest), isNull(), eq(customParameters));
+
+    adLoaderAd.load();
+
+    assertEquals(adLoaderAd.getAdLoaderAdType(), AdLoaderAdType.CUSTOM);
+
+    assertEquals(adLoaderAd.getFormatId(), "formatId");
+
+    verify(mockLoader)
+        .loadAdManagerAdLoaderAd(
+            eq("testId"), any(AdListener.class), eq(mockRequest), isNull(), eq(customParameters));
+
+    verify(testManager).onAdClicked(eq(1));
+    verify(testManager).onAdClosed(eq(1));
+    FlutterLoadAdError expectedError = new FlutterLoadAdError(mockLoadAdError);
+    verify(testManager).onAdFailedToLoad(eq(1), eq(expectedError));
+    verify(testManager).onAdImpression(eq(1));
+    verify(testManager).onAdOpened(eq(1));
+    verify(testManager).onAdLoaded(eq(1), isNull());
   }
 
   @Test(expected = IllegalStateException.class)

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdLoaderAdTest.java
@@ -30,10 +30,12 @@ import android.app.Activity;
 import com.google.android.gms.ads.AdListener;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.AdSize;
+import com.google.android.gms.ads.AdValue;
 import com.google.android.gms.ads.LoadAdError;
 import com.google.android.gms.ads.ResponseInfo;
 import com.google.android.gms.ads.admanager.AdManagerAdRequest;
 import com.google.android.gms.ads.admanager.AdManagerAdView;
+import com.google.android.gms.ads.nativead.NativeAd;
 import com.google.android.gms.ads.nativead.NativeCustomFormatAd;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugins.googlemobileads.FlutterAd.FlutterLoadAdError;
@@ -41,6 +43,7 @@ import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricTestRunner;
@@ -87,13 +90,13 @@ public class FlutterAdLoaderAdTest {
             })
         .when(mockLoader)
         .loadAdManagerAdLoaderAd(
-            eq("testId"), any(AdListener.class), eq(mockRequest), isNull(), isNull());
+            eq("testId"), any(AdListener.class), eq(mockRequest), isNull(), isNull(), isNull());
 
     adLoaderAd.load();
 
     verify(mockLoader)
         .loadAdManagerAdLoaderAd(
-            eq("testId"), any(AdListener.class), eq(mockRequest), isNull(), isNull());
+            eq("testId"), any(AdListener.class), eq(mockRequest), isNull(), isNull(), isNull());
 
     verify(testManager).onAdClicked(eq(1));
     verify(testManager).onAdClosed(eq(1));
@@ -131,12 +134,14 @@ public class FlutterAdLoaderAdTest {
               }
             })
         .when(mockLoader)
-        .loadAdLoaderAd(eq("testId"), any(AdListener.class), eq(mockRequest), isNull(), isNull());
+        .loadAdLoaderAd(
+            eq("testId"), any(AdListener.class), eq(mockRequest), isNull(), isNull(), isNull());
 
     adLoaderAd.load();
 
     verify(mockLoader)
-        .loadAdLoaderAd(eq("testId"), any(AdListener.class), eq(mockRequest), isNull(), isNull());
+        .loadAdLoaderAd(
+            eq("testId"), any(AdListener.class), eq(mockRequest), isNull(), isNull(), isNull());
 
     verify(testManager).onAdClicked(eq(1));
     verify(testManager).onAdClosed(eq(1));
@@ -188,7 +193,12 @@ public class FlutterAdLoaderAdTest {
             })
         .when(mockLoader)
         .loadAdManagerAdLoaderAd(
-            eq("testId"), any(AdListener.class), eq(mockRequest), eq(bannerParameters), isNull());
+            eq("testId"),
+            any(AdListener.class),
+            eq(mockRequest),
+            eq(bannerParameters),
+            isNull(),
+            isNull());
 
     adLoaderAd.load();
 
@@ -202,7 +212,12 @@ public class FlutterAdLoaderAdTest {
 
     verify(mockLoader)
         .loadAdManagerAdLoaderAd(
-            eq("testId"), any(AdListener.class), eq(mockRequest), eq(bannerParameters), isNull());
+            eq("testId"),
+            any(AdListener.class),
+            eq(mockRequest),
+            eq(bannerParameters),
+            isNull(),
+            isNull());
 
     verify(testManager).onAdClicked(eq(1));
     verify(testManager).onAdClosed(eq(1));
@@ -255,7 +270,12 @@ public class FlutterAdLoaderAdTest {
             })
         .when(mockLoader)
         .loadAdManagerAdLoaderAd(
-            eq("testId"), any(AdListener.class), eq(mockRequest), isNull(), eq(customParameters));
+            eq("testId"),
+            any(AdListener.class),
+            eq(mockRequest),
+            isNull(),
+            eq(customParameters),
+            isNull());
 
     adLoaderAd.load();
 
@@ -265,7 +285,12 @@ public class FlutterAdLoaderAdTest {
 
     verify(mockLoader)
         .loadAdManagerAdLoaderAd(
-            eq("testId"), any(AdListener.class), eq(mockRequest), isNull(), eq(customParameters));
+            eq("testId"),
+            any(AdListener.class),
+            eq(mockRequest),
+            isNull(),
+            eq(customParameters),
+            isNull());
 
     verify(testManager).onAdClicked(eq(1));
     verify(testManager).onAdClosed(eq(1));
@@ -274,6 +299,100 @@ public class FlutterAdLoaderAdTest {
     verify(testManager).onAdImpression(eq(1));
     verify(testManager).onAdOpened(eq(1));
     verify(testManager).onAdLoaded(eq(1), isNull());
+  }
+
+  @Test
+  public void loadAdLoaderAdNativeWithAdManagerAdRequest() {
+    final FlutterAdManagerAdRequest mockFlutterRequest = mock(FlutterAdManagerAdRequest.class);
+    final AdManagerAdRequest mockRequest = mock(AdManagerAdRequest.class);
+    when(mockFlutterRequest.asAdManagerAdRequest(anyString())).thenReturn(mockRequest);
+    FlutterAdLoader mockLoader = mock(FlutterAdLoader.class);
+    final FlutterAdLoaderAd adLoaderAd =
+        new FlutterAdLoaderAd(1, testManager, "testId", mockFlutterRequest, mockLoader);
+    final FlutterNativeAdLoadedListener listener = new FlutterNativeAdLoadedListener(adLoaderAd);
+    final NativeAdFactory mockNativeAdFactory = mock(NativeAdFactory.class);
+    final FlutterAdLoaderAd.NativeParameters nativeParameters =
+        new FlutterAdLoaderAd.NativeParameters(listener, mockNativeAdFactory, null, null);
+    adLoaderAd.nativeParameters = nativeParameters;
+
+    final LoadAdError mockLoadAdError = mock(LoadAdError.class);
+    when(mockLoadAdError.getCode()).thenReturn(1);
+    when(mockLoadAdError.getDomain()).thenReturn("2");
+    when(mockLoadAdError.getMessage()).thenReturn("3");
+
+    final ResponseInfo mockResponseInfo = mock(ResponseInfo.class);
+    final NativeAd mockNativeAd = mock(NativeAd.class);
+    when(mockNativeAd.getResponseInfo()).thenReturn(mockResponseInfo);
+
+    doAnswer(
+            new Answer() {
+              @Override
+              public Object answer(InvocationOnMock invocation) {
+                AdListener listener = invocation.getArgument(1);
+                listener.onAdClicked();
+                listener.onAdClosed();
+                listener.onAdFailedToLoad(mockLoadAdError);
+                listener.onAdImpression();
+                listener.onAdOpened();
+
+                FlutterAdLoaderAd.NativeParameters nativeParameters = invocation.getArgument(5);
+                nativeParameters.listener.onNativeAdLoaded(mockNativeAd);
+                return null;
+              }
+            })
+        .when(mockLoader)
+        .loadAdManagerAdLoaderAd(
+            eq("testId"),
+            any(AdListener.class),
+            eq(mockRequest),
+            isNull(),
+            isNull(),
+            eq(nativeParameters));
+
+    final AdValue mockAdValue = mock(AdValue.class);
+    when(mockAdValue.getCurrencyCode()).thenReturn("Dollars");
+    when(mockAdValue.getPrecisionType()).thenReturn(1);
+    when(mockAdValue.getValueMicros()).thenReturn(1000L);
+
+    doAnswer(
+            new Answer() {
+              @Override
+              public Object answer(InvocationOnMock invocation) {
+                FlutterPaidEventListener listener = invocation.getArgument(0);
+                listener.onPaidEvent(mockAdValue);
+                return null;
+              }
+            })
+        .when(mockNativeAd)
+        .setOnPaidEventListener(any(FlutterPaidEventListener.class));
+
+    adLoaderAd.load();
+
+    assertEquals(adLoaderAd.getAdLoaderAdType(), AdLoaderAdType.NATIVE);
+
+    verify(mockLoader)
+        .loadAdManagerAdLoaderAd(
+            eq("testId"),
+            any(AdListener.class),
+            eq(mockRequest),
+            isNull(),
+            isNull(),
+            eq(nativeParameters));
+
+    verify(testManager).onAdClicked(eq(1));
+    verify(testManager).onAdClosed(eq(1));
+    FlutterLoadAdError expectedError = new FlutterLoadAdError(mockLoadAdError);
+    verify(testManager).onAdFailedToLoad(eq(1), eq(expectedError));
+    verify(testManager).onAdImpression(eq(1));
+    verify(testManager).onAdOpened(eq(1));
+    verify(testManager).onAdLoaded(eq(1), eq(mockResponseInfo));
+
+    final ArgumentCaptor<FlutterAdValue> adValueCaptor =
+        ArgumentCaptor.forClass(FlutterAdValue.class);
+    verify(testManager).onPaidEvent(eq(adLoaderAd), adValueCaptor.capture());
+    assertEquals(adValueCaptor.getValue().currencyCode, "Dollars");
+    assertEquals(adValueCaptor.getValue().precisionType, 1);
+    assertEquals(adValueCaptor.getValue().valueMicros, 1000L);
   }
 
   @Test(expected = IllegalStateException.class)

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdViewOptionsTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdViewOptionsTest.java
@@ -1,0 +1,59 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.flutter.plugins.googlemobileads;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.android.gms.ads.formats.AdManagerAdViewOptions;
+import org.junit.Test;
+
+/** Tests for {@link FlutterAdManagerAdViewOptions}. */
+public class FlutterAdManagerAdViewOptionsTest {
+
+  @Test
+  public void testAsAdManagerAdViewOptions_null() {
+    FlutterAdManagerAdViewOptions flutterAdManagerAdViewOptions =
+        new FlutterAdManagerAdViewOptions(null);
+
+    AdManagerAdViewOptions adManagerAdViewOptions =
+        flutterAdManagerAdViewOptions.asAdManagerAdViewOptions();
+    AdManagerAdViewOptions defaultOptions = new AdManagerAdViewOptions.Builder().build();
+    assertEquals(
+        adManagerAdViewOptions.getManualImpressionsEnabled(),
+        defaultOptions.getManualImpressionsEnabled());
+  }
+
+  @Test
+  public void testAsAdManagerAdViewOptions_true() {
+    FlutterAdManagerAdViewOptions flutterAdManagerAdViewOptions =
+        new FlutterAdManagerAdViewOptions(true);
+
+    AdManagerAdViewOptions adManagerAdViewOptions =
+        flutterAdManagerAdViewOptions.asAdManagerAdViewOptions();
+    assertTrue(adManagerAdViewOptions.getManualImpressionsEnabled());
+  }
+
+  @Test
+  public void testAsAdManagerAdViewOptions_false() {
+    FlutterAdManagerAdViewOptions flutterAdManagerAdViewOptions =
+        new FlutterAdManagerAdViewOptions(false);
+
+    AdManagerAdViewOptions adManagerAdViewOptions =
+        flutterAdManagerAdViewOptions.asAdManagerAdViewOptions();
+    assertFalse(adManagerAdViewOptions.getManualImpressionsEnabled());
+  }
+}

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterBannerParametersTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterBannerParametersTest.java
@@ -1,0 +1,49 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.flutter.plugins.googlemobileads;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.google.android.gms.ads.admanager.AdManagerAdView;
+import com.google.android.gms.ads.formats.OnAdManagerAdViewLoadedListener;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+
+/** Tests for {@link FlutterBannerParameters}. */
+public class FlutterBannerParametersTest {
+
+  @Test
+  public void testAsBannerParameters() {
+    List<FlutterAdSize> sizes = Collections.singletonList(new FlutterAdSize(100, 200));
+    FlutterBannerParameters flutterBannerParameters = new FlutterBannerParameters(sizes, null);
+
+    OnAdManagerAdViewLoadedListener listener =
+        new OnAdManagerAdViewLoadedListener() {
+          @Override
+          public void onAdManagerAdViewLoaded(AdManagerAdView adView) {}
+        };
+
+    FlutterAdLoaderAd.BannerParameters bannerParameters =
+        flutterBannerParameters.asBannerParameters(listener);
+
+    assertEquals(bannerParameters.adSizes.length, 1);
+    assertEquals(bannerParameters.adSizes[0].getWidth(), 100);
+    assertEquals(bannerParameters.adSizes[0].getHeight(), 200);
+    assertNull(bannerParameters.adManagerAdViewOptions);
+    assertEquals(bannerParameters.listener, listener);
+  }
+}

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
@@ -829,6 +829,73 @@ public class GoogleMobileAdsTest {
     verify(result).success(adSize.getHeight());
   }
 
+  @Test
+  public void testGetAdLoaderAdType_adLoaderAd() {
+    // Setup mocks
+    AdInstanceManager testManagerSpy = spy(testManager);
+    FlutterMobileAdsWrapper mockMobileAds = mock(FlutterMobileAdsWrapper.class);
+    FlutterAdLoader mockLoader = mock(FlutterAdLoader.class);
+    GoogleMobileAdsPlugin plugin =
+        new GoogleMobileAdsPlugin(
+            mockFlutterPluginBinding, testManagerSpy, mockMobileAds, () -> mockLoader);
+    GoogleMobileAdsPlugin pluginSpy = spy(plugin);
+
+    // Load an ad loader ad
+    Map<String, Object> loadArgs = new HashMap<>();
+    loadArgs.put("adId", 1);
+    loadArgs.put("adUnitId", "test-ad-unit");
+    loadArgs.put("request", new FlutterAdRequest.Builder().build());
+
+    MethodCall loadAdLoaderAdMethodCall = new MethodCall("loadAdLoaderAd", loadArgs);
+    Result result = mock(Result.class);
+    pluginSpy.onMethodCall(loadAdLoaderAdMethodCall, result);
+    verify(result).success(null);
+
+    // Method call for getAdLoaderAdType.
+    Result getAdLoaderAdTypeResult = mock(Result.class);
+    Map<String, Object> getAdLoaderAdTypeArgs = Collections.singletonMap("adId", (Object) 1);
+    MethodCall getAdLoaderAdTypeMethodCall =
+        new MethodCall("getAdLoaderAdType", getAdLoaderAdTypeArgs);
+    pluginSpy.onMethodCall(getAdLoaderAdTypeMethodCall, getAdLoaderAdTypeResult);
+
+    ArgumentCaptor<Integer> argumentCaptor = ArgumentCaptor.forClass(Integer.class);
+    verify(getAdLoaderAdTypeResult).success(argumentCaptor.capture());
+    assertEquals(0, argumentCaptor.getValue().intValue());
+  }
+
+  @Test
+  public void testGetAdSize_adLoaderAd() {
+    // Setup mocks
+    AdInstanceManager testManagerSpy = spy(testManager);
+    FlutterMobileAdsWrapper mockMobileAds = mock(FlutterMobileAdsWrapper.class);
+    FlutterAdLoader mockLoader = mock(FlutterAdLoader.class);
+    GoogleMobileAdsPlugin plugin =
+        new GoogleMobileAdsPlugin(
+            mockFlutterPluginBinding, testManagerSpy, mockMobileAds, () -> mockLoader);
+    GoogleMobileAdsPlugin pluginSpy = spy(plugin);
+
+    // Load a banner ad
+    Map<String, Object> loadArgs = new HashMap<>();
+    loadArgs.put("adId", 1);
+    loadArgs.put("adUnitId", "test-ad-unit");
+    loadArgs.put("request", new FlutterAdRequest.Builder().build());
+
+    MethodCall loadAdLoaderAdMethodCall = new MethodCall("loadAdLoaderAd", loadArgs);
+    Result result = mock(Result.class);
+    pluginSpy.onMethodCall(loadAdLoaderAdMethodCall, result);
+    verify(result).success(null);
+
+    // Method call for getAdSize.
+    Result getAdSizeResult = mock(Result.class);
+    Map<String, Object> getAdSizeArgs = Collections.singletonMap("adId", (Object) 1);
+    MethodCall getAdSizeMethodCall = new MethodCall("getAdSize", getAdSizeArgs);
+    pluginSpy.onMethodCall(getAdSizeMethodCall, getAdSizeResult);
+
+    ArgumentCaptor<FlutterAdSize> argumentCaptor = ArgumentCaptor.forClass(FlutterAdSize.class);
+    verify(getAdSizeResult).success(argumentCaptor.capture());
+    assertEquals(null, argumentCaptor.getValue());
+  }
+
   public void testGetAdSize_bannerAd() {
     // Setup mocks
     AdInstanceManager testManagerSpy = spy(testManager);
@@ -910,6 +977,39 @@ public class GoogleMobileAdsTest {
     ArgumentCaptor<FlutterAdSize> argumentCaptor = ArgumentCaptor.forClass(FlutterAdSize.class);
     verify(getAdSizeResult).success(argumentCaptor.capture());
     assertEquals(argumentCaptor.getValue().getAdSize(), adSize);
+  }
+
+  @Test
+  public void testGetFormatId_adLoaderAd() {
+    // Setup mocks
+    AdInstanceManager testManagerSpy = spy(testManager);
+    FlutterMobileAdsWrapper mockMobileAds = mock(FlutterMobileAdsWrapper.class);
+    FlutterAdLoader mockLoader = mock(FlutterAdLoader.class);
+    GoogleMobileAdsPlugin plugin =
+        new GoogleMobileAdsPlugin(
+            mockFlutterPluginBinding, testManagerSpy, mockMobileAds, () -> mockLoader);
+    GoogleMobileAdsPlugin pluginSpy = spy(plugin);
+
+    // Load an ad loader ad
+    Map<String, Object> loadArgs = new HashMap<>();
+    loadArgs.put("adId", 1);
+    loadArgs.put("adUnitId", "test-ad-unit");
+    loadArgs.put("request", new FlutterAdRequest.Builder().build());
+
+    MethodCall loadAdLoaderAdMethodCall = new MethodCall("loadAdLoaderAd", loadArgs);
+    Result result = mock(Result.class);
+    pluginSpy.onMethodCall(loadAdLoaderAdMethodCall, result);
+    verify(result).success(null);
+
+    // Method call for getFormatId.
+    Result getFormatIdResult = mock(Result.class);
+    Map<String, Object> getFormatIdArgs = Collections.singletonMap("adId", (Object) 1);
+    MethodCall getFormatIdMethodCall = new MethodCall("getFormatId", getFormatIdArgs);
+    pluginSpy.onMethodCall(getFormatIdMethodCall, getFormatIdResult);
+
+    ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+    verify(getFormatIdResult).success(argumentCaptor.capture());
+    assertEquals(null, argumentCaptor.getValue());
   }
 
   @Test

--- a/packages/google_mobile_ads/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/google_mobile_ads/example/ios/Runner.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		9E61AA6129BBE8FD00801A83 /* FLTNativeTemplateFontStyleTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E61AA5C29BBE8FD00801A83 /* FLTNativeTemplateFontStyleTest.m */; };
 		9E61AA6229BBE8FD00801A83 /* FLTNativeTemplateColorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E61AA5D29BBE8FD00801A83 /* FLTNativeTemplateColorTest.m */; };
 		E276E99229DFB5870052484E /* FLTAdLoaderAdTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E276E99129DFB5870052484E /* FLTAdLoaderAdTest.m */; };
+		E2D4625F29DFC2560010C4D0 /* FLTAdManagerAdViewOptionsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E2D4625E29DFC2560010C4D0 /* FLTAdManagerAdViewOptionsTest.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -111,6 +112,7 @@
 		9EB9FE57280F853D00DDBB4F /* UserMessagingPlatform.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = UserMessagingPlatform.xcframework; path = Pods/GoogleUserMessagingPlatform/Frameworks/Release/UserMessagingPlatform.xcframework; sourceTree = "<group>"; };
 		9EFEAB4E29B0019F000A063B /* GoogleMobileAds.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GoogleMobileAds.xcframework; path = "Pods/Google-Mobile-Ads-SDK/Frameworks/GoogleMobileAdsFramework/GoogleMobileAds.xcframework"; sourceTree = "<group>"; };
 		E276E99129DFB5870052484E /* FLTAdLoaderAdTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLTAdLoaderAdTest.m; sourceTree = "<group>"; };
+		E2D4625E29DFC2560010C4D0 /* FLTAdManagerAdViewOptionsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLTAdManagerAdViewOptionsTest.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -216,6 +218,7 @@
 				9E61AA5829BBE8DA00801A83 /* NativeTemplates */,
 				9E61AA5529BBE8AF00801A83 /* UserMessagingPlatform */,
 				E276E99129DFB5870052484E /* FLTAdLoaderAdTest.m */,
+				E2D4625E29DFC2560010C4D0 /* FLTAdManagerAdViewOptionsTest.m */,
 				9E61AA2729BBE66900801A83 /* FLTAdUtilTest.m */,
 				9E61AA2429BBE66900801A83 /* FLTAppOpenAdTest.m */,
 				9E61AA2229BBE66900801A83 /* FLTBannerAdTest.m */,
@@ -418,6 +421,7 @@
 				E276E99229DFB5870052484E /* FLTAdLoaderAdTest.m in Sources */,
 				9E61AA5329BBE88000801A83 /* FLTUserMessagingPlatformReaderWriterTest.m in Sources */,
 				9E61AA3229BBE66900801A83 /* FLTAppOpenAdTest.m in Sources */,
+				E2D4625F29DFC2560010C4D0 /* FLTAdManagerAdViewOptionsTest.m in Sources */,
 				9E61AA5F29BBE8FD00801A83 /* FLTNativeTemplateTypeTest.m in Sources */,
 				9E61AA3429BBE66900801A83 /* FLTGamInterstitialAdTest.m in Sources */,
 				9E61AA6029BBE8FD00801A83 /* FLTNativeTemplateStyleTest.m in Sources */,

--- a/packages/google_mobile_ads/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/google_mobile_ads/example/ios/Runner.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		9E61AA6029BBE8FD00801A83 /* FLTNativeTemplateStyleTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E61AA5B29BBE8FD00801A83 /* FLTNativeTemplateStyleTest.m */; };
 		9E61AA6129BBE8FD00801A83 /* FLTNativeTemplateFontStyleTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E61AA5C29BBE8FD00801A83 /* FLTNativeTemplateFontStyleTest.m */; };
 		9E61AA6229BBE8FD00801A83 /* FLTNativeTemplateColorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E61AA5D29BBE8FD00801A83 /* FLTNativeTemplateColorTest.m */; };
+		E276E99229DFB5870052484E /* FLTAdLoaderAdTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E276E99129DFB5870052484E /* FLTAdLoaderAdTest.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -109,6 +110,7 @@
 		9EA7213525BB6464008D57E3 /* GoogleMobileAds.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GoogleMobileAds.xcframework; path = "Pods/Google-Mobile-Ads-SDK/Frameworks/GoogleMobileAdsFramework-Current/GoogleMobileAds.xcframework"; sourceTree = "<group>"; };
 		9EB9FE57280F853D00DDBB4F /* UserMessagingPlatform.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = UserMessagingPlatform.xcframework; path = Pods/GoogleUserMessagingPlatform/Frameworks/Release/UserMessagingPlatform.xcframework; sourceTree = "<group>"; };
 		9EFEAB4E29B0019F000A063B /* GoogleMobileAds.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GoogleMobileAds.xcframework; path = "Pods/Google-Mobile-Ads-SDK/Frameworks/GoogleMobileAdsFramework/GoogleMobileAds.xcframework"; sourceTree = "<group>"; };
+		E276E99129DFB5870052484E /* FLTAdLoaderAdTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLTAdLoaderAdTest.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -213,6 +215,7 @@
 			children = (
 				9E61AA5829BBE8DA00801A83 /* NativeTemplates */,
 				9E61AA5529BBE8AF00801A83 /* UserMessagingPlatform */,
+				E276E99129DFB5870052484E /* FLTAdLoaderAdTest.m */,
 				9E61AA2729BBE66900801A83 /* FLTAdUtilTest.m */,
 				9E61AA2429BBE66900801A83 /* FLTAppOpenAdTest.m */,
 				9E61AA2229BBE66900801A83 /* FLTBannerAdTest.m */,
@@ -412,6 +415,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9E61AA5729BBE8D000801A83 /* FLTUserMessagingPlatformManagerTest.m in Sources */,
+				E276E99229DFB5870052484E /* FLTAdLoaderAdTest.m in Sources */,
 				9E61AA5329BBE88000801A83 /* FLTUserMessagingPlatformReaderWriterTest.m in Sources */,
 				9E61AA3229BBE66900801A83 /* FLTAppOpenAdTest.m in Sources */,
 				9E61AA5F29BBE8FD00801A83 /* FLTNativeTemplateTypeTest.m in Sources */,

--- a/packages/google_mobile_ads/example/ios/RunnerTests/FLTAdLoaderAdTest.m
+++ b/packages/google_mobile_ads/example/ios/RunnerTests/FLTAdLoaderAdTest.m
@@ -1,0 +1,83 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+#import "google_mobile_ads/FLTAd_Internal.h"
+
+@interface FLTAdLoaderAdTest : XCTestCase
+@end
+
+@implementation FLTAdLoaderAdTest
+- (void)testDelegates {
+  UIViewController *viewController = OCMClassMock([UIViewController class]);
+  FLTAdInstanceManager *manager = OCMClassMock([FLTAdInstanceManager class]);
+
+  FLTAdLoaderAd *ad =
+      [[FLTAdLoaderAd alloc] initWithAdUnitId:@"testAdUnitId"
+                                      request:[[FLTAdRequest alloc] init]
+                           rootViewController:viewController
+                                         adId:@0];
+
+  ad.manager = manager;
+
+  [ad load];
+
+  XCTAssertEqual(ad.adLoader.delegate, ad);
+
+  // GADAdLoaderDelegate
+  NSError *error = [NSError errorWithDomain:@"domain" code:1 userInfo:nil];
+  [ad.adLoader.delegate adLoader:ad.adLoader.delegate
+      didFailToReceiveAdWithError:error];
+
+  OCMVerify([manager onAdFailedToLoad:[OCMArg isEqual:ad]
+                                error:[OCMArg isEqual:error]]);
+}
+
+- (void)testLoadAdLoaderAd {
+  FLTAdRequest *request = [[FLTAdRequest alloc] init];
+  request.keywords = @[ @"apple" ];
+  [self testLoadAdLoaderAd:request];
+}
+
+- (void)testLoadAdLoaderAdWithGAMRequest {
+  FLTGAMAdRequest *request = [[FLTGAMAdRequest alloc] init];
+  request.keywords = @[ @"apple" ];
+  [self testLoadAdLoaderAd:request];
+}
+
+- (void)testLoadAdLoaderAd:(FLTAdRequest *)request {
+  UIViewController *viewController = OCMClassMock([UIViewController class]);
+
+  FLTAdLoaderAd *ad = [[FLTAdLoaderAd alloc] initWithAdUnitId:@"testAdUnitId"
+                                                      request:request
+                                           rootViewController:viewController
+                                                         adId:@1];
+
+  XCTAssertEqual(ad.adLoader.adUnitID, @"testAdUnitId");
+  XCTAssertEqual(ad.adLoader.delegate, ad);
+
+  FLTAdLoaderAd *mockAdLoaderAd = OCMPartialMock(ad);
+  GADAdLoader *mockLoader = OCMPartialMock([ad adLoader]);
+  OCMStub([mockAdLoaderAd adLoader]).andReturn(mockLoader);
+  [mockAdLoaderAd load];
+
+  OCMVerify([mockLoader loadRequest:[OCMArg checkWithBlock:^BOOL(id obj) {
+                          GADRequest *requestArg = obj;
+                          return [requestArg.keywords
+                              isEqualToArray:@[ @"apple" ]];
+                        }]]);
+}
+@end

--- a/packages/google_mobile_ads/example/ios/RunnerTests/FLTAdManagerAdViewOptionsTest.m
+++ b/packages/google_mobile_ads/example/ios/RunnerTests/FLTAdManagerAdViewOptionsTest.m
@@ -1,0 +1,49 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "google_mobile_ads/FLTAd_Internal.h"
+
+@interface FLTAdManagerAdViewOptionsTest : XCTestCase
+@end
+
+@implementation FLTAdManagerAdViewOptionsTest
+- (void)testAsGADAdLoaderOptionsManualImpressionsEnabledUnset {
+  FLTAdManagerAdViewOptions *options =
+      [[FLTAdManagerAdViewOptions alloc] initWithManualImpressionsEnabled:nil];
+
+  XCTAssertEqual(options.asGADAdLoaderOptions.count, 0);
+}
+
+- (void)testAsGADAdLoaderOptionsManualImpressionsEnabledYes {
+  FLTAdManagerAdViewOptions *options =
+      [[FLTAdManagerAdViewOptions alloc] initWithManualImpressionsEnabled:@YES];
+
+  XCTAssertEqual(options.asGADAdLoaderOptions.count, 1);
+  GADAdLoaderOptions *option = options.asGADAdLoaderOptions[0];
+  XCTAssert([option isKindOfClass:[GAMBannerViewOptions class]]);
+  XCTAssertTrue(((GAMBannerViewOptions *)option).manualImpressionEnabled);
+}
+
+- (void)testAsGADAdLoaderOptionsManualImpressionsEnabledNo {
+  FLTAdManagerAdViewOptions *options =
+      [[FLTAdManagerAdViewOptions alloc] initWithManualImpressionsEnabled:@NO];
+
+  XCTAssertEqual(options.asGADAdLoaderOptions.count, 1);
+  GADAdLoaderOptions *option = options.asGADAdLoaderOptions[0];
+  XCTAssert([option isKindOfClass:[GAMBannerViewOptions class]]);
+  XCTAssertFalse(((GAMBannerViewOptions *)option).manualImpressionEnabled);
+}
+@end

--- a/packages/google_mobile_ads/example/ios/RunnerTests/FLTGoogleMobileAdsPluginMethodCallsTest.m
+++ b/packages/google_mobile_ads/example/ios/RunnerTests/FLTGoogleMobileAdsPluginMethodCallsTest.m
@@ -560,6 +560,89 @@
                      .size.height);
 }
 
+- (void)testGetAdLoaderAdType_adLoaderAd {
+  // Method calls to load an ad loader ad.
+  FlutterMethodCall *loadAdMethodCall = [FlutterMethodCall
+      methodCallWithMethodName:@"loadAdLoaderAd"
+                     arguments:@{
+                       @"adId" : @(1),
+                       @"adUnitId" : @"ad-unit-id",
+                       @"request" : [[FLTAdRequest alloc] init],
+                     }];
+
+  __block bool loadAdResultInvoked = false;
+  __block id _Nullable returnedLoadAdResult;
+  FlutterResult loadAdResult = ^(id _Nullable result) {
+    loadAdResultInvoked = true;
+    returnedLoadAdResult = result;
+  };
+
+  [_fltGoogleMobileAdsPlugin handleMethodCall:loadAdMethodCall
+                                       result:loadAdResult];
+
+  XCTAssertTrue(loadAdResultInvoked);
+  XCTAssertNil(returnedLoadAdResult);
+
+  // Method call to get the format id.
+  __block bool getAdLoaderAdTypeResultInvoked = false;
+  __block FLTAdLoaderAdType returnedGetAdLoaderAdTypeResult;
+  FlutterResult getAdLoaderAdTypeResult = ^(id _Nullable result) {
+    getAdLoaderAdTypeResultInvoked = true;
+    returnedGetAdLoaderAdTypeResult = result;
+  };
+
+  FlutterMethodCall *getAdLoaderAdTypeMethodCall =
+      [FlutterMethodCall methodCallWithMethodName:@"getAdLoaderAdType"
+                                        arguments:@{@"adId" : @(1)}];
+  [_fltGoogleMobileAdsPlugin handleMethodCall:getAdLoaderAdTypeMethodCall
+                                       result:getAdLoaderAdTypeResult];
+
+  XCTAssertTrue(getAdLoaderAdTypeResultInvoked);
+  XCTAssertEqual(returnedGetAdLoaderAdTypeResult,
+                 [[NSNumber alloc] initWithInteger:FLTAdLoaderAdTypeUnknown]);
+}
+
+- (void)testGetAdSize_adLoaderAd {
+  // Method calls to load an ad loader ad.
+  FlutterMethodCall *loadAdMethodCall = [FlutterMethodCall
+      methodCallWithMethodName:@"loadAdLoaderAd"
+                     arguments:@{
+                       @"adId" : @(1),
+                       @"adUnitId" : @"ad-unit-id",
+                       @"request" : [[FLTAdRequest alloc] init],
+                     }];
+
+  __block bool loadAdResultInvoked = false;
+  __block id _Nullable returnedLoadAdResult;
+  FlutterResult loadAdResult = ^(id _Nullable result) {
+    loadAdResultInvoked = true;
+    returnedLoadAdResult = result;
+  };
+
+  [_fltGoogleMobileAdsPlugin handleMethodCall:loadAdMethodCall
+                                       result:loadAdResult];
+
+  XCTAssertTrue(loadAdResultInvoked);
+  XCTAssertNil(returnedLoadAdResult);
+
+  // Method call to get the ad size.
+  __block bool getAdSizeResultInvoked = false;
+  __block FLTAdSize *_Nullable returnedGetAdSizeResult;
+  FlutterResult getAdSizeResult = ^(id _Nullable result) {
+    getAdSizeResultInvoked = true;
+    returnedGetAdSizeResult = result;
+  };
+
+  FlutterMethodCall *getAdSizeMethodCall =
+      [FlutterMethodCall methodCallWithMethodName:@"getAdSize"
+                                        arguments:@{@"adId" : @(1)}];
+  [_fltGoogleMobileAdsPlugin handleMethodCall:getAdSizeMethodCall
+                                       result:getAdSizeResult];
+
+  XCTAssertTrue(getAdSizeResultInvoked);
+  XCTAssertNil(returnedGetAdSizeResult);
+}
+
 - (void)testGetAdSize_bannerAd {
   // Method calls to load a banner ad.
   FlutterMethodCall *loadAdMethodCall = [FlutterMethodCall
@@ -601,6 +684,47 @@
   XCTAssertTrue(getAdSizeResultInvoked);
   XCTAssertEqualObjects(returnedGetAdSizeResult.width, @1);
   XCTAssertEqualObjects(returnedGetAdSizeResult.height, @2);
+}
+
+- (void)testGetFormatId_adLoaderAd {
+  // Method calls to load an ad loader ad.
+  FlutterMethodCall *loadAdMethodCall = [FlutterMethodCall
+      methodCallWithMethodName:@"loadAdLoaderAd"
+                     arguments:@{
+                       @"adId" : @(1),
+                       @"adUnitId" : @"ad-unit-id",
+                       @"request" : [[FLTAdRequest alloc] init],
+                     }];
+
+  __block bool loadAdResultInvoked = false;
+  __block id _Nullable returnedLoadAdResult;
+  FlutterResult loadAdResult = ^(id _Nullable result) {
+    loadAdResultInvoked = true;
+    returnedLoadAdResult = result;
+  };
+
+  [_fltGoogleMobileAdsPlugin handleMethodCall:loadAdMethodCall
+                                       result:loadAdResult];
+
+  XCTAssertTrue(loadAdResultInvoked);
+  XCTAssertNil(returnedLoadAdResult);
+
+  // Method call to get the format id.
+  __block bool getFormatIdResultInvoked = false;
+  __block NSString *_Nullable returnedGetFormatIdResult;
+  FlutterResult getFormatIdResult = ^(id _Nullable result) {
+    getFormatIdResultInvoked = true;
+    returnedGetFormatIdResult = result;
+  };
+
+  FlutterMethodCall *getFormatIdMethodCall =
+      [FlutterMethodCall methodCallWithMethodName:@"getFormatId"
+                                        arguments:@{@"adId" : @(1)}];
+  [_fltGoogleMobileAdsPlugin handleMethodCall:getFormatIdMethodCall
+                                       result:getFormatIdResult];
+
+  XCTAssertTrue(getFormatIdResultInvoked);
+  XCTAssertNil(returnedGetFormatIdResult);
 }
 
 - (void)testServerSideVerificationOptions_rewardedAd {

--- a/packages/google_mobile_ads/example/ios/RunnerTests/FLTGoogleMobileAdsReaderWriterTest.m
+++ b/packages/google_mobile_ads/example/ios/RunnerTests/FLTGoogleMobileAdsReaderWriterTest.m
@@ -863,6 +863,41 @@
   XCTAssertEqual(factories.count, 0);
 }
 
+- (void)testEncodeDecodeNativeParameters {
+  FLTNativeParameters *parameters = [[FLTNativeParameters alloc]
+      initWithFactoryId:@"factory-id"
+        nativeAdOptions:[[FLTNativeAdOptions alloc]
+                                initWithAdChoicesPlacement:@(1)
+                                          mediaAspectRatio:@(1)
+                                              videoOptions:nil
+                                   requestCustomMuteThisAd:@YES
+                               shouldRequestMultipleImages:@YES
+                            shouldReturnUrlsForImageAssets:@YES]
+            viewOptions:@{@"key" : @"value"}];
+
+  NSData *encodedMessage = [_messageCodec encode:parameters];
+
+  FLTNativeParameters *decodedParameters =
+      [_messageCodec decode:encodedMessage];
+
+  XCTAssertEqualObjects(decodedParameters.factoryId, @"factory-id");
+
+  XCTAssertEqualObjects(parameters.nativeAdOptions.adChoicesPlacement, @(1));
+  XCTAssertEqualObjects(parameters.nativeAdOptions.mediaAspectRatio, @(1));
+  XCTAssertNil(parameters.nativeAdOptions.videoOptions);
+  XCTAssertEqualObjects(parameters.nativeAdOptions.requestCustomMuteThisAd,
+                        @(YES));
+  XCTAssertEqualObjects(parameters.nativeAdOptions.shouldRequestMultipleImages,
+                        @(YES));
+  XCTAssertEqualObjects(
+      parameters.nativeAdOptions.shouldReturnUrlsForImageAssets, @(YES));
+
+  NSDictionary<NSString *, id> *viewOptions = decodedParameters.viewOptions;
+
+  XCTAssertNotNil(viewOptions);
+  XCTAssertEqualObjects(viewOptions[@"key"], @"value");
+}
+
 @end
 
 @implementation FLTTestAdSizeFactory

--- a/packages/google_mobile_ads/example/ios/RunnerTests/FLTGoogleMobileAdsReaderWriterTest.m
+++ b/packages/google_mobile_ads/example/ios/RunnerTests/FLTGoogleMobileAdsReaderWriterTest.m
@@ -836,6 +836,33 @@
   XCTAssertNil(options.manualImpressionsEnabled);
 }
 
+- (void)testEncodeDecodeCustomParameters {
+  FLTCustomParameters *parameters = [[FLTCustomParameters alloc]
+      initWithFormatIds:@[ @"formatId0", @"formatId1" ]
+            viewOptions:@{@"key" : @"value"}];
+
+  NSData *encodedMessage = [_messageCodec encode:parameters];
+
+  FLTCustomParameters *decodedParameters =
+      [_messageCodec decode:encodedMessage];
+
+  NSArray<NSString *> *formatIds = decodedParameters.formatIds;
+
+  XCTAssertEqual(formatIds.count, 2);
+  XCTAssertEqualObjects(formatIds[0], @"formatId0");
+  XCTAssertEqualObjects(formatIds[1], @"formatId1");
+
+  NSDictionary<NSString *, id> *viewOptions = decodedParameters.viewOptions;
+
+  XCTAssertNotNil(viewOptions);
+  XCTAssertEqualObjects(viewOptions[@"key"], @"value");
+
+  NSDictionary<NSString *, id<FLTCustomAdFactory>> *factories =
+      decodedParameters.factories;
+
+  XCTAssertEqual(factories.count, 0);
+}
+
 @end
 
 @implementation FLTTestAdSizeFactory

--- a/packages/google_mobile_ads/example/ios/RunnerTests/FLTGoogleMobileAdsReaderWriterTest.m
+++ b/packages/google_mobile_ads/example/ios/RunnerTests/FLTGoogleMobileAdsReaderWriterTest.m
@@ -780,6 +780,62 @@
   XCTAssertEqual(first.intValue, second.intValue);
 }
 
+- (void)testEncodeDecodeAdManagerAdViewOptionsNil {
+  FLTAdManagerAdViewOptions *options =
+      [[FLTAdManagerAdViewOptions alloc] initWithManualImpressionsEnabled:nil];
+
+  NSData *encodedMessage = [_messageCodec encode:options];
+
+  FLTAdManagerAdViewOptions *decodedOptions =
+      [_messageCodec decode:encodedMessage];
+  XCTAssertEqual(decodedOptions.manualImpressionsEnabled, nil);
+}
+
+- (void)testEncodeDecodeAdManagerAdViewOptionsYes {
+  FLTAdManagerAdViewOptions *options = [[FLTAdManagerAdViewOptions alloc]
+      initWithManualImpressionsEnabled:@(YES)];
+
+  NSData *encodedMessage = [_messageCodec encode:options];
+
+  FLTAdManagerAdViewOptions *decodedOptions =
+      [_messageCodec decode:encodedMessage];
+  XCTAssertEqual(decodedOptions.manualImpressionsEnabled, @(YES));
+}
+
+- (void)testEncodeDecodeAdManagerAdViewOptionsNo {
+  FLTAdManagerAdViewOptions *options = [[FLTAdManagerAdViewOptions alloc]
+      initWithManualImpressionsEnabled:@(NO)];
+
+  NSData *encodedMessage = [_messageCodec encode:options];
+
+  FLTAdManagerAdViewOptions *decodedOptions =
+      [_messageCodec decode:encodedMessage];
+  XCTAssertEqual(decodedOptions.manualImpressionsEnabled, @(NO));
+}
+
+- (void)testEncodeDecodeBannerParameters {
+  FLTBannerParameters *parameters = [[FLTBannerParameters alloc]
+      initWithSizes:@[ [[FLTAdSize alloc] initWithWidth:@(1) height:@(2)] ]
+            options:[[FLTAdManagerAdViewOptions alloc]
+                        initWithManualImpressionsEnabled:nil]];
+
+  NSData *encodedMessage = [_messageCodec encode:parameters];
+
+  FLTBannerParameters *decodedParameters =
+      [_messageCodec decode:encodedMessage];
+
+  NSArray<FLTAdSize *> *sizes = decodedParameters.sizes;
+
+  XCTAssertEqual(sizes.count, 1);
+  XCTAssertEqualObjects(sizes[0].width, @(1));
+  XCTAssertEqualObjects(sizes[0].height, @(2));
+
+  FLTAdManagerAdViewOptions *options = decodedParameters.options;
+
+  XCTAssertNotNil(options);
+  XCTAssertNil(options.manualImpressionsEnabled);
+}
+
 @end
 
 @implementation FLTTestAdSizeFactory

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTAdInstanceManager_Internal.m
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTAdInstanceManager_Internal.m
@@ -126,6 +126,22 @@
   [self sendAdEvent:@"onNativeAdWillDismissScreen" ad:ad];
 }
 
+- (void)onCustomNativeAdImpression:(nonnull id<FLTAd>)ad {
+  [self sendAdEvent:@"onCustomNativeAdImpression" ad:ad];
+}
+
+- (void)onCustomNativeAdWillPresentScreen:(nonnull id<FLTAd>)ad {
+  [self sendAdEvent:@"onCustomNativeAdWillPresentScreen" ad:ad];
+}
+
+- (void)onCustomNativeAdDidDismissScreen:(nonnull id<FLTAd>)ad {
+  [self sendAdEvent:@"onCustomNativeAdDidDismissScreen" ad:ad];
+}
+
+- (void)onCustomNativeAdWillDismissScreen:(nonnull id<FLTAd>)ad {
+  [self sendAdEvent:@"onCustomNativeAdWillDismissScreen" ad:ad];
+}
+
 - (void)onRewardedAdUserEarnedReward:(FLTRewardedAd *_Nonnull)ad
                               reward:(FLTRewardItem *_Nonnull)reward {
   [_channel invokeMethod:@"onAdEvent"

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTAdInstanceManager_Internal.m
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTAdInstanceManager_Internal.m
@@ -110,19 +110,19 @@
                }];
 }
 
-- (void)onNativeAdImpression:(FLTNativeAd *_Nonnull)ad {
+- (void)onNativeAdImpression:(nonnull id<FLTAd>)ad {
   [self sendAdEvent:@"onNativeAdImpression" ad:ad];
 }
 
-- (void)onNativeAdWillPresentScreen:(FLTNativeAd *_Nonnull)ad {
+- (void)onNativeAdWillPresentScreen:(nonnull id<FLTAd>)ad {
   [self sendAdEvent:@"onNativeAdWillPresentScreen" ad:ad];
 }
 
-- (void)onNativeAdDidDismissScreen:(FLTNativeAd *_Nonnull)ad {
+- (void)onNativeAdDidDismissScreen:(nonnull id<FLTAd>)ad {
   [self sendAdEvent:@"onNativeAdDidDismissScreen" ad:ad];
 }
 
-- (void)onNativeAdWillDismissScreen:(FLTNativeAd *_Nonnull)ad {
+- (void)onNativeAdWillDismissScreen:(nonnull id<FLTAd>)ad {
   [self sendAdEvent:@"onNativeAdWillDismissScreen" ad:ad];
 }
 
@@ -159,19 +159,19 @@
                }];
 }
 
-- (void)onBannerImpression:(FLTBannerAd *_Nonnull)ad {
+- (void)onBannerImpression:(nonnull id<FLTAd>)ad {
   [self sendAdEvent:@"onBannerImpression" ad:ad];
 }
 
-- (void)onBannerWillDismissScreen:(FLTBannerAd *)ad {
+- (void)onBannerWillDismissScreen:(nonnull id<FLTAd>)ad {
   [self sendAdEvent:@"onBannerWillDismissScreen" ad:ad];
 }
 
-- (void)onBannerDidDismissScreen:(FLTBannerAd *)ad {
+- (void)onBannerDidDismissScreen:(nonnull id<FLTAd>)ad {
   [self sendAdEvent:@"onBannerDidDismissScreen" ad:ad];
 }
 
-- (void)onBannerWillPresentScreen:(FLTBannerAd *_Nonnull)ad {
+- (void)onBannerWillPresentScreen:(nonnull id<FLTAd>)ad {
   [self sendAdEvent:@"onBannerWillPresentScreen" ad:ad];
 }
 

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTAd_Internal.m
@@ -1233,29 +1233,58 @@
 
 @end
 
+@implementation FLTBannerParameters
+- (nonnull instancetype)initWithSizes:(nonnull NSArray<FLTAdSize *> *)sizes
+                              options:(nullable FLTAdManagerAdViewOptions *)
+                                          options {
+  self = [super init];
+  _sizes = sizes;
+  _options = options;
+  return self;
+}
+@end
+
 #pragma mark - FLTAdLoaderAd
 
 @implementation FLTAdLoaderAd {
   NSString *_adUnitId;
   FLTAdRequest *_adRequest;
+  NSMutableArray<NSValue *> *_validAdSizes;
+  UIView *_view;
+  FLTBannerParameters *_banner;
 }
 
-- (nonnull instancetype)initWithAdUnitId:(nonnull NSString *)adUnitId
-                                 request:(nonnull FLTAdRequest *)request
-                      rootViewController:
-                          (nonnull UIViewController *)rootViewController
-                                    adId:(nonnull NSNumber *)adId {
+- (nonnull instancetype)
+      initWithAdUnitId:(nonnull NSString *)adUnitId
+               request:(nonnull FLTAdRequest *)request
+    rootViewController:(nonnull UIViewController *)rootViewController
+                  adId:(nonnull NSNumber *)adId
+                banner:(nullable FLTBannerParameters *)bannerParameters {
   self = [super init];
   if (self) {
     self.adId = adId;
     _adUnitId = adUnitId;
     _adRequest = request;
     _adLoaderAdType = FLTAdLoaderAdTypeUnknown;
-    _adSize = nil;
     _formatId = nil;
 
     NSMutableArray *adTypes = [[NSMutableArray alloc] init];
     NSMutableArray *options = [[NSMutableArray alloc] init];
+
+    if (![FLTAdUtil isNull:bannerParameters]) {
+      _banner = bannerParameters;
+      _validAdSizes =
+          [NSMutableArray arrayWithCapacity:bannerParameters.sizes.count];
+      for (FLTAdSize *size in bannerParameters.sizes) {
+        [_validAdSizes addObject:NSValueFromGADAdSize(size.size)];
+      }
+
+      [adTypes addObject:GADAdLoaderAdTypeGAMBanner];
+
+      if (![FLTAdUtil isNull:_banner.options]) {
+        [options addObjectsFromArray:_banner.options.asGADAdLoaderOptions];
+      }
+    }
 
     _adLoader = [[GADAdLoader alloc] initWithAdUnitID:_adUnitId
                                    rootViewController:rootViewController
@@ -1264,6 +1293,13 @@
     _adLoader.delegate = self;
   }
   return self;
+}
+
+- (FLTAdSize *)adSize {
+  if (_view && [_view isKindOfClass:[GADBannerView class]]) {
+    return [[FLTAdSize alloc] initWithAdSize:((GADBannerView *)_view).adSize];
+  }
+  return nil;
 }
 
 #pragma mark - FLTAd
@@ -1285,10 +1321,81 @@
   [manager onAdFailedToLoad:self error:error];
 }
 
+#pragma mark - GAMBannerAdLoaderDelegate
+
+- (nonnull NSArray<NSValue *> *)validBannerSizesForAdLoader:
+    (nonnull GADAdLoader *)adLoader {
+  return _validAdSizes;
+}
+
+- (void)adLoader:(nonnull GADAdLoader *)adLoader
+    didReceiveGAMBannerView:(nonnull GAMBannerView *)bannerView {
+  _adLoaderAdType = FLTAdLoaderAdTypeBanner;
+  _view = bannerView;
+
+  bannerView.appEventDelegate = self;
+  bannerView.delegate = self;
+
+  __weak FLTAdLoaderAd *weakSelf = self;
+  bannerView.paidEventHandler = ^(GADAdValue *_Nonnull value) {
+    if (weakSelf.manager == nil) {
+      return;
+    }
+    [weakSelf.manager
+        onPaidEvent:weakSelf
+              value:[[FLTAdValue alloc] initWithValue:value.value
+                                            precision:(NSInteger)value.precision
+                                         currencyCode:value.currencyCode]];
+  };
+
+  [bannerView recordImpression];
+
+  [manager onAdLoaded:self responseInfo:bannerView.responseInfo];
+}
+
+#pragma mark - GADBannerViewDelegate
+
+- (void)bannerViewDidReceiveAd:(nonnull GADBannerView *)bannerView {
+  // TODO  handled by adLoader:didReceiveGAMBannerView: ?
+}
+
+- (void)bannerView:(nonnull GADBannerView *)bannerView
+    didFailToReceiveAdWithError:(nonnull NSError *)error {
+  [manager onAdFailedToLoad:self error:error];
+}
+
+- (void)bannerViewDidRecordImpression:(nonnull GADBannerView *)bannerView {
+  [manager onBannerImpression:self];
+}
+
+- (void)bannerViewDidRecordClick:(nonnull GADBannerView *)bannerView {
+  [manager adDidRecordClick:self];
+}
+
+- (void)bannerViewWillPresentScreen:(nonnull GADBannerView *)bannerView {
+  [manager onBannerWillPresentScreen:self];
+}
+
+- (void)bannerViewWillDismissScreen:(nonnull GADBannerView *)bannerView {
+  [manager onBannerWillDismissScreen:self];
+}
+
+- (void)bannerViewDidDismissScreen:(nonnull GADBannerView *)bannerView {
+  [manager onBannerDidDismissScreen:self];
+}
+
+#pragma mark - GADAppEventDelegate
+
+- (void)adView:(nonnull GADBannerView *)banner
+    didReceiveAppEvent:(nonnull NSString *)name
+              withInfo:(nullable NSString *)info {
+  [self.manager onAppEvent:self name:name data:info];
+}
+
 #pragma mark - FlutterPlatformView
 
 - (nonnull UIView *)view {
-  return nil; // TODO not great
+  return _view;
 }
 
 @synthesize manager;
@@ -1466,4 +1573,25 @@
   return options;
 }
 
+@end
+
+@implementation FLTAdManagerAdViewOptions
+- (nonnull instancetype)initWithManualImpressionsEnabled:
+    (nullable NSNumber *)manualImpressionsEnabled {
+  self = [super init];
+  _manualImpressionsEnabled = manualImpressionsEnabled;
+  return self;
+}
+
+- (nonnull NSArray<GADAdLoaderOptions *> *)asGADAdLoaderOptions {
+  NSMutableArray<GADAdLoaderOptions *> *options = [NSMutableArray array];
+  if ([FLTAdUtil isNotNull:_manualImpressionsEnabled]) {
+    GAMBannerViewOptions *bannerViewOptions =
+        [[GAMBannerViewOptions alloc] init];
+    bannerViewOptions.manualImpressionEnabled =
+        _manualImpressionsEnabled.boolValue;
+    [options addObject:bannerViewOptions];
+  }
+  return options;
+}
 @end

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTAd_Internal.m
@@ -1233,6 +1233,68 @@
 
 @end
 
+#pragma mark - FLTAdLoaderAd
+
+@implementation FLTAdLoaderAd {
+  NSString *_adUnitId;
+  FLTAdRequest *_adRequest;
+}
+
+- (nonnull instancetype)initWithAdUnitId:(nonnull NSString *)adUnitId
+                                 request:(nonnull FLTAdRequest *)request
+                      rootViewController:
+                          (nonnull UIViewController *)rootViewController
+                                    adId:(nonnull NSNumber *)adId {
+  self = [super init];
+  if (self) {
+    self.adId = adId;
+    _adUnitId = adUnitId;
+    _adRequest = request;
+    _adLoaderAdType = FLTAdLoaderAdTypeUnknown;
+    _adSize = nil;
+    _formatId = nil;
+
+    NSMutableArray *adTypes = [[NSMutableArray alloc] init];
+    NSMutableArray *options = [[NSMutableArray alloc] init];
+
+    _adLoader = [[GADAdLoader alloc] initWithAdUnitID:_adUnitId
+                                   rootViewController:rootViewController
+                                              adTypes:adTypes
+                                              options:options];
+    _adLoader.delegate = self;
+  }
+  return self;
+}
+
+#pragma mark - FLTAd
+
+- (void)load {
+  GADRequest *request;
+  if ([_adRequest isKindOfClass:[FLTGAMAdRequest class]]) {
+    request = [(FLTGAMAdRequest *)_adRequest asGAMRequest:_adUnitId];
+  } else {
+    request = [_adRequest asGADRequest:_adUnitId];
+  }
+  [_adLoader loadRequest:request];
+}
+
+#pragma mark - GADAdLoaderDelegate
+
+- (void)adLoader:(nonnull GADAdLoader *)adLoader
+    didFailToReceiveAdWithError:(nonnull NSError *)error {
+  [manager onAdFailedToLoad:self error:error];
+}
+
+#pragma mark - FlutterPlatformView
+
+- (nonnull UIView *)view {
+  return nil; // TODO not great
+}
+
+@synthesize manager;
+
+@end
+
 @implementation FLTRewardItem
 - (instancetype _Nonnull)initWithAmount:(NSNumber *_Nonnull)amount
                                    type:(NSString *_Nonnull)type {

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTAd_Internal.m
@@ -1244,6 +1244,18 @@
 }
 @end
 
+@implementation FLTCustomParameters
+- (nonnull instancetype)
+    initWithFormatIds:(nonnull NSArray<NSString *> *)formatIds
+          viewOptions:(nullable NSDictionary<NSString *, id> *)viewOptions {
+  self = [super init];
+  _formatIds = formatIds;
+  _viewOptions = viewOptions;
+  _factories = [NSMutableDictionary dictionary];
+  return self;
+}
+@end
+
 #pragma mark - FLTAdLoaderAd
 
 @implementation FLTAdLoaderAd {
@@ -1252,6 +1264,7 @@
   NSMutableArray<NSValue *> *_validAdSizes;
   UIView *_view;
   FLTBannerParameters *_banner;
+  FLTCustomParameters *_custom;
 }
 
 - (nonnull instancetype)
@@ -1259,7 +1272,8 @@
                request:(nonnull FLTAdRequest *)request
     rootViewController:(nonnull UIViewController *)rootViewController
                   adId:(nonnull NSNumber *)adId
-                banner:(nullable FLTBannerParameters *)bannerParameters {
+                banner:(nullable FLTBannerParameters *)bannerParameters
+                custom:(nullable FLTCustomParameters *)customParameters {
   self = [super init];
   if (self) {
     self.adId = adId;
@@ -1284,6 +1298,12 @@
       if (![FLTAdUtil isNull:_banner.options]) {
         [options addObjectsFromArray:_banner.options.asGADAdLoaderOptions];
       }
+    }
+
+    if (![FLTAdUtil isNull:customParameters]) {
+      _custom = customParameters;
+
+      [adTypes addObject:GADAdLoaderAdTypeCustomNative];
     }
 
     _adLoader = [[GADAdLoader alloc] initWithAdUnitID:_adUnitId
@@ -1390,6 +1410,53 @@
     didReceiveAppEvent:(nonnull NSString *)name
               withInfo:(nullable NSString *)info {
   [self.manager onAppEvent:self name:name data:info];
+}
+
+#pragma mark - GADCustomNativeAdLoaderDelegate
+
+- (nonnull NSArray<NSString *> *)customNativeAdFormatIDsForAdLoader:
+    (nonnull GADAdLoader *)adLoader {
+  return _custom.formatIds;
+}
+
+- (void)adLoader:(nonnull GADAdLoader *)adLoader
+    didReceiveCustomNativeAd:(nonnull GADCustomNativeAd *)customNativeAd {
+  // Use Nil instead of Null to fix crash with Swift integrations.
+  NSDictionary<NSString *, id> *customOptions =
+      [[NSNull null] isEqual:_custom.viewOptions] ? nil : _custom.viewOptions;
+  _adLoaderAdType = FLTAdLoaderAdTypeCustom;
+  _formatId = customNativeAd.formatID;
+  _view = [_custom.factories[_formatId] createCustomNativeAd:customNativeAd
+                                               customOptions:customOptions];
+
+  customNativeAd.delegate = self;
+
+  [customNativeAd recordImpression];
+
+  [manager onAdLoaded:self responseInfo:customNativeAd.responseInfo];
+}
+
+#pragma mark - GADCustomNativeAdDelegate
+
+- (void)customNativeAdDidRecordImpression:
+    (nonnull GADCustomNativeAd *)nativeAd {
+  [manager onCustomNativeAdImpression:self];
+}
+
+- (void)customNativeAdDidRecordClick:(nonnull GADCustomNativeAd *)nativeAd {
+  [manager adDidRecordClick:self];
+}
+
+- (void)customNativeAdWillPresentScreen:(nonnull GADCustomNativeAd *)nativeAd {
+  [manager onCustomNativeAdWillPresentScreen:self];
+}
+
+- (void)customNativeAdWillDismissScreen:(nonnull GADCustomNativeAd *)nativeAd {
+  [manager onCustomNativeAdWillDismissScreen:self];
+}
+
+- (void)customNativeAdDidDismissScreen:(nonnull GADCustomNativeAd *)nativeAd {
+  [manager onCustomNativeAdDidDismissScreen:self];
 }
 
 #pragma mark - FlutterPlatformView

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTAd_Internal.m
@@ -1256,6 +1256,19 @@
 }
 @end
 
+@implementation FLTNativeParameters
+- (nonnull instancetype)
+    initWithFactoryId:(nonnull NSString *)factoryId
+      nativeAdOptions:(nullable FLTNativeAdOptions *)nativeAdOptions
+          viewOptions:(nullable NSDictionary<NSString *, id> *)viewOptions {
+  self = [super init];
+  _factoryId = factoryId;
+  _nativeAdOptions = nativeAdOptions;
+  _viewOptions = viewOptions;
+  return self;
+}
+@end
+
 #pragma mark - FLTAdLoaderAd
 
 @implementation FLTAdLoaderAd {
@@ -1265,6 +1278,7 @@
   UIView *_view;
   FLTBannerParameters *_banner;
   FLTCustomParameters *_custom;
+  FLTNativeParameters *_native;
 }
 
 - (nonnull instancetype)
@@ -1273,7 +1287,8 @@
     rootViewController:(nonnull UIViewController *)rootViewController
                   adId:(nonnull NSNumber *)adId
                 banner:(nullable FLTBannerParameters *)bannerParameters
-                custom:(nullable FLTCustomParameters *)customParameters {
+                custom:(nullable FLTCustomParameters *)customParameters
+                native:(nullable FLTNativeParameters *)nativeParameters {
   self = [super init];
   if (self) {
     self.adId = adId;
@@ -1304,6 +1319,17 @@
       _custom = customParameters;
 
       [adTypes addObject:GADAdLoaderAdTypeCustomNative];
+    }
+
+    if (![FLTAdUtil isNull:nativeParameters]) {
+      _native = nativeParameters;
+
+      [adTypes addObject:GADAdLoaderAdTypeNative];
+
+      if (![FLTAdUtil isNull:_native.nativeAdOptions]) {
+        [options
+            addObjectsFromArray:_native.nativeAdOptions.asGADAdLoaderOptions];
+      }
     }
 
     _adLoader = [[GADAdLoader alloc] initWithAdUnitID:_adUnitId
@@ -1457,6 +1483,54 @@
 
 - (void)customNativeAdDidDismissScreen:(nonnull GADCustomNativeAd *)nativeAd {
   [manager onCustomNativeAdDidDismissScreen:self];
+}
+
+#pragma mark - GADNativeAdLoaderDelegate
+
+- (void)adLoader:(nonnull GADAdLoader *)adLoader
+    didReceiveNativeAd:(nonnull GADNativeAd *)nativeAd {
+  // Use Nil instead of Null to fix crash with Swift integrations.
+  NSDictionary<NSString *, id> *customOptions =
+      [[NSNull null] isEqual:_native.viewOptions] ? nil : _native.viewOptions;
+  _adLoaderAdType = FLTAdLoaderAdTypeNative;
+  _view = [_native.factory createNativeAd:nativeAd customOptions:customOptions];
+  nativeAd.delegate = self;
+
+  __weak FLTAdLoaderAd *weakSelf = self;
+  nativeAd.paidEventHandler = ^(GADAdValue *_Nonnull value) {
+    if (weakSelf.manager == nil) {
+      return;
+    }
+    [weakSelf.manager
+        onPaidEvent:weakSelf
+              value:[[FLTAdValue alloc] initWithValue:value.value
+                                            precision:(NSInteger)value.precision
+                                         currencyCode:value.currencyCode]];
+  };
+
+  [manager onAdLoaded:self responseInfo:nativeAd.responseInfo];
+}
+
+#pragma mark - GADNativeAdDelegate
+
+- (void)nativeAdDidRecordImpression:(nonnull GADNativeAd *)nativeAd {
+  [manager onNativeAdImpression:self];
+}
+
+- (void)nativeAdDidRecordClick:(nonnull GADNativeAd *)nativeAd {
+  [manager adDidRecordClick:self];
+}
+
+- (void)nativeAdWillPresentScreen:(nonnull GADNativeAd *)nativeAd {
+  [manager onNativeAdWillPresentScreen:self];
+}
+
+- (void)nativeAdWillDismissScreen:(nonnull GADNativeAd *)nativeAd {
+  [manager onNativeAdWillDismissScreen:self];
+}
+
+- (void)nativeAdDidDismissScreen:(nonnull GADNativeAd *)nativeAd {
+  [manager onNativeAdDidDismissScreen:self];
 }
 
 #pragma mark - FlutterPlatformView

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTGoogleMobileAdsPlugin.m
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTGoogleMobileAdsPlugin.m
@@ -504,6 +504,22 @@
       }
     }
 
+    FLTNativeParameters *native = call.arguments[@"native"];
+    if ([FLTAdUtil isNotNull:native]) {
+      id<FLTNativeAdFactory> factory = _nativeAdFactories[native.factoryId];
+      if (!factory) {
+        NSString *message = [NSString
+            stringWithFormat:@"Can't find NativeAdFactory with id: %@",
+                             native.factoryId];
+        result([FlutterError errorWithCode:@"AdLoaderAdError"
+                                   message:message
+                                   details:nil]);
+        return;
+      }
+
+      native.factory = factory;
+    }
+
     FLTAdRequest *request;
     if ([FLTAdUtil isNotNull:call.arguments[@"request"]]) {
       request = call.arguments[@"request"];
@@ -517,7 +533,8 @@
                              rootViewController:rootController
                                            adId:call.arguments[@"adId"]
                                          banner:call.arguments[@"banner"]
-                                         custom:custom];
+                                         custom:custom
+                                         native:native];
     [_manager loadAd:ad];
     result(nil);
   } else if ([call.method isEqualToString:@"loadInterstitialAd"]) {

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTGoogleMobileAdsPlugin.m
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTGoogleMobileAdsPlugin.m
@@ -441,6 +441,21 @@
         nativeTemplateStyle:call.arguments[@"nativeTemplateStyle"]];
     [_manager loadAd:ad];
     result(nil);
+  } else if ([call.method isEqualToString:@"loadAdLoaderAd"]) {
+    FLTAdRequest *request;
+    if ([FLTAdUtil isNotNull:call.arguments[@"request"]]) {
+      request = call.arguments[@"request"];
+    } else if ([FLTAdUtil isNotNull:call.arguments[@"adManagerRequest"]]) {
+      request = call.arguments[@"adManagerRequest"];
+    }
+
+    FLTAdLoaderAd *ad =
+        [[FLTAdLoaderAd alloc] initWithAdUnitId:call.arguments[@"adUnitId"]
+                                        request:request
+                             rootViewController:rootController
+                                           adId:call.arguments[@"adId"]];
+    [_manager loadAd:ad];
+    result(nil);
   } else if ([call.method isEqualToString:@"loadInterstitialAd"]) {
     FLTInterstitialAd *ad =
         [[FLTInterstitialAd alloc] initWithAdUnitId:call.arguments[@"adUnitId"]
@@ -543,6 +558,31 @@
     } else {
       result(nil);
     }
+  } else if ([call.method isEqualToString:@"getAdLoaderAdType"]) {
+    id<FLTAd> ad = [_manager adFor:call.arguments[@"adId"]];
+    if ([FLTAdUtil isNull:ad]) {
+      // Called on an ad that hasn't been loaded yet.
+      result(nil);
+    }
+    if ([ad isKindOfClass:[FLTAdLoaderAd class]]) {
+      FLTAdLoaderAd *adLoaderAd = (FLTAdLoaderAd *)ad;
+      FLTAdLoaderAdType adLoaderType = [adLoaderAd adLoaderAdType];
+      result([[NSNumber alloc] initWithInteger:adLoaderType]);
+    } else {
+      result(FlutterMethodNotImplemented);
+    }
+  } else if ([call.method isEqualToString:@"getFormatId"]) {
+    id<FLTAd> ad = [_manager adFor:call.arguments[@"adId"]];
+    if ([FLTAdUtil isNull:ad]) {
+      // Called on an ad that hasn't been loaded yet.
+      result(nil);
+    }
+    if ([ad isKindOfClass:[FLTAdLoaderAd class]]) {
+      FLTAdLoaderAd *adLoaderAd = (FLTAdLoaderAd *)ad;
+      result([adLoaderAd formatId]);
+    } else {
+      result(FlutterMethodNotImplemented);
+    }
   } else if ([call.method isEqualToString:@"getAdSize"]) {
     id<FLTAd> ad = [_manager adFor:call.arguments[@"adId"]];
     if ([FLTAdUtil isNull:ad]) {
@@ -552,6 +592,9 @@
     if ([ad isKindOfClass:[FLTBannerAd class]]) {
       FLTBannerAd *bannerAd = (FLTBannerAd *)ad;
       result([bannerAd getAdSize]);
+    } else if ([ad isKindOfClass:[FLTAdLoaderAd class]]) {
+      FLTAdLoaderAd *adLoaderAd = (FLTAdLoaderAd *)ad;
+      result([adLoaderAd adSize]);
     } else {
       result(FlutterMethodNotImplemented);
     }

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTGoogleMobileAdsPlugin.m
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTGoogleMobileAdsPlugin.m
@@ -453,7 +453,8 @@
         [[FLTAdLoaderAd alloc] initWithAdUnitId:call.arguments[@"adUnitId"]
                                         request:request
                              rootViewController:rootController
-                                           adId:call.arguments[@"adId"]];
+                                           adId:call.arguments[@"adId"]
+                                         banner:call.arguments[@"banner"]];
     [_manager loadAd:ad];
     result(nil);
   } else if ([call.method isEqualToString:@"loadInterstitialAd"]) {

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTGoogleMobileAdsPlugin.m
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTGoogleMobileAdsPlugin.m
@@ -25,6 +25,8 @@
 @property NSObject<FlutterPluginRegistrar> *registrar;
 @property NSMutableDictionary<NSString *, id<FLTNativeAdFactory>>
     *nativeAdFactories;
+@property NSMutableDictionary<NSString *, id<FLTCustomAdFactory>>
+    *customAdFactories;
 @end
 
 /// Initialization handler for GMASDK. Invokes result at most once.
@@ -67,6 +69,7 @@
 
 @implementation FLTGoogleMobileAdsPlugin {
   NSMutableDictionary<NSString *, id<FLTNativeAdFactory>> *_nativeAdFactories;
+  NSMutableDictionary<NSString *, id<FLTCustomAdFactory>> *_customAdFactories;
   FLTAdInstanceManager *_manager;
   id<FLTMediationNetworkExtrasProvider> _mediationNetworkExtrasProvider;
   FLTGoogleMobileAdsReaderWriter *_readerWriter;
@@ -119,6 +122,7 @@
   if (self) {
       _registrar = registrar;
     _nativeAdFactories = [NSMutableDictionary dictionary];
+    _customAdFactories = [NSMutableDictionary dictionary];
     _manager =
         [[FLTAdInstanceManager alloc] initWithBinaryMessenger:binaryMessenger];
     _appStateNotifier =
@@ -200,6 +204,33 @@
   return YES;
 }
 
++ (BOOL)registerCustomAdFactory:(id<FlutterPluginRegistry>)registry
+                       formatId:(NSString *)formatId
+                customAdFactory:(id<FLTCustomAdFactory>)customAdFactory {
+  NSString *pluginClassName =
+      NSStringFromClass([FLTGoogleMobileAdsPlugin class]);
+  FLTGoogleMobileAdsPlugin *adMobPlugin = (FLTGoogleMobileAdsPlugin *)[registry
+      valuePublishedByPlugin:pluginClassName];
+  if (!adMobPlugin) {
+    NSString *reason =
+        [NSString stringWithFormat:@"Could not find a %@ instance. The plugin "
+                                   @"may have not been registered.",
+                                   pluginClassName];
+    @throw [NSException exceptionWithName:NSInvalidArgumentException
+                                   reason:reason
+                                 userInfo:nil];
+  }
+
+  if (adMobPlugin.customAdFactories[formatId]) {
+    NSLog(@"A CustomAdFactory with the following formatId already exists: %@",
+          formatId);
+    return NO;
+  }
+
+  [adMobPlugin.customAdFactories setValue:customAdFactory forKey:formatId];
+  return YES;
+}
+
 + (id<FLTNativeAdFactory>)unregisterNativeAdFactory:
                               (id<FlutterPluginRegistry>)registry
                                           factoryId:(NSString *)factoryId {
@@ -210,6 +241,19 @@
   id<FLTNativeAdFactory> factory = adMobPlugin.nativeAdFactories[factoryId];
   if (factory)
     [adMobPlugin.nativeAdFactories removeObjectForKey:factoryId];
+  return factory;
+}
+
++ (id<FLTCustomAdFactory>)unregisterCustomAdFactory:
+                              (id<FlutterPluginRegistry>)registry
+                                           formatId:(NSString *)formatId {
+  FLTGoogleMobileAdsPlugin *adMobPlugin = (FLTGoogleMobileAdsPlugin *)[registry
+      valuePublishedByPlugin:NSStringFromClass(
+                                 [FLTGoogleMobileAdsPlugin class])];
+
+  id<FLTCustomAdFactory> factory = adMobPlugin.customAdFactories[formatId];
+  if (factory)
+    [adMobPlugin.customAdFactories removeObjectForKey:formatId];
   return factory;
 }
 
@@ -442,6 +486,24 @@
     [_manager loadAd:ad];
     result(nil);
   } else if ([call.method isEqualToString:@"loadAdLoaderAd"]) {
+    FLTCustomParameters *custom = call.arguments[@"custom"];
+    if ([FLTAdUtil isNotNull:custom]) {
+      for (NSString *formatId in custom.formatIds) {
+        id<FLTCustomAdFactory> factory = _customAdFactories[formatId];
+        if (!factory) {
+          NSString *message = [NSString
+              stringWithFormat:@"Can't find CustomAdFactory with id: %@",
+                               formatId];
+          result([FlutterError errorWithCode:@"AdLoaderAdError"
+                                     message:message
+                                     details:nil]);
+          return;
+        }
+
+        [custom.factories setValue:factory forKey:formatId];
+      }
+    }
+
     FLTAdRequest *request;
     if ([FLTAdUtil isNotNull:call.arguments[@"request"]]) {
       request = call.arguments[@"request"];
@@ -454,7 +516,8 @@
                                         request:request
                              rootViewController:rootController
                                            adId:call.arguments[@"adId"]
-                                         banner:call.arguments[@"banner"]];
+                                         banner:call.arguments[@"banner"]
+                                         custom:custom];
     [_manager loadAd:ad];
     result(nil);
   } else if ([call.method isEqualToString:@"loadInterstitialAd"]) {

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTGoogleMobileAdsReaderWriter_Internal.m
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTGoogleMobileAdsReaderWriter_Internal.m
@@ -51,6 +51,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
   FLTAdmobFieldAdManagerAdViewOptions = 155,
   FLTAdmobBannerParameters = 156,
   FLTAdmobCustomParameters = 157,
+  FLTAdmobNativeParameters = 158,
 };
 
 @interface FLTGoogleMobileAdsWriter : FlutterStandardWriter
@@ -359,6 +360,12 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
         initWithFormatIds:[self readValueOfType:[self readByte]]
               viewOptions:[self readValueOfType:[self readByte]]];
   }
+  case FLTAdmobNativeParameters: {
+    return [[FLTNativeParameters alloc]
+        initWithFactoryId:[self readValueOfType:[self readByte]]
+          nativeAdOptions:[self readValueOfType:[self readByte]]
+              viewOptions:[self readValueOfType:[self readByte]]];
+  }
   }
   return [super readValueOfType:type];
 }
@@ -556,6 +563,12 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     FLTCustomParameters *customParameters = value;
     [self writeValue:customParameters.formatIds];
     [self writeValue:customParameters.viewOptions];
+  } else if ([value isKindOfClass:[FLTNativeParameters class]]) {
+    [self writeByte:FLTAdmobNativeParameters];
+    FLTNativeParameters *nativeParameters = value;
+    [self writeValue:nativeParameters.factoryId];
+    [self writeValue:nativeParameters.nativeAdOptions];
+    [self writeValue:nativeParameters.viewOptions];
   } else {
     [super writeValue:value];
   }

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTGoogleMobileAdsReaderWriter_Internal.m
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTGoogleMobileAdsReaderWriter_Internal.m
@@ -50,6 +50,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
   FLTAdmobFieldMediationExtras = 154,
   FLTAdmobFieldAdManagerAdViewOptions = 155,
   FLTAdmobBannerParameters = 156,
+  FLTAdmobCustomParameters = 157,
 };
 
 @interface FLTGoogleMobileAdsWriter : FlutterStandardWriter
@@ -353,6 +354,11 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
         initWithSizes:[self readValueOfType:[self readByte]]
               options:[self readValueOfType:[self readByte]]];
   }
+  case FLTAdmobCustomParameters: {
+    return [[FLTCustomParameters alloc]
+        initWithFormatIds:[self readValueOfType:[self readByte]]
+              viewOptions:[self readValueOfType:[self readByte]]];
+  }
   }
   return [super readValueOfType:type];
 }
@@ -545,6 +551,11 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     FLTBannerParameters *bannerParameters = value;
     [self writeValue:bannerParameters.sizes];
     [self writeValue:bannerParameters.options];
+  } else if ([value isKindOfClass:[FLTCustomParameters class]]) {
+    [self writeByte:FLTAdmobCustomParameters];
+    FLTCustomParameters *customParameters = value;
+    [self writeValue:customParameters.formatIds];
+    [self writeValue:customParameters.viewOptions];
   } else {
     [super writeValue:value];
   }

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTGoogleMobileAdsReaderWriter_Internal.m
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTGoogleMobileAdsReaderWriter_Internal.m
@@ -47,8 +47,9 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
   FLTAdmobFieldNativeTemplateFontStyle = 151,
   FLTAdmobFieldNativeTemplateType = 152,
   FLTAdmobFieldNativeTemplateColor = 153,
-  FLTAdmobFieldMediationExtras = 154
-
+  FLTAdmobFieldMediationExtras = 154,
+  FLTAdmobFieldAdManagerAdViewOptions = 155,
+  FLTAdmobBannerParameters = 156,
 };
 
 @interface FLTGoogleMobileAdsWriter : FlutterStandardWriter
@@ -342,6 +343,16 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
                                                    green:green
                                                     blue:blue];
   }
+  case FLTAdmobFieldAdManagerAdViewOptions: {
+    return [[FLTAdManagerAdViewOptions alloc]
+        initWithManualImpressionsEnabled:[self
+                                             readValueOfType:[self readByte]]];
+  }
+  case FLTAdmobBannerParameters: {
+    return [[FLTBannerParameters alloc]
+        initWithSizes:[self readValueOfType:[self readByte]]
+              options:[self readValueOfType:[self readByte]]];
+  }
   }
   return [super readValueOfType:type];
 }
@@ -525,6 +536,15 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
     [self writeValue:templateStyle.secondaryTextStyle];
     [self writeValue:templateStyle.tertiaryTextStyle];
     [self writeValue:templateStyle.cornerRadius];
+  } else if ([value isKindOfClass:[FLTAdManagerAdViewOptions class]]) {
+    [self writeByte:FLTAdmobFieldAdManagerAdViewOptions];
+    FLTAdManagerAdViewOptions *options = value;
+    [self writeValue:options.manualImpressionsEnabled];
+  } else if ([value isKindOfClass:[FLTBannerParameters class]]) {
+    [self writeByte:FLTAdmobBannerParameters];
+    FLTBannerParameters *bannerParameters = value;
+    [self writeValue:bannerParameters.sizes];
+    [self writeValue:bannerParameters.options];
   } else {
     [super writeValue:value];
   }

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/include/google_mobile_ads/FLTAdInstanceManager_Internal.h
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/include/google_mobile_ads/FLTAdInstanceManager_Internal.h
@@ -18,6 +18,7 @@
 #import <GoogleMobileAds/GoogleMobileAds.h>
 
 @protocol FLTAd;
+@class FLTAdLoaderAd;
 @class FLTBannerAd;
 @class FLTNativeAd;
 @class FLTRewardedAd;

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/include/google_mobile_ads/FLTAdInstanceManager_Internal.h
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/include/google_mobile_ads/FLTAdInstanceManager_Internal.h
@@ -44,6 +44,10 @@
 - (void)onNativeAdWillPresentScreen:(nonnull id<FLTAd>)ad;
 - (void)onNativeAdDidDismissScreen:(nonnull id<FLTAd>)ad;
 - (void)onNativeAdWillDismissScreen:(nonnull id<FLTAd>)ad;
+- (void)onCustomNativeAdImpression:(nonnull id<FLTAd>)ad;
+- (void)onCustomNativeAdWillPresentScreen:(nonnull id<FLTAd>)ad;
+- (void)onCustomNativeAdDidDismissScreen:(nonnull id<FLTAd>)ad;
+- (void)onCustomNativeAdWillDismissScreen:(nonnull id<FLTAd>)ad;
 - (void)onRewardedAdUserEarnedReward:(FLTRewardedAd *_Nonnull)ad
                               reward:(FLTRewardItem *_Nonnull)reward;
 - (void)onRewardedInterstitialAdUserEarnedReward:

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/include/google_mobile_ads/FLTAdInstanceManager_Internal.h
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/include/google_mobile_ads/FLTAdInstanceManager_Internal.h
@@ -39,10 +39,10 @@
 - (void)onAppEvent:(id<FLTAd> _Nonnull)ad
               name:(NSString *_Nullable)name
               data:(NSString *_Nullable)data;
-- (void)onNativeAdImpression:(FLTNativeAd *_Nonnull)ad;
-- (void)onNativeAdWillPresentScreen:(FLTNativeAd *_Nonnull)ad;
-- (void)onNativeAdDidDismissScreen:(FLTNativeAd *_Nonnull)ad;
-- (void)onNativeAdWillDismissScreen:(FLTNativeAd *_Nonnull)ad;
+- (void)onNativeAdImpression:(nonnull id<FLTAd>)ad;
+- (void)onNativeAdWillPresentScreen:(nonnull id<FLTAd>)ad;
+- (void)onNativeAdDidDismissScreen:(nonnull id<FLTAd>)ad;
+- (void)onNativeAdWillDismissScreen:(nonnull id<FLTAd>)ad;
 - (void)onRewardedAdUserEarnedReward:(FLTRewardedAd *_Nonnull)ad
                               reward:(FLTRewardItem *_Nonnull)reward;
 - (void)onRewardedInterstitialAdUserEarnedReward:
@@ -50,10 +50,10 @@
                                           reward:
                                               (FLTRewardItem *_Nonnull)reward;
 - (void)onPaidEvent:(id<FLTAd> _Nonnull)ad value:(FLTAdValue *_Nonnull)value;
-- (void)onBannerImpression:(FLTBannerAd *_Nonnull)ad;
-- (void)onBannerWillDismissScreen:(FLTBannerAd *_Nonnull)ad;
-- (void)onBannerDidDismissScreen:(FLTBannerAd *_Nonnull)ad;
-- (void)onBannerWillPresentScreen:(FLTBannerAd *_Nonnull)ad;
+- (void)onBannerImpression:(nonnull id<FLTAd>)ad;
+- (void)onBannerWillDismissScreen:(nonnull id<FLTAd>)ad;
+- (void)onBannerDidDismissScreen:(nonnull id<FLTAd>)ad;
+- (void)onBannerWillPresentScreen:(nonnull id<FLTAd>)ad;
 
 - (void)adWillPresentFullScreenContent:(id<FLTAd> _Nonnull)ad;
 - (void)adDidDismissFullScreenContent:(id<FLTAd> _Nonnull)ad;

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/include/google_mobile_ads/FLTAd_Internal.h
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/include/google_mobile_ads/FLTAd_Internal.h
@@ -302,6 +302,23 @@
 - (GADAdLoader *_Nonnull)adLoader;
 @end
 
+typedef NS_ENUM(NSInteger, FLTAdLoaderAdType) {
+  FLTAdLoaderAdTypeUnknown = 0,
+};
+
+@interface FLTAdLoaderAd
+    : FLTBaseAd <FLTAd, FlutterPlatformView, GADAdLoaderDelegate>
+@property(readonly, nonnull) GADAdLoader *adLoader;
+@property(readonly) FLTAdLoaderAdType adLoaderAdType;
+@property(readonly, nullable) FLTAdSize *adSize;
+@property(readonly, nullable) NSString *formatId;
+- (nonnull instancetype)initWithAdUnitId:(nonnull NSString *)adUnitId
+                                 request:(nonnull FLTAdRequest *)request
+                      rootViewController:
+                          (nonnull UIViewController *)rootViewController
+                                    adId:(nonnull NSNumber *)adId;
+@end
+
 @interface FLTRewardItem : NSObject
 @property(readonly) NSNumber *_Nonnull amount;
 @property(readonly) NSString *_Nonnull type;

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/include/google_mobile_ads/FLTAd_Internal.h
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/include/google_mobile_ads/FLTAd_Internal.h
@@ -24,6 +24,7 @@
 
 @class FLTAdInstanceManager;
 @protocol FLTNativeAdFactory;
+@protocol FLTCustomAdFactory;
 
 @interface FLTAdSize : NSObject
 @property(readonly) GADAdSize size;
@@ -314,6 +315,7 @@
 typedef NS_ENUM(NSInteger, FLTAdLoaderAdType) {
   FLTAdLoaderAdTypeUnknown = 0,
   FLTAdLoaderAdTypeBanner = 1,
+  FLTAdLoaderAdTypeCustom = 2,
 };
 
 @interface FLTBannerParameters : NSObject
@@ -324,10 +326,20 @@ typedef NS_ENUM(NSInteger, FLTAdLoaderAdType) {
                                   (nullable FLTAdManagerAdViewOptions *)options;
 @end
 
+@interface FLTCustomParameters : NSObject
+@property(readonly, nonnull) NSArray<NSString *> *formatIds;
+@property(readonly, nullable) NSDictionary<NSString *, id> *viewOptions;
+@property(nullable) NSDictionary<NSString *, id<FLTCustomAdFactory>> *factories;
+- (nonnull instancetype)
+    initWithFormatIds:(nonnull NSArray<NSString *> *)formatIds
+          viewOptions:(NSDictionary<NSString *, id> *_Nullable)viewOptions;
+@end
+
 @interface FLTAdLoaderAd
     : FLTBaseAd <FLTAd, FlutterPlatformView, GADAdLoaderDelegate,
                  GAMBannerAdLoaderDelegate, GADBannerViewDelegate,
-                 GADAppEventDelegate>
+                 GADAppEventDelegate, GADCustomNativeAdLoaderDelegate,
+                 GADCustomNativeAdDelegate>
 @property(readonly, nonnull) GADAdLoader *adLoader;
 @property(readonly) FLTAdLoaderAdType adLoaderAdType;
 @property(readonly, nullable) FLTAdSize *adSize;
@@ -337,7 +349,8 @@ typedef NS_ENUM(NSInteger, FLTAdLoaderAdType) {
                request:(nonnull FLTAdRequest *)request
     rootViewController:(nonnull UIViewController *)rootViewController
                   adId:(nonnull NSNumber *)adId
-                banner:(nullable FLTBannerParameters *)bannerParameters;
+                banner:(nullable FLTBannerParameters *)bannerParameters
+                custom:(nullable FLTCustomParameters *)customParameters;
 @end
 
 @interface FLTRewardItem : NSObject

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/include/google_mobile_ads/FLTAd_Internal.h
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/include/google_mobile_ads/FLTAd_Internal.h
@@ -287,6 +287,15 @@
 - (NSArray<GADAdLoaderOptions *> *_Nonnull)asGADAdLoaderOptions;
 @end
 
+@interface FLTAdManagerAdViewOptions : NSObject
+@property(readonly, nullable) NSNumber *manualImpressionsEnabled;
+
+- (nonnull instancetype)initWithManualImpressionsEnabled:
+    (nullable NSNumber *)manualImpressionsEnabled;
+
+- (nonnull NSArray<GADAdLoaderOptions *> *)asGADAdLoaderOptions;
+@end
+
 @interface FLTNativeAd
     : FLTBaseAd <FLTAd, FlutterPlatformView, GADNativeAdDelegate,
                  GADNativeAdLoaderDelegate>
@@ -304,19 +313,31 @@
 
 typedef NS_ENUM(NSInteger, FLTAdLoaderAdType) {
   FLTAdLoaderAdTypeUnknown = 0,
+  FLTAdLoaderAdTypeBanner = 1,
 };
 
+@interface FLTBannerParameters : NSObject
+@property(readonly, nonnull) NSArray<FLTAdSize *> *sizes;
+@property(readonly, nullable) FLTAdManagerAdViewOptions *options;
+- (nonnull instancetype)initWithSizes:(nonnull NSArray<FLTAdSize *> *)sizes
+                              options:
+                                  (nullable FLTAdManagerAdViewOptions *)options;
+@end
+
 @interface FLTAdLoaderAd
-    : FLTBaseAd <FLTAd, FlutterPlatformView, GADAdLoaderDelegate>
+    : FLTBaseAd <FLTAd, FlutterPlatformView, GADAdLoaderDelegate,
+                 GAMBannerAdLoaderDelegate, GADBannerViewDelegate,
+                 GADAppEventDelegate>
 @property(readonly, nonnull) GADAdLoader *adLoader;
 @property(readonly) FLTAdLoaderAdType adLoaderAdType;
 @property(readonly, nullable) FLTAdSize *adSize;
 @property(readonly, nullable) NSString *formatId;
-- (nonnull instancetype)initWithAdUnitId:(nonnull NSString *)adUnitId
-                                 request:(nonnull FLTAdRequest *)request
-                      rootViewController:
-                          (nonnull UIViewController *)rootViewController
-                                    adId:(nonnull NSNumber *)adId;
+- (nonnull instancetype)
+      initWithAdUnitId:(nonnull NSString *)adUnitId
+               request:(nonnull FLTAdRequest *)request
+    rootViewController:(nonnull UIViewController *)rootViewController
+                  adId:(nonnull NSNumber *)adId
+                banner:(nullable FLTBannerParameters *)bannerParameters;
 @end
 
 @interface FLTRewardItem : NSObject

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/include/google_mobile_ads/FLTAd_Internal.h
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/include/google_mobile_ads/FLTAd_Internal.h
@@ -316,6 +316,7 @@ typedef NS_ENUM(NSInteger, FLTAdLoaderAdType) {
   FLTAdLoaderAdTypeUnknown = 0,
   FLTAdLoaderAdTypeBanner = 1,
   FLTAdLoaderAdTypeCustom = 2,
+  FLTAdLoaderAdTypeNative = 3,
 };
 
 @interface FLTBannerParameters : NSObject
@@ -335,11 +336,23 @@ typedef NS_ENUM(NSInteger, FLTAdLoaderAdType) {
           viewOptions:(NSDictionary<NSString *, id> *_Nullable)viewOptions;
 @end
 
+@interface FLTNativeParameters : NSObject
+@property(readonly, nonnull) NSString *factoryId;
+@property(readonly, nullable) FLTNativeAdOptions *nativeAdOptions;
+@property(readonly, nullable) NSDictionary<NSString *, id> *viewOptions;
+@property(nullable) id<FLTNativeAdFactory> factory;
+- (nonnull instancetype)
+    initWithFactoryId:(nonnull NSString *)factoryId
+      nativeAdOptions:(nullable FLTNativeAdOptions *)nativeAdOptions
+          viewOptions:(nullable NSDictionary<NSString *, id> *)viewOptions;
+@end
+
 @interface FLTAdLoaderAd
     : FLTBaseAd <FLTAd, FlutterPlatformView, GADAdLoaderDelegate,
                  GAMBannerAdLoaderDelegate, GADBannerViewDelegate,
                  GADAppEventDelegate, GADCustomNativeAdLoaderDelegate,
-                 GADCustomNativeAdDelegate>
+                 GADCustomNativeAdDelegate, GADNativeAdLoaderDelegate,
+                 GADNativeAdDelegate>
 @property(readonly, nonnull) GADAdLoader *adLoader;
 @property(readonly) FLTAdLoaderAdType adLoaderAdType;
 @property(readonly, nullable) FLTAdSize *adSize;
@@ -350,7 +363,8 @@ typedef NS_ENUM(NSInteger, FLTAdLoaderAdType) {
     rootViewController:(nonnull UIViewController *)rootViewController
                   adId:(nonnull NSNumber *)adId
                 banner:(nullable FLTBannerParameters *)bannerParameters
-                custom:(nullable FLTCustomParameters *)customParameters;
+                custom:(nullable FLTCustomParameters *)customParameters
+                native:(nullable FLTNativeParameters *)nativeParameters;
 @end
 
 @interface FLTRewardItem : NSObject

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/include/google_mobile_ads/FLTGoogleMobileAdsPlugin.h
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/include/google_mobile_ads/FLTGoogleMobileAdsPlugin.h
@@ -46,6 +46,13 @@
                                    (NSDictionary *_Nullable)customOptions;
 @end
 
+@protocol FLTCustomAdFactory
+@required
+- (nullable UIView *)
+    createCustomNativeAd:(nonnull GADCustomNativeAd *)customNativeAd
+           customOptions:(nullable NSDictionary *)customOptions;
+@end
+
 /**
  * Flutter plugin providing access to the Google Mobile Ads API.
  */
@@ -95,6 +102,10 @@
                 nativeAdFactory:
                     (id<FLTNativeAdFactory> _Nonnull)nativeAdFactory;
 
++ (BOOL)registerCustomAdFactory:(nonnull id<FlutterPluginRegistry>)registry
+                       formatId:(nonnull NSString *)formatId
+                customAdFactory:(nonnull id<FLTCustomAdFactory>)customAdFactory;
+
 /**
  * Unregisters a `FLTNativeAdFactory` used to create `GADNativeAdView`s from a
  * Native Ad created in Dart.
@@ -108,4 +119,8 @@
 + (id<FLTNativeAdFactory> _Nullable)
     unregisterNativeAdFactory:(id<FlutterPluginRegistry> _Nonnull)registry
                     factoryId:(NSString *_Nonnull)factoryId;
+
++ (nullable id<FLTCustomAdFactory>)
+    unregisterCustomAdFactory:(nonnull id<FlutterPluginRegistry>)registry
+                     formatId:(nonnull NSString *)formatId;
 @end

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -1145,6 +1145,77 @@ class NativeAd extends AdWithView {
   }
 }
 
+/// Type of ad served by [AdLoaderAd]
+enum AdLoaderAdType {
+  /// Unknown ad type
+  unknown,
+}
+
+/// An AdLoaderAd.
+///
+/// A widget which uses the platforms' ad loader (an [AdLoader]
+/// (https://developers.google.com/android/reference/com/google/android/gms/ads/AdLoader)
+/// on Android, or a [GADAdLoader]
+/// (https://developers.google.com/ad-manager/mobile-ads-sdk/ios/api/reference/Classes/GADAdLoader)
+/// on iOS) to allow receiving multiple ad types for a given request.
+///
+/// These types are:
+///
+/// * A "banner" ad, ([AdManagerAdView]
+/// (https://developers.google.com/android/reference/com/google/android/gms/ads/admanager/AdManagerAdView)
+/// on Android and [GAMBannerView]
+/// (https://developers.google.com/ad-manager/mobile-ads-sdk/ios/api/reference/Classes/GAMBannerView.html)
+/// on iOS)
+///
+/// * A "custom" ad, ([NativeCustomFormatAd]
+/// (https://developers.google.com/android/reference/com/google/android/gms/ads/nativead/NativeCustomFormatAd)
+/// on Android and [GADCustomNativeAd]
+/// (https://developers.google.com/admob/ios/api/reference/Classes/GADCustomNativeAd.html) on iOS)
+///
+/// * A "native" ad, ([NativeAd]
+/// (https://developers.google.com/android/reference/com/google/android/gms/ads/nativead/NativeAd)
+/// on Android and [GADNativeAd]
+/// (https://developers.google.com/admob/ios/api/reference/Classes/GADNativeAd.html) on iOS)
+class AdLoaderAd extends AdWithView {
+  /// Creates an [AdLoaderAd]
+  ///
+  /// A valid [adUnitId], nonnull [listener] and nonnull [request] are required.
+  AdLoaderAd({
+    required String adUnitId,
+    required this.listener,
+    required AdRequest request,
+  }) : super(adUnitId: adUnitId, listener: listener) {
+    if (request is AdManagerAdRequest) {
+      adManagerRequest = request;
+    } else {
+      this.request = request;
+    }
+  }
+
+  /// A listener for receiving events in the ad lifecycle.
+  @override
+  final AdLoaderAdListener listener;
+
+  /// Targeting information used to fetch an [Ad].
+  AdRequest? request;
+
+  /// Targeting information used to fetch an [Ad] with Ad Manager.
+  AdManagerAdRequest? adManagerRequest;
+
+  @override
+  Future<void> load() => instanceManager.loadAdLoaderAd(this);
+
+  /// Returns the AdLoaderAdType of the currently served ad.
+  Future<AdLoaderAdType> getAdLoaderAdType() =>
+      instanceManager.getAdLoaderAdType(this);
+
+  /// Returns the AdSize of the associated platform ad object.
+  Future<AdSize?> getPlatformAdSize() => instanceManager.getAdSize(this);
+
+  /// Returns the formatId of the served Custom ad.
+  Future<String?> getFormatId() => instanceManager.getFormatId(this);
+}
+
 /// A full-screen interstitial ad for the Google Mobile Ads Plugin.
 class InterstitialAd extends AdWithoutView {
   /// Creates an [InterstitialAd].

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -1152,6 +1152,9 @@ enum AdLoaderAdType {
 
   /// Banner ad type
   banner,
+
+  /// Custom ad type
+  custom,
 }
 
 /// An AdLoaderAd.
@@ -1188,6 +1191,7 @@ class AdLoaderAd extends AdWithView {
     required this.listener,
     required AdRequest request,
     this.banner,
+    this.custom,
   }) : super(adUnitId: adUnitId, listener: listener) {
     if (request is AdManagerAdRequest) {
       adManagerRequest = request;
@@ -1208,6 +1212,9 @@ class AdLoaderAd extends AdWithView {
 
   /// Optional parameters used to configure served "banner" ads
   final BannerParameters? banner;
+
+  /// Optional parameters used to configure served "custom" ads
+  final CustomParameters? custom;
 
   @override
   Future<void> load() => instanceManager.loadAdLoaderAd(this);
@@ -1674,6 +1681,30 @@ class BannerParameters {
     return other is BannerParameters &&
         listEquals<AdSize>(sizes, other.sizes) &&
         adManagerAdViewOptions == other.adManagerAdViewOptions;
+  }
+}
+
+/// Central configuration item for custom format requests served
+/// by an [AdLoaderAd]
+class CustomParameters {
+  /// A list of format IDs, corresponding to those in the
+  /// Google Ad Manager console
+  final List<String> formatIds;
+
+  /// View options used to create the Platform view
+  ///
+  /// These options are passed to the platform's `CustomAdFactory`
+  Map<String, Object>? viewOptions;
+
+  /// Construct a [CustomParameters] instance, used by an [AdLoaderAd] to
+  /// configure custom view
+  CustomParameters({required this.formatIds, this.viewOptions});
+
+  @override
+  bool operator ==(other) {
+    return other is CustomParameters &&
+        listEquals<String>(formatIds, other.formatIds) &&
+        mapEquals<String, Object>(viewOptions, other.viewOptions);
   }
 }
 

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -1155,6 +1155,9 @@ enum AdLoaderAdType {
 
   /// Custom ad type
   custom,
+
+  /// Native ad type
+  native,
 }
 
 /// An AdLoaderAd.
@@ -1192,6 +1195,7 @@ class AdLoaderAd extends AdWithView {
     required AdRequest request,
     this.banner,
     this.custom,
+    this.native,
   }) : super(adUnitId: adUnitId, listener: listener) {
     if (request is AdManagerAdRequest) {
       adManagerRequest = request;
@@ -1215,6 +1219,9 @@ class AdLoaderAd extends AdWithView {
 
   /// Optional parameters used to configure served "custom" ads
   final CustomParameters? custom;
+
+  /// Optional parameters used to configure served "native" ads
+  final NativeParameters? native;
 
   @override
   Future<void> load() => instanceManager.loadAdLoaderAd(this);
@@ -1704,6 +1711,37 @@ class CustomParameters {
   bool operator ==(other) {
     return other is CustomParameters &&
         listEquals<String>(formatIds, other.formatIds) &&
+        mapEquals<String, Object>(viewOptions, other.viewOptions);
+  }
+}
+
+/// Central configuration item for native view requests served by an
+/// [AdLoaderAd].
+class NativeParameters {
+  /// An identifier for the factory that creates the Platform view.
+  final String factoryId;
+
+  /// Options to configure the native ad request.
+  final NativeAdOptions? nativeAdOptions;
+
+  /// Optional options used to create the Platform view.
+  ///
+  /// These options are passed to the platform's `NativeAdFactory`.
+  final Map<String, Object>? viewOptions;
+
+  /// Construct a [NativeParameters] instance, used by an [AdLoaderAd] to
+  /// configure native views.
+  NativeParameters({
+    required this.factoryId,
+    this.nativeAdOptions,
+    this.viewOptions,
+  });
+
+  @override
+  bool operator ==(other) {
+    return other is NativeParameters &&
+        factoryId == other.factoryId &&
+        nativeAdOptions == other.nativeAdOptions &&
         mapEquals<String, Object>(viewOptions, other.viewOptions);
   }
 }

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -1149,6 +1149,9 @@ class NativeAd extends AdWithView {
 enum AdLoaderAdType {
   /// Unknown ad type
   unknown,
+
+  /// Banner ad type
+  banner,
 }
 
 /// An AdLoaderAd.
@@ -1184,6 +1187,7 @@ class AdLoaderAd extends AdWithView {
     required String adUnitId,
     required this.listener,
     required AdRequest request,
+    this.banner,
   }) : super(adUnitId: adUnitId, listener: listener) {
     if (request is AdManagerAdRequest) {
       adManagerRequest = request;
@@ -1201,6 +1205,9 @@ class AdLoaderAd extends AdWithView {
 
   /// Targeting information used to fetch an [Ad] with Ad Manager.
   AdManagerAdRequest? adManagerRequest;
+
+  /// Optional parameters used to configure served "banner" ads
+  final BannerParameters? banner;
 
   @override
   Future<void> load() => instanceManager.loadAdLoaderAd(this);
@@ -1629,6 +1636,45 @@ enum AdChoicesPlacement {
 
   /// Bottom left corner.
   bottomLeftCorner,
+}
+
+/// Used to configure ad manager ad view requests.
+class AdManagerAdViewOptions {
+  /// Whether manual impression reporting is enabled
+  ///
+  /// Default value is false.
+  final bool? manualImpressionsEnabled;
+
+  /// Construct an [AdManagerAdViewOptions], an optional class used to further customize
+  /// ad manager ad view requests.
+  AdManagerAdViewOptions({this.manualImpressionsEnabled});
+
+  @override
+  bool operator ==(other) {
+    return other is AdManagerAdViewOptions &&
+        manualImpressionsEnabled == other.manualImpressionsEnabled;
+  }
+}
+
+/// Central configuration item for ad manager ad view requests served by
+/// an [AdLoaderAd].
+class BannerParameters {
+  /// List of sizes the [AdLoaderAd] should expect
+  final List<AdSize> sizes;
+
+  /// Additional options used when configuring the ad manager ad view
+  final AdManagerAdViewOptions? adManagerAdViewOptions;
+
+  /// Construct a [BannerParameters], used by an [AdLoaderAd] to configure
+  /// ad manager ad views
+  BannerParameters({required this.sizes, this.adManagerAdViewOptions});
+
+  @override
+  bool operator ==(other) {
+    return other is BannerParameters &&
+        listEquals<AdSize>(sizes, other.sizes) &&
+        adManagerAdViewOptions == other.adManagerAdViewOptions;
+  }
 }
 
 /// Used to configure native ad requests.

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -509,6 +509,8 @@ class AdInstanceManager {
       switch (adLoaderAdType) {
         case 0:
           return AdLoaderAdType.unknown;
+        case 1:
+          return AdLoaderAdType.banner;
         default:
           debugPrint('Error: unknown AdLoaderAdType value: $adLoaderAdType');
           return AdLoaderAdType.unknown;
@@ -517,6 +519,8 @@ class AdInstanceManager {
       switch (adLoaderAdType) {
         case 0:
           return AdLoaderAdType.unknown;
+        case 1:
+          return AdLoaderAdType.banner;
         default:
           debugPrint('Error: unknown AdLoaderAdType value: $adLoaderAdType');
           return AdLoaderAdType.unknown;
@@ -617,6 +621,7 @@ class AdInstanceManager {
       'adUnitId': ad.adUnitId,
       'request': ad.request,
       'adManagerRequest': ad.adManagerRequest,
+      'banner': ad.banner,
     });
   }
 
@@ -928,6 +933,8 @@ class AdMessageCodec extends StandardMessageCodec {
   static const int _valueNativeTemplateType = 152;
   static const int _valueColor = 153;
   static const int _valueMediationExtras = 154;
+  static const int _valueAdManagerAdViewOptions = 155;
+  static const int _valueBannerParameters = 156;
 
   @override
   void writeValue(WriteBuffer buffer, dynamic value) {
@@ -1064,6 +1071,13 @@ class AdMessageCodec extends StandardMessageCodec {
     } else if (value is NativeTemplateFontStyle) {
       buffer.putUint8(_valueNativeTemplateFontStyle);
       writeValue(buffer, value.index);
+    } else if (value is AdManagerAdViewOptions) {
+      buffer.putUint8(_valueAdManagerAdViewOptions);
+      writeValue(buffer, value.manualImpressionsEnabled);
+    } else if (value is BannerParameters) {
+      buffer.putUint8(_valueBannerParameters);
+      writeValue(buffer, value.sizes);
+      writeValue(buffer, value.adManagerAdViewOptions);
     } else {
       super.writeValue(buffer, value);
     }
@@ -1330,6 +1344,15 @@ class AdMessageCodec extends StandardMessageCodec {
           buffer.getUint8(),
           buffer,
         )];
+      case _valueAdManagerAdViewOptions:
+        return AdManagerAdViewOptions(
+          manualImpressionsEnabled: readValueOfType(buffer.getUint8(), buffer),
+        );
+      case _valueBannerParameters:
+        return BannerParameters(
+          sizes: readValueOfType(buffer.getUint8(), buffer)?.cast<AdSize>(),
+          adManagerAdViewOptions: readValueOfType(buffer.getUint8(), buffer),
+        );
       default:
         return super.readValueOfType(type, buffer);
     }

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -493,6 +493,37 @@ class AdInstanceManager {
         <dynamic, dynamic>{'adId': adIdFor(ad)},
       );
 
+  Future<String?> getFormatId(Ad ad) =>
+      instanceManager.channel.invokeMethod<String>(
+        'getFormatId',
+        <dynamic, dynamic>{'adId': adIdFor(ad)},
+      );
+
+  Future<AdLoaderAdType> getAdLoaderAdType(Ad ad) async {
+    int adLoaderAdType = (await instanceManager.channel.invokeMethod<int>(
+      'getAdLoaderAdType',
+      <dynamic, dynamic>{'adId': adIdFor(ad)},
+    ))!;
+
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      switch (adLoaderAdType) {
+        case 0:
+          return AdLoaderAdType.unknown;
+        default:
+          debugPrint('Error: unknown AdLoaderAdType value: $adLoaderAdType');
+          return AdLoaderAdType.unknown;
+      }
+    } else {
+      switch (adLoaderAdType) {
+        case 0:
+          return AdLoaderAdType.unknown;
+        default:
+          debugPrint('Error: unknown AdLoaderAdType value: $adLoaderAdType');
+          return AdLoaderAdType.unknown;
+      }
+    }
+  }
+
   /// Returns null if an invalid [adId] was passed in.
   Ad? adFor(int adId) => _loadedAds[adId];
 
@@ -568,6 +599,24 @@ class AdInstanceManager {
       'nativeAdOptions': ad.nativeAdOptions,
       'customOptions': ad.customOptions,
       'nativeTemplateStyle': ad.nativeTemplateStyle,
+    });
+  }
+
+  /// Starts loading the ad if not previously loaded.
+  ///
+  /// Loading also terminates if ad is already in the process of loading.
+  Future<void> loadAdLoaderAd(AdLoaderAd ad) {
+    if (adIdFor(ad) != null) {
+      return Future<void>.value();
+    }
+
+    final int adId = _nextAdId++;
+    _loadedAds[adId] = ad;
+    return channel.invokeMethod<void>('loadAdLoaderAd', <dynamic, dynamic>{
+      'adId': adId,
+      'adUnitId': ad.adUnitId,
+      'request': ad.request,
+      'adManagerRequest': ad.adManagerRequest,
     });
   }
 

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -517,6 +517,8 @@ class AdInstanceManager {
           return AdLoaderAdType.banner;
         case 2:
           return AdLoaderAdType.custom;
+        case 3:
+          return AdLoaderAdType.native;
         default:
           debugPrint('Error: unknown AdLoaderAdType value: $adLoaderAdType');
           return AdLoaderAdType.unknown;
@@ -529,6 +531,8 @@ class AdInstanceManager {
           return AdLoaderAdType.banner;
         case 2:
           return AdLoaderAdType.custom;
+        case 3:
+          return AdLoaderAdType.native;
         default:
           debugPrint('Error: unknown AdLoaderAdType value: $adLoaderAdType');
           return AdLoaderAdType.unknown;
@@ -631,6 +635,7 @@ class AdInstanceManager {
       'adManagerRequest': ad.adManagerRequest,
       'banner': ad.banner,
       'custom': ad.custom,
+      'native': ad.native,
     });
   }
 
@@ -945,6 +950,7 @@ class AdMessageCodec extends StandardMessageCodec {
   static const int _valueAdManagerAdViewOptions = 155;
   static const int _valueBannerParameters = 156;
   static const int _valueCustomParameters = 157;
+  static const int _valueNativeParameters = 158;
 
   @override
   void writeValue(WriteBuffer buffer, dynamic value) {
@@ -1091,6 +1097,11 @@ class AdMessageCodec extends StandardMessageCodec {
     } else if (value is CustomParameters) {
       buffer.putUint8(_valueCustomParameters);
       writeValue(buffer, value.formatIds);
+      writeValue(buffer, value.viewOptions);
+    } else if (value is NativeParameters) {
+      buffer.putUint8(_valueNativeParameters);
+      writeValue(buffer, value.factoryId);
+      writeValue(buffer, value.nativeAdOptions);
       writeValue(buffer, value.viewOptions);
     } else {
       super.writeValue(buffer, value);
@@ -1370,6 +1381,15 @@ class AdMessageCodec extends StandardMessageCodec {
       case _valueCustomParameters:
         return CustomParameters(
           formatIds: readValueOfType(buffer.getUint8(), buffer).cast<String>(),
+          viewOptions: readValueOfType(
+            buffer.getUint8(),
+            buffer,
+          )?.cast<String, Object>(),
+        );
+      case _valueNativeParameters:
+        return NativeParameters(
+          factoryId: readValueOfType(buffer.getUint8(), buffer),
+          nativeAdOptions: readValueOfType(buffer.getUint8(), buffer),
           viewOptions: readValueOfType(
             buffer.getUint8(),
             buffer,

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -103,14 +103,17 @@ class AdInstanceManager {
         break;
       case 'onNativeAdWillPresentScreen': // Fall through
       case 'onBannerWillPresentScreen':
+      case 'onCustomNativeWillPresentScreen':
         _invokeOnAdOpened(ad, eventName);
         break;
       case 'onNativeAdDidDismissScreen': // Fall through
       case 'onBannerDidDismissScreen':
+      case 'onCustomNativeAdDidDismissScreen':
         _invokeOnAdClosed(ad, eventName);
         break;
       case 'onBannerWillDismissScreen': // Fall through
       case 'onNativeAdWillDismissScreen':
+      case 'onCustomNativeAdWillDismissScreen':
         if (ad is AdWithView) {
           ad.listener.onAdWillDismissScreen?.call(ad);
         } else {
@@ -124,6 +127,7 @@ class AdInstanceManager {
       case 'onBannerImpression':
       case 'adDidRecordImpression': // Fall through
       case 'onNativeAdImpression': // Fall through
+      case 'onCustomNativeAdImpression':
         _invokeOnAdImpression(ad, eventName);
         break;
       case 'adWillPresentFullScreenContent':
@@ -511,6 +515,8 @@ class AdInstanceManager {
           return AdLoaderAdType.unknown;
         case 1:
           return AdLoaderAdType.banner;
+        case 2:
+          return AdLoaderAdType.custom;
         default:
           debugPrint('Error: unknown AdLoaderAdType value: $adLoaderAdType');
           return AdLoaderAdType.unknown;
@@ -521,6 +527,8 @@ class AdInstanceManager {
           return AdLoaderAdType.unknown;
         case 1:
           return AdLoaderAdType.banner;
+        case 2:
+          return AdLoaderAdType.custom;
         default:
           debugPrint('Error: unknown AdLoaderAdType value: $adLoaderAdType');
           return AdLoaderAdType.unknown;
@@ -622,6 +630,7 @@ class AdInstanceManager {
       'request': ad.request,
       'adManagerRequest': ad.adManagerRequest,
       'banner': ad.banner,
+      'custom': ad.custom,
     });
   }
 
@@ -935,6 +944,7 @@ class AdMessageCodec extends StandardMessageCodec {
   static const int _valueMediationExtras = 154;
   static const int _valueAdManagerAdViewOptions = 155;
   static const int _valueBannerParameters = 156;
+  static const int _valueCustomParameters = 157;
 
   @override
   void writeValue(WriteBuffer buffer, dynamic value) {
@@ -1078,6 +1088,10 @@ class AdMessageCodec extends StandardMessageCodec {
       buffer.putUint8(_valueBannerParameters);
       writeValue(buffer, value.sizes);
       writeValue(buffer, value.adManagerAdViewOptions);
+    } else if (value is CustomParameters) {
+      buffer.putUint8(_valueCustomParameters);
+      writeValue(buffer, value.formatIds);
+      writeValue(buffer, value.viewOptions);
     } else {
       super.writeValue(buffer, value);
     }
@@ -1352,6 +1366,14 @@ class AdMessageCodec extends StandardMessageCodec {
         return BannerParameters(
           sizes: readValueOfType(buffer.getUint8(), buffer)?.cast<AdSize>(),
           adManagerAdViewOptions: readValueOfType(buffer.getUint8(), buffer),
+        );
+      case _valueCustomParameters:
+        return CustomParameters(
+          formatIds: readValueOfType(buffer.getUint8(), buffer).cast<String>(),
+          viewOptions: readValueOfType(
+            buffer.getUint8(),
+            buffer,
+          )?.cast<String, Object>(),
         );
       default:
         return super.readValueOfType(type, buffer);

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -1192,8 +1192,8 @@ class AdMessageCodec extends StandardMessageCodec {
         );
       case _valueRewardItem:
         return RewardItem(
-          readValueOfType(buffer.getUint8(), buffer),
-          readValueOfType(buffer.getUint8(), buffer),
+          readValueOfType(buffer.getUint8(), buffer) ?? 0,
+          _safeReadString(buffer),
         );
       case _valueResponseInfo:
         return ResponseInfo(
@@ -1278,7 +1278,7 @@ class AdMessageCodec extends StandardMessageCodec {
           buffer.getUint8(),
           buffer,
         );
-        final String description = readValueOfType(buffer.getUint8(), buffer);
+        final String description = _safeReadString(buffer);
 
         double latency = readValueOfType(buffer.getUint8(), buffer).toDouble();
         // Android provides this value as an int in milliseconds while iOS

--- a/packages/google_mobile_ads/lib/src/ad_listeners.dart
+++ b/packages/google_mobile_ads/lib/src/ad_listeners.dart
@@ -227,6 +227,43 @@ class NativeAdListener extends AdWithViewListener {
        );
 }
 
+/// A listener for receiving notifications for the lifecycle of an [AdLoaderAd]
+class AdLoaderAdListener extends AdWithViewListener {
+  /// Constructs an [AdLoaderAdListener] with the provided event callbacks.
+  ///
+  /// Typically you will override [onAdLoaded] and [onAdFailedToLoad]:
+  /// ```dart
+  /// AdLoaderAdListener(
+  ///   onAdLoaded: (ad) {
+  ///     // Ad successfully loaded - display an AdWidget with the ad.
+  ///   },
+  ///   onAdFailedToLoad: (ad, error) {
+  ///     // Ad failed to load - log the error and dispose the ad.
+  ///   },
+  ///   ...
+  /// )
+  /// ```
+  AdLoaderAdListener({
+    AdEventCallback? onAdLoaded,
+    AdLoadErrorCallback? onAdFailedToLoad,
+    AdEventCallback? onAdOpened,
+    AdEventCallback? onAdWillDismissScreen,
+    AdEventCallback? onAdClosed,
+    AdEventCallback? onAdImpression,
+    OnPaidEventCallback? onPaidEvent,
+    AdEventCallback? onAdClicked,
+  }) : super(
+         onAdLoaded: onAdLoaded,
+         onAdFailedToLoad: onAdFailedToLoad,
+         onAdOpened: onAdOpened,
+         onAdWillDismissScreen: onAdWillDismissScreen,
+         onAdClosed: onAdClosed,
+         onAdImpression: onAdImpression,
+         onPaidEvent: onPaidEvent,
+         onAdClicked: onAdClicked,
+       );
+}
+
 /// Callback events for for full screen ads, such as Rewarded and Interstitial.
 class FullScreenContentCallback<Ad> {
   /// Construct a new [FullScreenContentCallback].

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -54,6 +54,7 @@ void main() {
               case 'setImmersiveMode':
               case 'loadBannerAd':
               case 'loadNativeAd':
+              case 'loadAdLoaderAd':
               case 'showAdWithoutView':
               case 'disposeAd':
               case 'loadRewardedAd':

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -1196,6 +1196,31 @@ void main() {
       expect(result.type, 'type');
     });
 
+    test('encode/decode $RewardItem with null values', () async {
+      final WriteBuffer buffer = WriteBuffer();
+      buffer.putUint8(132);
+      codec.writeValue(buffer, null);
+      codec.writeValue(buffer, null);
+
+      final RewardItem result = codec.decodeMessage(buffer.done());
+      expect(result.amount, 0);
+      expect(result.type, '');
+    });
+
+    test('encode/decode $AdapterStatus with null description', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      final WriteBuffer buffer = WriteBuffer();
+      buffer.putUint8(136);
+      codec.writeValue(buffer, AdapterInitializationState.ready);
+      codec.writeValue(buffer, null);
+      codec.writeValue(buffer, 1000);
+
+      final AdapterStatus result = codec.decodeMessage(buffer.done());
+      expect(result.state, AdapterInitializationState.ready);
+      expect(result.description, '');
+      expect(result.latency, 1.0);
+    });
+
     test('encode/decode $InlineAdaptiveSize', () async {
       ByteData byteData = codec.encodeMessage(
         AdSize.getCurrentOrientationInlineAdaptiveBannerAdSize(100),

--- a/packages/google_mobile_ads/test/ad_loader_ad_test.dart
+++ b/packages/google_mobile_ads/test/ad_loader_ad_test.dart
@@ -73,6 +73,7 @@ void main() {
             'adManagerRequest': null,
             'banner': null,
             'custom': null,
+            'native': null,
           },
         ),
       ]);
@@ -100,6 +101,7 @@ void main() {
             'adManagerRequest': request,
             'banner': null,
             'custom': null,
+            'native': null,
           },
         ),
       ]);
@@ -127,6 +129,7 @@ void main() {
             'adManagerRequest': null,
             'banner': banner,
             'custom': null,
+            'native': null,
           },
         ),
       ]);
@@ -156,6 +159,37 @@ void main() {
             'adManagerRequest': null,
             'banner': null,
             'custom': custom,
+            'native': null,
+          },
+        ),
+      ]);
+
+      expect(instanceManager.adFor(0), isNotNull);
+    });
+
+    test('load with $NativeParameters', () async {
+      final NativeParameters native = NativeParameters(
+        factoryId: 'test-factory-id',
+      );
+      final AdLoaderAd adLoaderAd = AdLoaderAd(
+        adUnitId: 'test-ad-unit',
+        listener: AdLoaderAdListener(),
+        request: AdRequest(),
+        native: native,
+      );
+
+      await adLoaderAd.load();
+      expect(log, <Matcher>[
+        isMethodCall(
+          'loadAdLoaderAd',
+          arguments: <String, dynamic>{
+            'adId': 0,
+            'adUnitId': 'test-ad-unit',
+            'request': adLoaderAd.request,
+            'adManagerRequest': null,
+            'banner': null,
+            'custom': null,
+            'native': native,
           },
         ),
       ]);

--- a/packages/google_mobile_ads/test/ad_loader_ad_test.dart
+++ b/packages/google_mobile_ads/test/ad_loader_ad_test.dart
@@ -72,6 +72,7 @@ void main() {
             'request': request,
             'adManagerRequest': null,
             'banner': null,
+            'custom': null,
           },
         ),
       ]);
@@ -98,6 +99,7 @@ void main() {
             'request': null,
             'adManagerRequest': request,
             'banner': null,
+            'custom': null,
           },
         ),
       ]);
@@ -124,6 +126,36 @@ void main() {
             'request': adLoaderAd.request,
             'adManagerRequest': null,
             'banner': banner,
+            'custom': null,
+          },
+        ),
+      ]);
+
+      expect(instanceManager.adFor(0), isNotNull);
+    });
+
+    test('load with $CustomParameters', () async {
+      final CustomParameters custom = CustomParameters(
+        formatIds: ['test-format-id'],
+      );
+      final AdLoaderAd adLoaderAd = AdLoaderAd(
+        adUnitId: 'test-ad-unit',
+        listener: AdLoaderAdListener(),
+        request: AdRequest(),
+        custom: custom,
+      );
+
+      await adLoaderAd.load();
+      expect(log, <Matcher>[
+        isMethodCall(
+          'loadAdLoaderAd',
+          arguments: <String, dynamic>{
+            'adId': 0,
+            'adUnitId': 'test-ad-unit',
+            'request': adLoaderAd.request,
+            'adManagerRequest': null,
+            'banner': null,
+            'custom': custom,
           },
         ),
       ]);

--- a/packages/google_mobile_ads/test/ad_loader_ad_test.dart
+++ b/packages/google_mobile_ads/test/ad_loader_ad_test.dart
@@ -1,0 +1,281 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_mobile_ads/src/ad_containers.dart';
+import 'package:google_mobile_ads/src/ad_instance_manager.dart';
+import 'package:google_mobile_ads/src/ad_listeners.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Ad Loader Ad Tests', () {
+    final List<MethodCall> log = <MethodCall>[];
+
+    setUp(() async {
+      log.clear();
+      instanceManager = AdInstanceManager(
+        'plugins.flutter.io/google_mobile_ads',
+      );
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(instanceManager.channel, (
+            MethodCall methodCall,
+          ) async {
+            log.add(methodCall);
+            switch (methodCall.method) {
+              case 'getAdLoaderAdType':
+                return Future<dynamic>.value(0);
+              case 'getAdSize':
+                return Future<dynamic>.value(AdSize.banner);
+              case 'getFormatId':
+                return Future<dynamic>.value('format-id');
+              case 'loadAdLoaderAd':
+                return Future<void>.value();
+              default:
+                assert(false);
+                return null;
+            }
+          });
+    });
+
+    test('load with $AdRequest', () async {
+      final AdRequest request = AdRequest();
+      final AdLoaderAd adLoaderAd = AdLoaderAd(
+        adUnitId: 'test-ad-unit',
+        listener: AdLoaderAdListener(),
+        request: request,
+      );
+
+      await adLoaderAd.load();
+
+      expect(log, <Matcher>[
+        isMethodCall(
+          'loadAdLoaderAd',
+          arguments: <String, dynamic>{
+            'adId': 0,
+            'adUnitId': 'test-ad-unit',
+            'request': request,
+            'adManagerRequest': null,
+          },
+        ),
+      ]);
+
+      expect(instanceManager.adFor(0), isNotNull);
+    });
+
+    test('load with $AdManagerAdRequest', () async {
+      final AdManagerAdRequest request = AdManagerAdRequest();
+      final AdLoaderAd adLoaderAd = AdLoaderAd(
+        adUnitId: 'test-ad-unit',
+        listener: AdLoaderAdListener(),
+        request: request,
+      );
+
+      await adLoaderAd.load();
+
+      expect(log, <Matcher>[
+        isMethodCall(
+          'loadAdLoaderAd',
+          arguments: <String, dynamic>{
+            'adId': 0,
+            'adUnitId': 'test-ad-unit',
+            'request': null,
+            'adManagerRequest': request,
+          },
+        ),
+      ]);
+
+      expect(instanceManager.adFor(0), isNotNull);
+    });
+
+    test('getAdLoaderAdType delegates to $MethodChannel', () async {
+      final AdLoaderAd adLoaderAd = AdLoaderAd(
+        adUnitId: 'test-ad-unit',
+        listener: AdLoaderAdListener(),
+        request: AdRequest(),
+      );
+
+      final result = await adLoaderAd.getAdLoaderAdType();
+
+      expect(result, equals(AdLoaderAdType.unknown));
+
+      expect(log, <Matcher>[
+        isMethodCall(
+          'getAdLoaderAdType',
+          arguments: <String, dynamic>{'adId': null},
+        ),
+      ]);
+    });
+
+    test('getFormatId delegates to $MethodChannel', () async {
+      final AdLoaderAd adLoaderAd = AdLoaderAd(
+        adUnitId: 'test-ad-unit',
+        listener: AdLoaderAdListener(),
+        request: AdRequest(),
+      );
+
+      final result = await adLoaderAd.getFormatId();
+
+      expect(result, equals('format-id'));
+
+      expect(log, <Matcher>[
+        isMethodCall('getFormatId', arguments: <String, dynamic>{'adId': null}),
+      ]);
+    });
+
+    test('getPlatformAdSize delegates to $MethodChannel', () async {
+      final AdLoaderAd adLoaderAd = AdLoaderAd(
+        adUnitId: 'test-ad-unit',
+        listener: AdLoaderAdListener(),
+        request: AdRequest(),
+      );
+
+      final result = await adLoaderAd.getPlatformAdSize();
+
+      expect(result, equals(AdSize.banner));
+
+      expect(log, <Matcher>[
+        isMethodCall('getAdSize', arguments: <String, dynamic>{'adId': null}),
+      ]);
+    });
+
+    test('onAdLoaded event', () async {
+      var testOnAdLoaded = (eventName, adId) async {
+        final Completer<Ad> completer = Completer<Ad>();
+
+        final AdLoaderAd ad = AdLoaderAd(
+          adUnitId: 'test-ad-unit',
+          listener: AdLoaderAdListener(
+            onAdLoaded: (ad) => completer.complete(ad),
+          ),
+          request: AdRequest(),
+        );
+
+        await ad.load();
+
+        final MethodCall methodCall = MethodCall(
+          'onAdEvent',
+          <dynamic, dynamic>{'adId': adId, 'eventName': eventName},
+        );
+
+        final ByteData data = instanceManager.channel.codec.encodeMethodCall(
+          methodCall,
+        );
+
+        await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .handlePlatformMessage(
+              'plugins.flutter.io/google_mobile_ads',
+              data,
+              (ByteData? data) {},
+            );
+
+        expect(completer.future, completion(ad));
+      };
+
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      await testOnAdLoaded('onAdLoaded', 0);
+
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      await testOnAdLoaded('onAdLoaded', 1);
+    });
+
+    test('onAdFailedToLoad event', () async {
+      var testOnAdFailedToLoad = (eventName, adId) async {
+        final Completer<Ad> completer = Completer<Ad>();
+
+        final AdLoaderAd ad = AdLoaderAd(
+          adUnitId: 'test-ad-unit',
+          listener: AdLoaderAdListener(
+            onAdFailedToLoad: (ad, error) => completer.complete(ad),
+          ),
+          request: AdRequest(),
+        );
+
+        await ad.load();
+
+        final MethodCall methodCall = MethodCall(
+          'onAdEvent',
+          <dynamic, dynamic>{
+            'adId': adId,
+            'eventName': eventName,
+            'loadAdError': LoadAdError(0, '', '', null),
+          },
+        );
+
+        final ByteData data = instanceManager.channel.codec.encodeMethodCall(
+          methodCall,
+        );
+
+        await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .handlePlatformMessage(
+              'plugins.flutter.io/google_mobile_ads',
+              data,
+              (ByteData? data) {},
+            );
+
+        expect(completer.future, completion(ad));
+      };
+
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      await testOnAdFailedToLoad('onAdFailedToLoad', 0);
+
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      await testOnAdFailedToLoad('onAdFailedToLoad', 1);
+    });
+
+    test('onAdClicked event', () async {
+      var testOnAdClicked = (eventName, adId) async {
+        final Completer<Ad> completer = Completer<Ad>();
+
+        final AdLoaderAd ad = AdLoaderAd(
+          adUnitId: 'test-ad-unit',
+          listener: AdLoaderAdListener(
+            onAdClicked: (ad) => completer.complete(ad),
+          ),
+          request: AdRequest(),
+        );
+
+        await ad.load();
+
+        final MethodCall methodCall = MethodCall(
+          'onAdEvent',
+          <dynamic, dynamic>{'adId': adId, 'eventName': eventName},
+        );
+
+        final ByteData data = instanceManager.channel.codec.encodeMethodCall(
+          methodCall,
+        );
+
+        await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .handlePlatformMessage(
+              'plugins.flutter.io/google_mobile_ads',
+              data,
+              (ByteData? data) {},
+            );
+
+        expect(completer.future, completion(ad));
+      };
+
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      await testOnAdClicked('adDidRecordClick', 0);
+
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      await testOnAdClicked('onAdClicked', 1);
+    });
+  });
+}

--- a/packages/google_mobile_ads/test/ad_loader_ad_test.dart
+++ b/packages/google_mobile_ads/test/ad_loader_ad_test.dart
@@ -71,6 +71,7 @@ void main() {
             'adUnitId': 'test-ad-unit',
             'request': request,
             'adManagerRequest': null,
+            'banner': null,
           },
         ),
       ]);
@@ -96,6 +97,33 @@ void main() {
             'adUnitId': 'test-ad-unit',
             'request': null,
             'adManagerRequest': request,
+            'banner': null,
+          },
+        ),
+      ]);
+
+      expect(instanceManager.adFor(0), isNotNull);
+    });
+
+    test('load with $BannerParameters', () async {
+      final BannerParameters banner = BannerParameters(sizes: [AdSize.banner]);
+      final AdLoaderAd adLoaderAd = AdLoaderAd(
+        adUnitId: 'test-ad-unit',
+        listener: AdLoaderAdListener(),
+        request: AdRequest(),
+        banner: banner,
+      );
+
+      await adLoaderAd.load();
+      expect(log, <Matcher>[
+        isMethodCall(
+          'loadAdLoaderAd',
+          arguments: <String, dynamic>{
+            'adId': 0,
+            'adUnitId': 'test-ad-unit',
+            'request': adLoaderAd.request,
+            'adManagerRequest': null,
+            'banner': banner,
           },
         ),
       ]);
@@ -236,6 +264,205 @@ void main() {
 
       debugDefaultTargetPlatformOverride = TargetPlatform.android;
       await testOnAdFailedToLoad('onAdFailedToLoad', 1);
+    });
+
+    test('onAdOpened event', () async {
+      var testOnAdOpened = (eventName, adId) async {
+        final Completer<Ad> completer = Completer<Ad>();
+
+        final AdLoaderAd ad = AdLoaderAd(
+          adUnitId: 'test-ad-unit',
+          listener: AdLoaderAdListener(
+            onAdOpened: (ad) => completer.complete(ad),
+          ),
+          request: AdRequest(),
+        );
+
+        await ad.load();
+
+        final MethodCall methodCall = MethodCall(
+          'onAdEvent',
+          <dynamic, dynamic>{'adId': adId, 'eventName': eventName},
+        );
+
+        final ByteData data = instanceManager.channel.codec.encodeMethodCall(
+          methodCall,
+        );
+
+        await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .handlePlatformMessage(
+              'plugins.flutter.io/google_mobile_ads',
+              data,
+              (ByteData? data) {},
+            );
+
+        expect(completer.future, completion(ad));
+      };
+
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      await testOnAdOpened('onBannerWillPresentScreen', 0);
+
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      await testOnAdOpened('onAdOpened', 1);
+    });
+
+    test('onAdWillDismissScreen event', () async {
+      var testOnAdWillDismissScreen = (eventName, adId) async {
+        final Completer<Ad> completer = Completer<Ad>();
+
+        final AdLoaderAd ad = AdLoaderAd(
+          adUnitId: 'test-ad-unit',
+          listener: AdLoaderAdListener(
+            onAdWillDismissScreen: (ad) => completer.complete(ad),
+          ),
+          request: AdRequest(),
+        );
+
+        await ad.load();
+
+        final MethodCall methodCall = MethodCall(
+          'onAdEvent',
+          <dynamic, dynamic>{'adId': adId, 'eventName': eventName},
+        );
+
+        final ByteData data = instanceManager.channel.codec.encodeMethodCall(
+          methodCall,
+        );
+
+        await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .handlePlatformMessage(
+              'plugins.flutter.io/google_mobile_ads',
+              data,
+              (ByteData? data) {},
+            );
+
+        expect(completer.future, completion(ad));
+      };
+
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      await testOnAdWillDismissScreen('onBannerWillDismissScreen', 0);
+    });
+
+    test('onAdClosed event', () async {
+      var testOnAdClosed = (eventName, adId) async {
+        final Completer<Ad> completer = Completer<Ad>();
+
+        final AdLoaderAd ad = AdLoaderAd(
+          adUnitId: 'test-ad-unit',
+          listener: AdLoaderAdListener(
+            onAdClosed: (ad) => completer.complete(ad),
+          ),
+          request: AdRequest(),
+        );
+
+        await ad.load();
+
+        final MethodCall methodCall = MethodCall(
+          'onAdEvent',
+          <dynamic, dynamic>{'adId': adId, 'eventName': eventName},
+        );
+
+        final ByteData data = instanceManager.channel.codec.encodeMethodCall(
+          methodCall,
+        );
+
+        await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .handlePlatformMessage(
+              'plugins.flutter.io/google_mobile_ads',
+              data,
+              (ByteData? data) {},
+            );
+
+        expect(completer.future, completion(ad));
+      };
+
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      await testOnAdClosed('onBannerDidDismissScreen', 0);
+
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      await testOnAdClosed('onAdClosed', 1);
+    });
+
+    test('onAdImpression event', () async {
+      var testOnAdImpression = (eventName, adId) async {
+        final Completer<Ad> completer = Completer<Ad>();
+
+        final AdLoaderAd ad = AdLoaderAd(
+          adUnitId: 'test-ad-unit',
+          listener: AdLoaderAdListener(
+            onAdImpression: (ad) => completer.complete(ad),
+          ),
+          request: AdRequest(),
+        );
+
+        await ad.load();
+
+        final MethodCall methodCall = MethodCall(
+          'onAdEvent',
+          <dynamic, dynamic>{'adId': adId, 'eventName': eventName},
+        );
+
+        final ByteData data = instanceManager.channel.codec.encodeMethodCall(
+          methodCall,
+        );
+
+        await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .handlePlatformMessage(
+              'plugins.flutter.io/google_mobile_ads',
+              data,
+              (ByteData? data) {},
+            );
+
+        expect(completer.future, completion(ad));
+      };
+
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      await testOnAdImpression('onBannerImpression', 0);
+
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      await testOnAdImpression('onAdImpression', 1);
+    });
+
+    test('onPaidEvent event', () async {
+      var testOnPaidEvent = (eventName, adId) async {
+        final Completer<Ad> completer = Completer<Ad>();
+
+        final AdLoaderAd ad = AdLoaderAd(
+          adUnitId: 'test-ad-unit',
+          listener: AdLoaderAdListener(
+            onPaidEvent: (ad, micros, precision, currency) =>
+                completer.complete(ad),
+          ),
+          request: AdRequest(),
+        );
+
+        await ad.load();
+
+        final MethodCall methodCall =
+            MethodCall('onAdEvent', <dynamic, dynamic>{
+              'adId': adId,
+              'eventName': eventName,
+              'valueMicros': 0,
+              'precision': 0,
+              'currencyCode': 'AUD',
+            });
+
+        final ByteData data = instanceManager.channel.codec.encodeMethodCall(
+          methodCall,
+        );
+
+        await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .handlePlatformMessage(
+              'plugins.flutter.io/google_mobile_ads',
+              data,
+              (ByteData? data) {},
+            );
+
+        expect(completer.future, completion(ad));
+      };
+
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      await testOnPaidEvent('onPaidEvent', 0);
     });
 
     test('onAdClicked event', () async {

--- a/packages/google_mobile_ads/test/mobile_ads_test.dart
+++ b/packages/google_mobile_ads/test/mobile_ads_test.dart
@@ -717,5 +717,37 @@ void main() {
         expect(result.viewOptions, <String, Object>{'key': 'value'});
       }
     });
+
+    test('encode/decode minimal $NativeParameters', () {
+      for (final platform in [TargetPlatform.android, TargetPlatform.iOS]) {
+        debugDefaultTargetPlatformOverride = platform;
+        ByteData byteData = codec.encodeMessage(
+          NativeParameters(factoryId: 'test-factory-id'),
+        )!;
+
+        NativeParameters result = codec.decodeMessage(byteData);
+        expect(result.factoryId, 'test-factory-id');
+        expect(result.nativeAdOptions, null);
+        expect(result.viewOptions, null);
+      }
+    });
+
+    test('encode/decode $NativeParameters', () {
+      for (final platform in [TargetPlatform.android, TargetPlatform.iOS]) {
+        debugDefaultTargetPlatformOverride = platform;
+        ByteData byteData = codec.encodeMessage(
+          NativeParameters(
+            factoryId: 'test-factory-id',
+            nativeAdOptions: NativeAdOptions(),
+            viewOptions: <String, Object>{'key': 'value'},
+          ),
+        )!;
+
+        NativeParameters result = codec.decodeMessage(byteData);
+        expect(result.factoryId, 'test-factory-id');
+        expect(result.nativeAdOptions, NativeAdOptions());
+        expect(result.viewOptions, <String, Object>{'key': 'value'});
+      }
+    });
   });
 }

--- a/packages/google_mobile_ads/test/mobile_ads_test.dart
+++ b/packages/google_mobile_ads/test/mobile_ads_test.dart
@@ -634,5 +634,59 @@ void main() {
       expect(result.tertiaryTextStyle, templateStyle.tertiaryTextStyle);
       expect(result.mainBackgroundColor, templateStyle.mainBackgroundColor);
     });
+
+    test('encode/decode minimal $AdManagerAdViewOptions', () {
+      for (final platform in [TargetPlatform.android, TargetPlatform.iOS]) {
+        debugDefaultTargetPlatformOverride = platform;
+        ByteData byteData = codec.encodeMessage(AdManagerAdViewOptions())!;
+
+        AdManagerAdViewOptions result = codec.decodeMessage(byteData);
+        expect(result.manualImpressionsEnabled, null);
+      }
+    });
+
+    test('encode/decode $AdManagerAdViewOptions', () {
+      for (final platform in [TargetPlatform.android, TargetPlatform.iOS]) {
+        debugDefaultTargetPlatformOverride = platform;
+        ByteData byteData = codec.encodeMessage(
+          AdManagerAdViewOptions(manualImpressionsEnabled: true),
+        )!;
+
+        AdManagerAdViewOptions result = codec.decodeMessage(byteData);
+        expect(result.manualImpressionsEnabled, true);
+
+        byteData = codec.encodeMessage(
+          AdManagerAdViewOptions(manualImpressionsEnabled: false),
+        )!;
+
+        result = codec.decodeMessage(byteData);
+        expect(result.manualImpressionsEnabled, false);
+
+        byteData = codec.encodeMessage(
+          AdManagerAdViewOptions(manualImpressionsEnabled: null),
+        )!;
+
+        result = codec.decodeMessage(byteData);
+        expect(result.manualImpressionsEnabled, null);
+      }
+    });
+
+    test('encode/decode $BannerParameters', () {
+      for (final platform in [TargetPlatform.android, TargetPlatform.iOS]) {
+        debugDefaultTargetPlatformOverride = platform;
+        ByteData byteData = codec.encodeMessage(
+          BannerParameters(
+            sizes: [AdSize.banner],
+            adManagerAdViewOptions: AdManagerAdViewOptions(
+              manualImpressionsEnabled: true,
+            ),
+          ),
+        )!;
+
+        BannerParameters result = codec.decodeMessage(byteData);
+        expect(result.sizes, [AdSize.banner]);
+        expect(result.adManagerAdViewOptions?.manualImpressionsEnabled, true);
+      }
+    });
   });
 }

--- a/packages/google_mobile_ads/test/mobile_ads_test.dart
+++ b/packages/google_mobile_ads/test/mobile_ads_test.dart
@@ -688,5 +688,34 @@ void main() {
         expect(result.adManagerAdViewOptions?.manualImpressionsEnabled, true);
       }
     });
+
+    test('encode/decode minimal $CustomParameters', () {
+      for (final platform in [TargetPlatform.android, TargetPlatform.iOS]) {
+        debugDefaultTargetPlatformOverride = platform;
+        ByteData byteData = codec.encodeMessage(
+          CustomParameters(formatIds: ['test-format-id']),
+        )!;
+
+        CustomParameters result = codec.decodeMessage(byteData);
+        expect(result.formatIds, ['test-format-id']);
+        expect(result.viewOptions, null);
+      }
+    });
+
+    test('encode/decode $CustomParameters', () {
+      for (final platform in [TargetPlatform.android, TargetPlatform.iOS]) {
+        debugDefaultTargetPlatformOverride = platform;
+        ByteData byteData = codec.encodeMessage(
+          CustomParameters(
+            formatIds: ['test-format-id'],
+            viewOptions: <String, Object>{'key': 'value'},
+          ),
+        )!;
+
+        CustomParameters result = codec.decodeMessage(byteData);
+        expect(result.formatIds, ['test-format-id']);
+        expect(result.viewOptions, <String, Object>{'key': 'value'});
+      }
+    });
   });
 }


### PR DESCRIPTION
## Description

The motivation behind this PR is to allow more elaborate configurations such as the one described [here](https://developers.google.com/ad-manager/mobile-ads-sdk/android/native-banner), where a single `AdLoader` can serve either a `NativeAd` or an `AdManagerAdView`.

To this end, this PR adds a new widget, `AdLoaderAd`, which can configured to serve any of the following platform ad types, all provided by `AdLoader`/`GADAdLoader`:

* `NativeAd`/`GADNativeAd`
* `AdManagerAdView`/`GAMBannerView`
* `NativeCustomFormatAd`/`GADCustomNativeAd`

For the most part the widget and its supporting classes operated independently of the existing widgets. A notable exception is that for the `NativeAd`/`GADNativeAd` and `GAMBannerView` components, the existing supporting classes behind the relevant widgets are used. To allow this, internal APIs are modified as part of:

* Android: Make `FlutterNativeAdLoadedListener` more generally usable
* iOS: Relax constraints on `FLTAdInstanceManager` methods

to allow more general types to be passed to the existing classes. These changes do not cause any incompatibility with existing internal code.

To facilitate testing of the specific ad type under Android, a testing-only constructor has been added as part of:

* Android: Allow passing a `FlutterAdLoader` factory

This is applicable to the `FlutterAdLoaderAd` type but could also be used by other types that expect a `FlutterAdLoader` during building and construction.

## Related Issues

N/A

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
