### PR TITLE
Update webview example to set 3p cookies on android

### DIFF
--- a/packages/google_mobile_ads/example/lib/webview_example.dart
+++ b/packages/google_mobile_ads/example/lib/webview_example.dart
@@ -48,9 +48,7 @@ class _WebViewExampleState extends State<WebViewExample> {
     await controller.setBackgroundColor(const Color(0x00000000));
     await controller.setNavigationDelegate(
       NavigationDelegate(
-        onProgress: (int progress) {
-          // Update loading bar.
-        },
+        onProgress: (int progress) {},
         onPageStarted: (String url) {},
         onPageFinished: (String url) {},
         onWebResourceError: (WebResourceError error) {},

--- a/packages/google_mobile_ads/example/lib/webview_example.dart
+++ b/packages/google_mobile_ads/example/lib/webview_example.dart
@@ -18,7 +18,6 @@ import 'package:flutter/material.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 import 'package:webview_flutter_android/webview_flutter_android.dart';
-import 'package:webview_flutter_platform_interface/webview_flutter_platform_interface.dart';
 
 /// Opens a WebView and tries to register it via `MobileAds.registerWebView()`.
 class WebViewExample extends StatefulWidget {

--- a/packages/google_mobile_ads/example/lib/webview_example.dart
+++ b/packages/google_mobile_ads/example/lib/webview_example.dart
@@ -17,6 +17,8 @@
 import 'package:flutter/material.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:webview_flutter/webview_flutter.dart';
+import 'package:webview_flutter_android/webview_flutter_android.dart';
+import 'package:webview_flutter_platform_interface/webview_flutter_platform_interface.dart';
 
 /// Opens a WebView and tries to register it via `MobileAds.registerWebView()`.
 class WebViewExample extends StatefulWidget {
@@ -38,27 +40,37 @@ class _WebViewExampleState extends State<WebViewExample> {
   @override
   void initState() {
     super.initState();
+    createWebView();
+  }
 
-    controller = WebViewController()
-      ..setJavaScriptMode(JavaScriptMode.unrestricted)
-      ..setBackgroundColor(const Color(0x00000000))
-      ..setNavigationDelegate(
-        NavigationDelegate(
-          onProgress: (int progress) {
-            // Update loading bar.
-          },
-          onPageStarted: (String url) {},
-          onPageFinished: (String url) {},
-          onWebResourceError: (WebResourceError error) {},
-          onNavigationRequest: (NavigationRequest request) {
-            if (request.url.startsWith('https://www.youtube.com/')) {
-              return NavigationDecision.prevent;
-            }
-            return NavigationDecision.navigate;
-          },
-        ),
-      )
-      ..loadRequest(Uri.parse('https://webview-api-for-ads-test.glitch.me/'));
-    MobileAds.instance.registerWebView(controller);
+  void createWebView() async {
+    controller = WebViewController();
+    await controller.setJavaScriptMode(JavaScriptMode.unrestricted);
+    await controller.setBackgroundColor(const Color(0x00000000));
+    await controller.setNavigationDelegate(
+      NavigationDelegate(
+        onProgress: (int progress) {
+          // Update loading bar.
+        },
+        onPageStarted: (String url) {},
+        onPageFinished: (String url) {},
+        onWebResourceError: (WebResourceError error) {},
+        onNavigationRequest: (NavigationRequest request) {
+          if (request.url.startsWith('https://www.youtube.com/')) {
+            return NavigationDecision.prevent;
+          }
+          return NavigationDecision.navigate;
+        },
+      ),
+    );
+    if (controller.platform is AndroidWebViewController) {
+      AndroidWebViewCookieManager cookieManager = AndroidWebViewCookieManager(
+          PlatformWebViewCookieManagerCreationParams());
+      await cookieManager.setAcceptThirdPartyCookies(
+          controller.platform as AndroidWebViewController, true);
+    }
+    await MobileAds.instance.registerWebView(controller);
+    await controller
+        .loadRequest(Uri.parse('https://webview-api-for-ads-test.glitch.me/'));
   }
 }

--- a/packages/google_mobile_ads/example/pubspec.yaml
+++ b/packages/google_mobile_ads/example/pubspec.yaml
@@ -20,6 +20,8 @@ dependencies:
     sdk: flutter
   google_mobile_ads:
     path: ../
+  webview_flutter_android: ^3.7.0
+  webview_flutter: ^4.0.5
 
 dev_dependencies:
   pedantic: ^1.11.0


### PR DESCRIPTION
Update webview example to use the latest version of webview_flutter_android, which supports enabling 3p cookies

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/googleads/googleads-mobile-flutter/issues). Indicate, which of these issues are resolved or fixed by this PR.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
