### PR TITLE
Use xcodebuild for ios unit tests

### DIFF
--- a/.github/workflows/google_mobile_ads.yaml
+++ b/.github/workflows/google_mobile_ads.yaml
@@ -19,6 +19,8 @@ on:
     paths:
       - "packages/google_mobile_ads/**"
       - ".github/workflows/google_mobile_ads.yaml"
+      - "packages/google_mobile_ads/ios/**"
+      - "packages/google_mobile_ads/android/**"
   push:
     branches:
       - master

--- a/.github/workflows/google_mobile_ads.yaml
+++ b/.github/workflows/google_mobile_ads.yaml
@@ -63,9 +63,9 @@ jobs:
         run: ./.github/workflows/scripts/build-example.sh ios ./lib/main.dart
       - name: "Unit Tests"
         run: |
-          cd packages/google_mobile_ads/ios
-          pod lib lint --allow-warnings
-  
+          cd packages/google_mobile_ads/example/ios
+          xcodebuild -configuration Debug VERBOSE_SCRIPT_LOGGING=YES -workspace Runner.xcworkspace -scheme Runner -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14 Pro,OS=16.1' test  
+ 
   flutter:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'

--- a/.github/workflows/google_mobile_ads.yaml
+++ b/.github/workflows/google_mobile_ads.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: "Unit Tests"
         run: |
           cd packages/google_mobile_ads/example/ios
-          xcodebuild -configuration Debug VERBOSE_SCRIPT_LOGGING=YES -workspace Runner.xcworkspace -scheme Runner -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14 Pro,OS=16.1' test  
+          xcodebuild -configuration Debug VERBOSE_SCRIPT_LOGGING=YES -workspace Runner.xcworkspace -scheme Runner -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14 Pro,OS=16.2' test  
  
   flutter:
     runs-on: ubuntu-latest

--- a/packages/google_mobile_ads/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/google_mobile_ads/example/ios/Runner.xcodeproj/project.pbxproj
@@ -27,7 +27,6 @@
 		9E7A912E2825E14C005FD19A /* FLTUserMessagingPlatformReaderWriterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E7A912C2825E14C005FD19A /* FLTUserMessagingPlatformReaderWriterTest.m */; };
 		9E7A912F2825E14C005FD19A /* FLTUserMessagingPlatformManagerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E7A912D2825E14C005FD19A /* FLTUserMessagingPlatformManagerTest.m */; };
 		9E7B9D8F273206F800C6A6AB /* FLTAppStateNotifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E7B9D8E273206F800C6A6AB /* FLTAppStateNotifier.m */; };
-		9EA7213725BB6517008D57E3 /* GoogleMobileAds.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EA7213525BB6464008D57E3 /* GoogleMobileAds.xcframework */; };
 		9EA7474E2637CD6800E0B0E4 /* FLTBannerAdTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EA7474C2637CD6800E0B0E4 /* FLTBannerAdTest.m */; };
 		9EA7474F2637CD6800E0B0E4 /* FLTGAMBannerAdTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EA7474D2637CD6800E0B0E4 /* FLTGAMBannerAdTest.m */; };
 		9EA747532637EC7000E0B0E4 /* FLTGamInterstitialAdTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EA747512637EC7000E0B0E4 /* FLTGamInterstitialAdTest.m */; };
@@ -59,6 +58,7 @@
 		9EF4E70C26392B230007E4FE /* FLTMobileAds_Internal.h in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4E6FF26392B230007E4FE /* FLTMobileAds_Internal.h */; };
 		9EF4E7102639410D0007E4FE /* FLTRewardedAdTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4E70F2639410D0007E4FE /* FLTRewardedAdTest.m */; };
 		9EF4E7142639D4B30007E4FE /* FLTNativeAdTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4E7132639D4B30007E4FE /* FLTNativeAdTest.m */; };
+		9EFEAB4F29B0019F000A063B /* GoogleMobileAds.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EFEAB4E29B0019F000A063B /* GoogleMobileAds.xcframework */; };
 		BEF5C9D9BC96688454A0E3B0 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F14CED182CC13194D568B4C4 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
@@ -169,6 +169,7 @@
 		9EF4E6FF26392B230007E4FE /* FLTMobileAds_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FLTMobileAds_Internal.h; path = ../../ios/Classes/FLTMobileAds_Internal.h; sourceTree = "<group>"; };
 		9EF4E70F2639410D0007E4FE /* FLTRewardedAdTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FLTRewardedAdTest.m; path = ../../../ios/Tests/FLTRewardedAdTest.m; sourceTree = "<group>"; };
 		9EF4E7132639D4B30007E4FE /* FLTNativeAdTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FLTNativeAdTest.m; path = ../../../ios/Tests/FLTNativeAdTest.m; sourceTree = "<group>"; };
+		9EFEAB4E29B0019F000A063B /* GoogleMobileAds.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GoogleMobileAds.xcframework; path = "Pods/Google-Mobile-Ads-SDK/Frameworks/GoogleMobileAdsFramework/GoogleMobileAds.xcframework"; sourceTree = "<group>"; };
 		B4B811D89E676EBD37E2E206 /* libPods-google_mobile_ads_exampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-google_mobile_ads_exampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0B22AB9B287C9F711EAAF48 /* Pods-google_mobile_ads_exampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-google_mobile_ads_exampleTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-google_mobile_ads_exampleTests/Pods-google_mobile_ads_exampleTests.debug.xcconfig"; sourceTree = "<group>"; };
 		CE82265EF05E2A9632B25E60 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
@@ -181,8 +182,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9EFEAB4F29B0019F000A063B /* GoogleMobileAds.xcframework in Frameworks */,
 				9EB9FE59280F86D100DDBB4F /* UserMessagingPlatform.xcframework in Frameworks */,
-				9EA7213725BB6517008D57E3 /* GoogleMobileAds.xcframework in Frameworks */,
 				5C7E63AC163134A326635FC7 /* libPods-google_mobile_ads_exampleTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -212,6 +213,7 @@
 		5B6AAA352BAC85BF7DD68C46 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				9EFEAB4E29B0019F000A063B /* GoogleMobileAds.xcframework */,
 				9EB9FE57280F853D00DDBB4F /* UserMessagingPlatform.xcframework */,
 				9EA7213525BB6464008D57E3 /* GoogleMobileAds.xcframework */,
 				B4B811D89E676EBD37E2E206 /* libPods-google_mobile_ads_exampleTests.a */,


### PR DESCRIPTION
## Description

Update github unit test actions to use `xcodebuild test` instead of `pod lib lint` to run iOS unit tests.
This is necessary as part of supporting the [register webview API,](https://github.com/flutter/plugins/pull/7071), since we need to add `  s.dependency 'webview_flutter_wkwebview'` to our podspec. This only builds in iOS apps that have the flutter podfile macros, and not in `pod lib lint`.

Also fixes the `google_mobile_ads_exampleTests` target in the example xcodeproj so it points to the right xcframework. This lets us run the tests from xcode. For some reason this broke after updating `Google-Mobile-Ads-SDK` past 9.10.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/googleads/googleads-mobile-flutter/issues). Indicate, which of these issues are resolved or fixed by this PR.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

