### PR TITLE
Add flag that lets you opt out of visibility detector workaround

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -3,6 +3,9 @@
   * `NativeAd` has a new optional parameter, `nativeTemplateStyle` of type `NativeTemplateStyle`.
     If provided, the plugin will inflate and style a platform native ad view for you, instead of
     requiring you to write and register a NativeAdFactory (android) or FLTNativeAdFactory (iOS).
+* Adds a new flag, AdWidget.optOutOfVisibilityDetectorWorkaround. Setting this to true
+  lets you opt out of the fix added for https://github.com/googleads/googleads-mobile-flutter/issues/580,
+  which was resolved in Flutter 3.7.0.
 
 ## 2.3.0
 * Updates GMA iOS dependency to 9.13

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -618,6 +618,17 @@ abstract class AdWithoutView extends Ad {
 /// Must call `load()` first before showing the widget. Otherwise, a
 /// [PlatformException] will be thrown.
 class AdWidget extends StatefulWidget {
+
+  /// Opt out of the visibility detector workaround.
+  ///
+  /// As a workaround for
+  /// https://github.com/googleads/googleads-mobile-flutter/issues/580,
+  /// we wait for the widget to get displayed once before attaching
+  /// the platform view.
+  ///
+  /// Set this flag to true if you are building with Flutter 3.7.0 or higher.
+  static bool optOutOfVisibilityDetectorWorkaround = false;
+
   /// Default constructor for [AdWidget].
   ///
   /// [ad] must be loaded before this is added to the widget tree.
@@ -684,8 +695,8 @@ class _AdWidgetState extends State<AdWidget> {
       // https://github.com/googleads/googleads-mobile-flutter/issues/580,
       // where impressions are erroneously fired due to how platform views are
       // rendered.
-      // TODO (jjliu15): Remove this after the flutter issue is resolved.
-      if (_firstVisibleOccurred) {
+      if (_firstVisibleOccurred
+          || AdWidget.optOutOfVisibilityDetectorWorkaround) {
         return PlatformViewLink(
           viewType: '${instanceManager.channel.name}/ad_widget',
           surfaceFactory:

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -618,7 +618,6 @@ abstract class AdWithoutView extends Ad {
 /// Must call `load()` first before showing the widget. Otherwise, a
 /// [PlatformException] will be thrown.
 class AdWidget extends StatefulWidget {
-
   /// Opt out of the visibility detector workaround.
   ///
   /// As a workaround for
@@ -695,8 +694,8 @@ class _AdWidgetState extends State<AdWidget> {
       // https://github.com/googleads/googleads-mobile-flutter/issues/580,
       // where impressions are erroneously fired due to how platform views are
       // rendered.
-      if (_firstVisibleOccurred
-          || AdWidget.optOutOfVisibilityDetectorWorkaround) {
+      if (_firstVisibleOccurred ||
+          AdWidget.optOutOfVisibilityDetectorWorkaround) {
         return PlatformViewLink(
           viewType: '${instanceManager.channel.name}/ad_widget',
           surfaceFactory:

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -325,7 +325,7 @@ void main() {
     });
 
     testWidgets('Build ad widget Android, visibility detector workaround on',
-            (WidgetTester tester) async {
+        (WidgetTester tester) async {
       AdWidget.optOutOfVisibilityDetectorWorkaround = false;
       debugDefaultTargetPlatformOverride = TargetPlatform.android;
       // Create a loaded ad
@@ -385,7 +385,7 @@ void main() {
     });
 
     testWidgets('Build ad widget Android, visibility detector opted out',
-      (WidgetTester tester) async {
+        (WidgetTester tester) async {
       AdWidget.optOutOfVisibilityDetectorWorkaround = true;
       debugDefaultTargetPlatformOverride = TargetPlatform.android;
       // Create a loaded ad
@@ -422,7 +422,7 @@ void main() {
 
       // VisibilityRender should not be in the UI
       final visibilityDetectors =
-      tester.widgetList(find.byType(VisibilityDetector));
+          tester.widgetList(find.byType(VisibilityDetector));
       expect(visibilityDetectors.isEmpty, true);
 
       final platformViewLink = tester.widget(find.byType(PlatformViewLink));


### PR DESCRIPTION
## Description

Add a bool flag to AdWidget that lets you opt out of the visibility detector workaround.

## Related Issues

https://github.com/googleads/googleads-mobile-flutter/issues/754

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
