### PR TITLE
Native templates layout fixes

### DIFF
--- a/packages/google_mobile_ads/android/src/main/res/layout/gnt_medium_template_view.xml
+++ b/packages/google_mobile_ads/android/src/main/res/layout/gnt_medium_template_view.xml
@@ -87,7 +87,7 @@
                 android:layout_height="@dimen/gnt_no_size"
                 android:layout_weight="0.5"
                 android:gravity="left"
-                android:background="@color/gnt_white"
+                android:background="@android:color/transparent"
                 app:layout_constraintBottom_toTopOf="@+id/row_two"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
@@ -144,7 +144,7 @@
               </TextView>
               <RatingBar
                   android:id="@+id/rating_bar"
-                  android:background="@color/gnt_white"
+                  android:background="@android:color/transparent"
                   android:layout_width="wrap_content"
                   android:layout_height="wrap_content"
                   android:textSize="@dimen/gnt_text_size_small"

--- a/packages/google_mobile_ads/android/src/main/res/layout/gnt_small_template_view.xml
+++ b/packages/google_mobile_ads/android/src/main/res/layout/gnt_small_template_view.xml
@@ -3,14 +3,14 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android">
   <com.google.android.gms.ads.nativead.NativeAdView
-      android:layout_height="wrap_content"
+      android:layout_height="match_parent"
       android:layout_width="match_parent"
       android:layout_centerInParent="true"
       android:id="@+id/native_ad_view"
       >
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_width="match_parent"
         android:layout_centerInParent="true"
         android:background="@drawable/gnt_outline_shape"
@@ -69,7 +69,7 @@
               app:layout_constraintEnd_toEndOf="parent"
               app:layout_constraintStart_toStartOf="parent"
               app:layout_constraintTop_toTopOf="parent"
-              android:background="@color/gnt_test_background_color"
+              android:background="@android:color/transparent"
               >
 
             <TextView
@@ -121,7 +121,7 @@
             </TextView>
             <RatingBar
                 android:id="@+id/rating_bar"
-                android:background="@color/gnt_white"
+                android:background="@android:color/transparent"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textSize="@dimen/gnt_text_size_small"

--- a/packages/google_mobile_ads/android/src/main/res/layout/medium_template_view_layout.xml
+++ b/packages/google_mobile_ads/android/src/main/res/layout/medium_template_view_layout.xml
@@ -2,7 +2,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="350dp"
+    android:layout_height="wrap_content"
     android:id="@+id/template_medium"
     app:gnt_template_type="@layout/gnt_medium_template_view">
 </com.google.android.ads.nativetemplates.TemplateView>

--- a/packages/google_mobile_ads/android/src/main/res/layout/small_template_view_layout.xml
+++ b/packages/google_mobile_ads/android/src/main/res/layout/small_template_view_layout.xml
@@ -2,7 +2,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="250dp"
+    android:layout_height="wrap_content"
     android:id="@+id/template_small"
     app:gnt_template_type="@layout/gnt_small_template_view">
 </com.google.android.ads.nativetemplates.TemplateView>

--- a/packages/google_mobile_ads/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/google_mobile_ads/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -510,6 +510,7 @@
 		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -564,6 +565,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/packages/google_mobile_ads/example/lib/native_template_example.dart
