### PR TITLE
Fix build example in github workflows

### DIFF
--- a/.github/workflows/adaptive_banner_example.yaml
+++ b/.github/workflows/adaptive_banner_example.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
-        run: ./.github/workflows/scripts/build-example.sh android ./lib/main.dart
+        run: ./.github/workflows/scripts/build-example.sh android ./lib/main.dart samples/admob/adaptive_banner_example
   
   iOS:
     runs-on: macos-latest
@@ -57,7 +57,7 @@ jobs:
           ./.github/workflows/scripts/install-tools.sh
           flutter config
       - name: "Build iOS Example"
-        run: ./.github/workflows/scripts/build-example.sh ios ./lib/main.dart
+        run: ./.github/workflows/scripts/build-example.sh ios ./lib/main.dart samples/admob/adaptive_banner_example
   
   flutter:
     runs-on: ubuntu-latest

--- a/.github/workflows/app_open_example.yaml
+++ b/.github/workflows/app_open_example.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
-        run: ./.github/workflows/scripts/build-example.sh android ./lib/main.dart
+        run: ./.github/workflows/scripts/build-example.sh android ./lib/main.dart samples/app_open_example
   
   iOS:
     runs-on: macos-latest
@@ -57,7 +57,7 @@ jobs:
           ./.github/workflows/scripts/install-tools.sh
           flutter config
       - name: "Build iOS Example"
-        run: ./.github/workflows/scripts/build-example.sh ios ./lib/main.dart
+        run: ./.github/workflows/scripts/build-example.sh ios ./lib/main.dart samples/app_open_example
   
   flutter:
     runs-on: ubuntu-latest

--- a/.github/workflows/banner_example.yaml
+++ b/.github/workflows/banner_example.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
-        run: ./.github/workflows/scripts/build-example.sh android ./lib/main.dart
+        run: ./.github/workflows/scripts/build-example.sh android ./lib/main.dart samples/admob/banner_example
   
   iOS:
     runs-on: macos-latest
@@ -57,7 +57,7 @@ jobs:
           ./.github/workflows/scripts/install-tools.sh
           flutter config
       - name: "Build iOS Example"
-        run: ./.github/workflows/scripts/build-example.sh ios ./lib/main.dart
+        run: ./.github/workflows/scripts/build-example.sh ios ./lib/main.dart samples/admob/banner_example
   
   flutter:
     runs-on: ubuntu-latest

--- a/.github/workflows/google_mobile_ads.yaml
+++ b/.github/workflows/google_mobile_ads.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
-        run: ./.github/workflows/scripts/build-example.sh android ./lib/main.dart
+        run: ./.github/workflows/scripts/build-example.sh android ./lib/main.dart packages/google_mobile_ads/example
       - name: "Unit Tests"
         run: |
           cd packages/google_mobile_ads/example/android
@@ -62,7 +62,7 @@ jobs:
         run: |
           ./.github/workflows/scripts/install-tools.sh
       - name: "Build iOS Example"
-        run: ./.github/workflows/scripts/build-example.sh ios ./lib/main.dart
+        run: ./.github/workflows/scripts/build-example.sh ios ./lib/main.dart packages/google_mobile_ads/example
       - name: "Unit Tests"
         run: |
           cd packages/google_mobile_ads/example/ios

--- a/.github/workflows/interstitial_example.yaml
+++ b/.github/workflows/interstitial_example.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
-        run: ./.github/workflows/scripts/build-example.sh android ./lib/main.dart
+        run: ./.github/workflows/scripts/build-example.sh android ./lib/main.dart samples/admob/interstitial_example
   
   iOS:
     runs-on: macos-latest
@@ -57,7 +57,7 @@ jobs:
           ./.github/workflows/scripts/install-tools.sh
           flutter config
       - name: "Build iOS Example"
-        run: ./.github/workflows/scripts/build-example.sh ios ./lib/main.dart
+        run: ./.github/workflows/scripts/build-example.sh ios ./lib/main.dart samples/admob/interstitial_example
   
   flutter:
     runs-on: ubuntu-latest

--- a/.github/workflows/native_platform_example
+++ b/.github/workflows/native_platform_example
@@ -41,7 +41,7 @@ jobs:
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
-        run: ./.github/workflows/scripts/build-example.sh android ./lib/main.dart
+        run: ./.github/workflows/scripts/build-example.sh android ./lib/main.dart samples/admob/native_platform_example
   
   iOS:
     runs-on: macos-latest
@@ -57,7 +57,7 @@ jobs:
           ./.github/workflows/scripts/install-tools.sh
           flutter config
       - name: "Build iOS Example"
-        run: ./.github/workflows/scripts/build-example.sh ios ./lib/main.dart
+        run: ./.github/workflows/scripts/build-example.sh ios ./lib/main.dart samples/admob/native_platform_example
   
   flutter:
     runs-on: ubuntu-latest

