### PR TITLE
Use top most view controller on iOS

### DIFF
--- a/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
+++ b/packages/google_mobile_ads/ios/Classes/FLTGoogleMobileAdsPlugin.m
@@ -194,7 +194,24 @@
 }
 
 - (UIViewController *)rootController {
-  return UIApplication.sharedApplication.delegate.window.rootViewController;
+  UIViewController *root =
+      UIApplication.sharedApplication.delegate.window.rootViewController;
+  if ([FLTAdUtil isNull:root]) {
+    // UIApplication.sharedApplication.delegate.window is not guaranteed to be
+    // set. Use the keyWindow in this case.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    root = UIApplication.sharedApplication.keyWindow.rootViewController;
+#pragma clang diagnostic pop
+  }
+
+  // Get the presented view controller. This fixes an issue in the add to app
+  // case: https://github.com/googleads/googleads-mobile-flutter/issues/700
+  UIViewController *presentedViewController = root;
+  while (presentedViewController.presentedViewController) {
+    presentedViewController = presentedViewController.presentedViewController;
+  }
+  return presentedViewController;
 }
 
 - (void)handleMethodCall:(FlutterMethodCall *)call


### PR DESCRIPTION
## Description

Fixes an issue in the add to app case for iOS. The rootViewController is presenting another VC which causes GMA to fail to show the interstitial. 
## Related Issues

https://github.com/googleads/googleads-mobile-flutter/issues/700

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.