+++ b/packages/google_mobile_ads/example/lib/native_template_example.dart
@@ -48,8 +48,11 @@ class _NativeTemplateExampleExampleState extends State<NativeTemplateExample> {
             },
             itemBuilder: (BuildContext context, int index) {
               if (index == 5 && _nativeAd != null && _nativeAdIsLoaded) {
-                return Container(
-                    width: 250, height: 600, child: AdWidget(ad: _nativeAd!));
+                return Align(
+                  alignment: Alignment.center,
+                  child: Container(
+                      width: 400, height: 400, child: AdWidget(ad: _nativeAd!)),
+                );
               }
               return Text(
                 Constants.placeholderText,
@@ -65,11 +68,7 @@ class _NativeTemplateExampleExampleState extends State<NativeTemplateExample> {
     super.didChangeDependencies();
     // Create the ad objects and load ads.
     _nativeAd = NativeAd(
-      adUnitId:
-          // '/6499/example/native',
-          Platform.isAndroid
-              ? 'ca-app-pub-3940256099942544/2247696110'
-              : 'ca-app-pub-3940256099942544/3986624511',
+      adUnitId: '/6499/example/native',
       request: AdRequest(),
       listener: NativeAdListener(
         onAdLoaded: (Ad ad) {
@@ -87,30 +86,13 @@ class _NativeTemplateExampleExampleState extends State<NativeTemplateExample> {
       ),
       nativeTemplateStyle: NativeTemplateStyle(
         templateType: TemplateType.medium,
-        mainBackgroundColor: Colors.purple,
+        mainBackgroundColor: Colors.white12,
         callToActionTextStyle: NativeTemplateTextStyle(
-          textColor: Colors.cyan,
-          backgroundColor: Colors.red,
-          style: NativeTemplateFontStyle.monospace,
           size: 16.0,
         ),
         primaryTextStyle: NativeTemplateTextStyle(
-          textColor: Colors.red,
-          backgroundColor: Colors.cyan,
-          style: NativeTemplateFontStyle.italic,
-          size: 16.0,
-        ),
-        secondaryTextStyle: NativeTemplateTextStyle(
-          textColor: Colors.green,
-          backgroundColor: Colors.black,
-          style: NativeTemplateFontStyle.bold,
-          size: 16.0,
-        ),
-        tertiaryTextStyle: NativeTemplateTextStyle(
-          textColor: Colors.brown,
-          backgroundColor: Colors.amber,
-          style: NativeTemplateFontStyle.normal,
-          size: 16.0,
+          textColor: Colors.black38,
+          backgroundColor: Colors.white70,
         ),
       ),
     )..load();

--- a/packages/google_mobile_ads/example/lib/native_template_example.dart
+++ b/packages/google_mobile_ads/example/lib/native_template_example.dart
@@ -14,8 +14,6 @@
 
 // ignore_for_file: public_member_api_docs
 
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'constants.dart';

--- a/packages/google_mobile_ads/ios/Classes/NativeTemplates/FLTNativeTemplateStyle.m
+++ b/packages/google_mobile_ads/ios/Classes/NativeTemplates/FLTNativeTemplateStyle.m
@@ -46,6 +46,8 @@
 - (FLTNativeTemplateViewWrapper *_Nonnull)getDisplayedView:
     (GADNativeAd *_Nonnull)gadNativeAd {
   GADTTemplateView *templateView = _templateType.templateView;
+  templateView.nativeAd = gadNativeAd;
+  
   NSMutableDictionary *styles = [[NSMutableDictionary alloc] init];
   if ([FLTAdUtil isNotNull:_mainBackgroundColor]) {
     styles[GADTNativeTemplateStyleKeyMainBackgroundColor] =
@@ -110,7 +112,6 @@
     }
   }
   templateView.styles = styles;
-  templateView.nativeAd = gadNativeAd;
 
   FLTNativeTemplateViewWrapper *wrapper =
       [[FLTNativeTemplateViewWrapper alloc] initWithFrame:CGRectZero];

--- a/packages/google_mobile_ads/ios/Classes/NativeTemplates/FLTNativeTemplateStyle.m
+++ b/packages/google_mobile_ads/ios/Classes/NativeTemplates/FLTNativeTemplateStyle.m
@@ -47,7 +47,7 @@
     (GADNativeAd *_Nonnull)gadNativeAd {
   GADTTemplateView *templateView = _templateType.templateView;
   templateView.nativeAd = gadNativeAd;
-  
+
   NSMutableDictionary *styles = [[NSMutableDictionary alloc] init];
   if ([FLTAdUtil isNotNull:_mainBackgroundColor]) {
     styles[GADTNativeTemplateStyleKeyMainBackgroundColor] =
@@ -127,7 +127,8 @@
   [super layoutSubviews];
   if (_templateView) {
     [self addSubview:_templateView];
-    // Constrain the top of the templateView to the top of this view. This top aligns the template view
+    // Constrain the top of the templateView to the top of this view. This top
+    // aligns the template view
     if (_templateView.superview) {
       [_templateView.superview
           addConstraint:[NSLayoutConstraint
@@ -139,16 +140,17 @@
                                     multiplier:1
                                       constant:0]];
       [_templateView.superview
-          addConstraint:[NSLayoutConstraint
-                            constraintWithItem:_templateView.superview
-                                     attribute:NSLayoutAttributeBottom
-                                     relatedBy:NSLayoutRelationGreaterThanOrEqual
-                                        toItem:_templateView
-                                     attribute:NSLayoutAttributeBottom
-                                    multiplier:1
-                                      constant:0]];
+          addConstraint:
+              [NSLayoutConstraint
+                  constraintWithItem:_templateView.superview
+                           attribute:NSLayoutAttributeBottom
+                           relatedBy:NSLayoutRelationGreaterThanOrEqual
+                              toItem:_templateView
+                           attribute:NSLayoutAttributeBottom
+                          multiplier:1
+                            constant:0]];
     }
-        [_templateView addHorizontalConstraintsToSuperviewWidth];
+    [_templateView addHorizontalConstraintsToSuperviewWidth];
   }
 }
 

--- a/packages/google_mobile_ads/ios/Classes/NativeTemplates/FLTNativeTemplateStyle.m
+++ b/packages/google_mobile_ads/ios/Classes/NativeTemplates/FLTNativeTemplateStyle.m
@@ -127,8 +127,28 @@
   [super layoutSubviews];
   if (_templateView) {
     [self addSubview:_templateView];
-    [_templateView addVerticalCenterConstraintToSuperview];
-    [_templateView addHorizontalConstraintsToSuperviewWidth];
+    // Constrain the top of the templateView to the top of this view. This top aligns the template view
+    if (_templateView.superview) {
+      [_templateView.superview
+          addConstraint:[NSLayoutConstraint
+                            constraintWithItem:_templateView.superview
+                                     attribute:NSLayoutAttributeTop
+                                     relatedBy:NSLayoutRelationEqual
+                                        toItem:_templateView
+                                     attribute:NSLayoutAttributeTop
+                                    multiplier:1
+                                      constant:0]];
+      [_templateView.superview
+          addConstraint:[NSLayoutConstraint
+                            constraintWithItem:_templateView.superview
+                                     attribute:NSLayoutAttributeBottom
+                                     relatedBy:NSLayoutRelationGreaterThanOrEqual
+                                        toItem:_templateView
+                                     attribute:NSLayoutAttributeBottom
+                                    multiplier:1
+                                      constant:0]];
+    }
+        [_templateView addHorizontalConstraintsToSuperviewWidth];
   }
 }
 

--- a/packages/google_mobile_ads/ios/Classes/NativeTemplates/GoogleAdsMobileIosNativeTemplates/GADTMediumTemplateView.xib
+++ b/packages/google_mobile_ads/ios/Classes/NativeTemplates/GoogleAdsMobileIosNativeTemplates/GADTMediumTemplateView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -108,7 +108,7 @@
                                     </constraints>
                                 </stackView>
                             </subviews>
-                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
                                 <constraint firstAttribute="bottom" secondItem="dtV-H5-CUV" secondAttribute="bottom" id="JTS-sy-ZIx"/>
                                 <constraint firstItem="dtV-H5-CUV" firstAttribute="leading" secondItem="JRU-6T-XIW" secondAttribute="leading" id="KnB-yd-LES"/>

--- a/packages/google_mobile_ads/ios/Classes/NativeTemplates/GoogleAdsMobileIosNativeTemplates/GADTTemplateView.m
+++ b/packages/google_mobile_ads/ios/Classes/NativeTemplates/GoogleAdsMobileIosNativeTemplates/GADTTemplateView.m
@@ -198,12 +198,15 @@ static NSString *const GADTBlue = @"#5C84F0";
     self.backgroundColor = (UIColor *)[self
         styleForKey:GADTNativeTemplateStyleKeyMainBackgroundColor];
   }
+  [self styleAdBadge];
 }
+
 - (void)styleAdBadge {
   UILabel *adBadge = self.adBadge;
   adBadge.layer.borderColor = adBadge.textColor.CGColor;
   adBadge.layer.borderWidth = 1.0;
   adBadge.layer.cornerRadius = 3.0;
+  adBadge.layer.masksToBounds = YES;
 }
 
 - (void)setStyles:


### PR DESCRIPTION
## Description

Fix layout issues in native templates.
* Make background of the view container for the secondary text view transparent instead of white, on android and iOS. Without this there will always be a white background on the container, regardless of whether the publisher overrides the main, primary, secondary background colors
* Set TemplateView.nativeAd before updating the styles on iOS. This fixes an issue where you could see the text on the call to action button change
* Update constraints on iOS so that the template view is top aligned to its container, instead of center

## Related Issues
* b/268343525
* b/268343865
* b/268353721

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.