### PR TITLE
Added explicit dependency of UMP 2.1.0

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0
+* Updates GMA iOS dependency to 10.9
+* Adds explicit UMP SDK 2.1.0 dependency for Android.
+
 ## 3.0.0
 * Adds support for `MobileAds.registerWebView()`. This API supports in-app ad monetization for
   `WebView`s. You can read more in the [android](https://developers.google.com/admob/android/webview)

--- a/packages/google_mobile_ads/android/build.gradle
+++ b/packages/google_mobile_ads/android/build.gradle
@@ -32,6 +32,7 @@ android {
     }
     dependencies {
       api 'com.google.android.gms:play-services-ads:22.0.0'
+      implementation 'com.google.android.ump:user-messaging-platform:2.1.0'
       implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
       implementation 'androidx.lifecycle:lifecycle-process:2.2.0'
       implementation 'com.google.errorprone:error_prone_annotations:2.16'

--- a/packages/google_mobile_ads/ios/google_mobile_ads.podspec
+++ b/packages/google_mobile_ads/ios/google_mobile_ads.podspec
@@ -15,7 +15,7 @@ Google Mobile Ads plugin for Flutter.
   s.source_files = 'Classes/**/*.{h,m}'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'Google-Mobile-Ads-SDK','~> 10.4.0'
+  s.dependency 'Google-Mobile-Ads-SDK','~> 10.9.0'
   s.dependency 'webview_flutter_wkwebview'
   s.ios.deployment_target = '10.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS' => 'armv7 arm64 x86_64' }


### PR DESCRIPTION
## Description

- Uses the latest release UMP SDK for android. For iOS, it should be included in Google Mobile Ads SDK 7.64.0 pod and above.

## Related Issues

[Issue 735](https://github.com/googleads/googleads-mobile-flutter/issues/735)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