--- a/.github/workflows/native_template_example.yaml
+++ b/.github/workflows/native_template_example.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
-        run: ./.github/workflows/scripts/build-example.sh android ./lib/main.dart
+        run: ./.github/workflows/scripts/build-example.sh android ./lib/main.dart samples/admob/native_template_example
   
   iOS:
     runs-on: macos-latest
@@ -57,7 +57,7 @@ jobs:
           ./.github/workflows/scripts/install-tools.sh
           flutter config
       - name: "Build iOS Example"
-        run: ./.github/workflows/scripts/build-example.sh ios ./lib/main.dart
+        run: ./.github/workflows/scripts/build-example.sh ios ./lib/main.dart samples/admob/native_template_example
   
   flutter:
     runs-on: ubuntu-latest

--- a/.github/workflows/rewarded_example.yaml
+++ b/.github/workflows/rewarded_example.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
-        run: ./.github/workflows/scripts/build-example.sh android ./lib/main.dart
+        run: ./.github/workflows/scripts/build-example.sh android ./lib/main.dart samples/admob/rewarded_example
 
   iOS:
     runs-on: macos-latest
@@ -57,7 +57,7 @@ jobs:
           ./.github/workflows/scripts/install-tools.sh
           flutter config
       - name: "Build iOS Example"
-        run: ./.github/workflows/scripts/build-example.sh ios ./lib/main.dart
+        run: ./.github/workflows/scripts/build-example.sh ios ./lib/main.dart samples/admob/rewarded_example
 
   flutter:
     runs-on: ubuntu-latest

--- a/.github/workflows/rewarded_interstitial_example.yaml
+++ b/.github/workflows/rewarded_interstitial_example.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
-        run: ./.github/workflows/scripts/build-example.sh android ./lib/main.dart
+        run: ./.github/workflows/scripts/build-example.sh android ./lib/main.dart samples/admob/rewarded_interstitial_example
 
   iOS:
     runs-on: macos-latest
@@ -57,7 +57,7 @@ jobs:
           ./.github/workflows/scripts/install-tools.sh
           flutter config
       - name: "Build iOS Example"
-        run: ./.github/workflows/scripts/build-example.sh ios ./lib/main.dart
+        run: ./.github/workflows/scripts/build-example.sh ios ./lib/main.dart samples/admob/rewarded_interstitial_example
 
   flutter:
     runs-on: ubuntu-latest

--- a/.github/workflows/scripts/build-example.sh
+++ b/.github/workflows/scripts/build-example.sh
@@ -12,34 +12,21 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-DEFAULT_TARGET="./test_driver/MELOS_PARENT_PACKAGE_NAME_e2e.dart"
+DEFAULT_TARGET="lib/main.dart"
 
 ACTION=$1
 TARGET_FILE=${2:-$DEFAULT_TARGET}
+EXAMPLE_APP_DIRECTORY=$3
 
-melos bootstrap
+cd "$EXAMPLE_APP_DIRECTORY"
 
 if [ "$ACTION" == "android" ]
 then
-  melos exec -c 1 --scope="$GOOGLEMOBILEADS_PLUGIN_SCOPE_EXAMPLE" -- \
-    flutter build apk --debug --target="$TARGET_FILE" --dart-define=CI=true
-  MELOS_EXIT_CODE=$?
-  pkill dart || true
-  pkill java || true
-  pkill -f '.*GradleDaemon.*' || true
-  exit $MELOS_EXIT_CODE
+  flutter build apk --debug --target="$TARGET_FILE" --dart-define=CI=true
 fi
 
 if [ "$ACTION" == "ios" ]
 then
-  melos exec -c 1 --scope="$GOOGLEMOBILEADS_PLUGIN_SCOPE_EXAMPLE" -- \
-    flutter build ios --no-codesign --simulator --debug --target="$TARGET_FILE" --dart-define=CI=true
-  exit
+  flutter build ios --no-codesign --simulator --debug --target="$TARGET_FILE" --dart-define=CI=true
 fi
 
-if [ "$ACTION" == "macos" ]
-then
-  melos exec -c 1 --scope="$GOOGLEMOBILEADS_PLUGIN_SCOPE_EXAMPLE" -- \
-    flutter build macos --debug --target="$TARGET_FILE" --device-id=macos --dart-define=CI=true
-  exit
-fi

--- a/packages/google_mobile_ads/example/android/app/build.gradle
+++ b/packages/google_mobile_ads/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     lintOptions {
         disable 'InvalidPackage'


### PR DESCRIPTION
## Description

Building the example apps has been failing due to a melos error in github actions: https://github.com/googleads/googleads-mobile-flutter/actions/runs/4423396484/jobs/7756094341. Update the script to just run the command directly.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/googleads/googleads-mobile-flutter/issues). Indicate, which of these issues are resolved or fixed by this PR.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
