### PR TITLE
Added dispose call to full screen callbacks

### DIFF
--- a/samples/admob/interstitial_example/lib/main.dart
+++ b/samples/admob/interstitial_example/lib/main.dart
@@ -99,7 +99,9 @@ class InterstitialExampleState extends State<InterstitialExample> {
                 // Called when an impression occurs on the ad.
                 onAdImpression: (ad) {},
                 // Called when the ad failed to show full screen content.
-                onAdFailedToShowFullScreenContent: (ad, err) {},
+                onAdFailedToShowFullScreenContent: (ad, err) {
+                  ad.dispose();
+                },
                 // Called when the ad dismissed full screen content.
                 onAdDismissedFullScreenContent: (ad) {
                   ad.dispose();

--- a/samples/admob/rewarded_example/lib/main.dart
+++ b/samples/admob/rewarded_example/lib/main.dart
@@ -128,7 +128,9 @@ class RewardedExampleState extends State<RewardedExample> {
               // Called when an impression occurs on the ad.
               onAdImpression: (ad) {},
               // Called when the ad failed to show full screen content.
-              onAdFailedToShowFullScreenContent: (ad, err) {},
+              onAdFailedToShowFullScreenContent: (ad, err) {
+                ad.dispose();
+              },
               // Called when the ad dismissed full screen content.
               onAdDismissedFullScreenContent: (ad) {
                 ad.dispose();

--- a/samples/admob/rewarded_interstitial_example/lib/main.dart
+++ b/samples/admob/rewarded_interstitial_example/lib/main.dart
@@ -125,7 +125,9 @@ class RewardedInterstitialExampleState
               // Called when an impression occurs on the ad.
               onAdImpression: (ad) {},
               // Called when the ad failed to show full screen content.
-              onAdFailedToShowFullScreenContent: (ad, err) {},
+              onAdFailedToShowFullScreenContent: (ad, err) {
+                ad.dispose();
+              },
               // Called when the ad dismissed full screen content.
               onAdDismissedFullScreenContent: (ad) {
                 ad.dispose();


### PR DESCRIPTION
## Description

Added `ad.dispose();` to `onAdFailedToShowFullScreenContent` callback to follow the best practices provided by our docs.

Includes:
- Interstitial
- Rewarded
- Rewarded Interstitial

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
