### PR TITLE
Make `AdInstanceManager.getAdSize` nullable

### DIFF
--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -434,14 +434,13 @@ class AdInstanceManager {
     ))!;
   }
 
-  Future<AdSize> getAdSize(Ad ad) async {
-    return (await instanceManager.channel.invokeMethod<AdSize>(
-      'getAdSize',
-      <dynamic, dynamic>{
-        'adId': adIdFor(ad),
-      },
-    ))!;
-  }
+  Future<AdSize?> getAdSize(Ad ad) =>
+      instanceManager.channel.invokeMethod<AdSize>(
+        'getAdSize',
+        <dynamic, dynamic>{
+          'adId': adIdFor(ad),
+        },
+      );
 
   /// Returns null if an invalid [adId] was passed in.
   Ad? adFor(int adId) => _loadedAds[adId];


### PR DESCRIPTION
## Description

As both the Android and iOS implementations of `getAdSize` are marked as possibly returning a null value (and, in some cases will do so) it is more accurate to mark the corresponding `AdInstanceManager.getAdSize` method as also potentially returning a null value.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
