### PR TITLE
Fixed Incorrect AdChoicesPlacement int value.

### DIFF
--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -18,24 +18,25 @@
 
 import 'dart:async';
 import 'dart:collection';
+import 'dart:io';
 
-import 'package:google_mobile_ads/src/ad_inspector_containers.dart';
-import 'package:google_mobile_ads/src/ad_listeners.dart';
-import 'package:google_mobile_ads/src/mobile_ads.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:google_mobile_ads/src/ad_inspector_containers.dart';
+import 'package:google_mobile_ads/src/ad_listeners.dart';
+import 'package:google_mobile_ads/src/mobile_ads.dart';
 import 'package:google_mobile_ads/src/nativetemplates/template_type.dart';
 import 'package:google_mobile_ads/src/webview_controller_util.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 import 'package:webview_flutter_android/webview_flutter_android.dart';
 import 'package:webview_flutter_wkwebview/webview_flutter_wkwebview.dart';
 
+import 'ad_containers.dart';
 import 'nativetemplates/native_template_font_style.dart';
 import 'nativetemplates/native_template_style.dart';
 import 'nativetemplates/native_template_text_style.dart';
 import 'request_configuration.dart';
-import 'ad_containers.dart';
 
 /// Loads and disposes [BannerAds] and [InterstitialAds].
 AdInstanceManager instanceManager = AdInstanceManager(
@@ -1316,10 +1317,10 @@ extension AdChoicesPlacementExtension on AdChoicesPlacement {
   /// Gets the int mapping to pass to platform channel.
   int get intValue {
     switch (this) {
-      case AdChoicesPlacement.topLeftCorner:
-        return 0;
       case AdChoicesPlacement.topRightCorner:
-        return 1;
+        return Platform.isAndroid ? 1 : 0;
+      case AdChoicesPlacement.topLeftCorner:
+        return Platform.isAndroid ? 0 : 1;
       case AdChoicesPlacement.bottomRightCorner:
         return 2;
       case AdChoicesPlacement.bottomLeftCorner:
@@ -1331,9 +1332,13 @@ extension AdChoicesPlacementExtension on AdChoicesPlacement {
   static AdChoicesPlacement? fromInt(int? intValue) {
     switch (intValue) {
       case 0:
-        return AdChoicesPlacement.topLeftCorner;
+        return Platform.isAndroid
+            ? AdChoicesPlacement.topLeftCorner
+            : AdChoicesPlacement.topRightCorner;
       case 1:
-        return AdChoicesPlacement.topRightCorner;
+        return Platform.isAndroid
+            ? AdChoicesPlacement.topRightCorner
+            : AdChoicesPlacement.topLeftCorner;
       case 2:
         return AdChoicesPlacement.bottomRightCorner;
       case 3:

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -1316,9 +1316,9 @@ extension AdChoicesPlacementExtension on AdChoicesPlacement {
   /// Gets the int mapping to pass to platform channel.
   int get intValue {
     switch (this) {
-      case AdChoicesPlacement.topRightCorner:
-        return 0;
       case AdChoicesPlacement.topLeftCorner:
+        return 0;
+      case AdChoicesPlacement.topRightCorner:
         return 1;
       case AdChoicesPlacement.bottomRightCorner:
         return 2;
@@ -1331,9 +1331,9 @@ extension AdChoicesPlacementExtension on AdChoicesPlacement {
   static AdChoicesPlacement? fromInt(int? intValue) {
     switch (intValue) {
       case 0:
-        return AdChoicesPlacement.topRightCorner;
-      case 1:
         return AdChoicesPlacement.topLeftCorner;
+      case 1:
+        return AdChoicesPlacement.topRightCorner;
       case 2:
         return AdChoicesPlacement.bottomRightCorner;
       case 3:


### PR DESCRIPTION
## Description

As per the gms ads library [docs](https://developers.google.com/android/reference/com/google/android/gms/ads/nativead/NativeAdOptions#public-static-final-int-adchoices_top_left) the int value for `ADCHOICES_TOP_LEFT` is `0` and `ADCHOICES_TOP_RIGHT` is `1`. It causes the AdChoicesIcon to be in the opposite position in native ads.


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.
