### PR TITLE
Native template android button size

### DIFF
--- a/packages/google_mobile_ads/android/src/main/res/layout/gnt_medium_template_view.xml
+++ b/packages/google_mobile_ads/android/src/main/res/layout/gnt_medium_template_view.xml
@@ -34,7 +34,7 @@
 
       <androidx.constraintlayout.widget.ConstraintLayout
           android:layout_height="60dp"
-          android:layout_marginTop="@dimen/gnt_default_margin"
+          android:layout_marginTop="@dimen/gnt_small_margin"
           android:layout_width="match_parent"
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintStart_toStartOf="parent"
@@ -202,7 +202,7 @@
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toBottomOf="@id/middle"
           android:paddingStart="@dimen/gnt_default_margin"
-          android:layout_marginBottom="@dimen/gnt_default_margin"
+          android:layout_marginBottom="@dimen/gnt_small_margin"
           />
       <androidx.appcompat.widget.AppCompatButton
           android:id="@+id/cta"
@@ -218,7 +218,8 @@
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toBottomOf="@id/body"
-          />
+          app:layout_constraintHeight_min="35dp"
+      />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
   </com.google.android.gms.ads.nativead.NativeAdView>

--- a/packages/google_mobile_ads/android/src/main/res/layout/gnt_small_template_view.xml
+++ b/packages/google_mobile_ads/android/src/main/res/layout/gnt_small_template_view.xml
@@ -48,8 +48,8 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="@dimen/gnt_no_size"
             android:layout_height="@dimen/gnt_no_size"
-            android:layout_marginTop="@dimen/gnt_default_margin"
-            android:layout_marginBottom="@dimen/gnt_default_margin"
+            android:layout_marginTop="@dimen/gnt_no_margin"
+            android:layout_marginBottom="@dimen/gnt_no_margin"
             android:layout_marginStart="@dimen/gnt_default_margin"
             android:layout_marginEnd="@dimen/gnt_default_margin"
             android:orientation="vertical"
@@ -171,6 +171,8 @@
               app:layout_constraintEnd_toEndOf="parent"
               app:layout_constraintStart_toStartOf="parent"
               app:layout_constraintTop_toBottomOf="@id/row_two"
+              android:gravity="center"
+              app:layout_constraintHeight_percent="0.35"
               />
 
 

--- a/packages/google_mobile_ads/android/src/main/res/values/dimens.xml
+++ b/packages/google_mobile_ads/android/src/main/res/values/dimens.xml
@@ -5,6 +5,7 @@
   <item name="gnt_media_view_weight" format="float" type="dimen">1.0</item>
   <item name="gnt_medium_template_top_weight" format="float" type="dimen">0.2</item>
   <dimen name="gnt_default_margin">10dp</dimen>
+  <dimen name="gnt_small_margin">5dp</dimen>
   <dimen name="gnt_text_size_small">12sp</dimen>
   <dimen name="gnt_text_size_large">15sp</dimen>
   <dimen name="gnt_ad_indicator_width">25dp</dimen>

--- a/packages/google_mobile_ads/example/lib/native_template_example.dart
+++ b/packages/google_mobile_ads/example/lib/native_template_example.dart
@@ -46,11 +46,14 @@ class _NativeTemplateExampleExampleState extends State<NativeTemplateExample> {
             },
             itemBuilder: (BuildContext context, int index) {
               if (index == 5 && _nativeAd != null && _nativeAdIsLoaded) {
-                return Align(
-                  alignment: Alignment.center,
-                  child: Container(
-                      width: 400, height: 400, child: AdWidget(ad: _nativeAd!)),
-                );
+                return Align(alignment: Alignment.center, child:
+                ConstrainedBox(  constraints: const BoxConstraints(
+                  minWidth: 300,
+                  minHeight: 350,
+                  maxHeight: 400,
+                  maxWidth: 450,
+                ),
+                child: AdWidget(ad: _nativeAd!),));
               }
               return Text(
                 Constants.placeholderText,

--- a/packages/google_mobile_ads/example/lib/native_template_example.dart
+++ b/packages/google_mobile_ads/example/lib/native_template_example.dart
@@ -46,14 +46,17 @@ class _NativeTemplateExampleExampleState extends State<NativeTemplateExample> {
             },
             itemBuilder: (BuildContext context, int index) {
               if (index == 5 && _nativeAd != null && _nativeAdIsLoaded) {
-                return Align(alignment: Alignment.center, child:
-                ConstrainedBox(  constraints: const BoxConstraints(
-                  minWidth: 300,
-                  minHeight: 350,
-                  maxHeight: 400,
-                  maxWidth: 450,
-                ),
-                child: AdWidget(ad: _nativeAd!),));
+                return Align(
+                    alignment: Alignment.center,
+                    child: ConstrainedBox(
+                      constraints: const BoxConstraints(
+                        minWidth: 300,
+                        minHeight: 350,
+                        maxHeight: 400,
+                        maxWidth: 450,
+                      ),
+                      child: AdWidget(ad: _nativeAd!),
+                    ));
               }
               return Text(
                 Constants.placeholderText,


### PR DESCRIPTION
## Description

More layout fixes for native templates.
This increases the size of the cta button and decreases margins in the android layouts, making them look more like iOS.

This is just corresponding changes for cl/515451504.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/googleads/googleads-mobile-flutter/issues). Indicate, which of these issues are resolved or fixed by this PR.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
