### PR TITLE
fix(README): use the correct RewardedAd property name

### DIFF
--- a/samples/admob/rewarded_example/README.md
+++ b/samples/admob/rewarded_example/README.md
@@ -23,7 +23,7 @@ The sample shows how to load a rewarded ad.
 RewardedAd.load(
   adUnitId: _adUnitId,
   request: const AdRequest(),
-  adLoadCallback: RewardedAdLoadCallback(
+  rewardedAdLoadCallback: RewardedAdLoadCallback(
     onAdLoaded: (RewardedAd ad) {
       // Keep a reference to the ad so you can show it later.
       _rewardedAd = ad;


### PR DESCRIPTION
## Description

The property named 'adLoadCallback' of `RewardedAd.load()` shown in the example is outdated, It has been replaced by 'rewardedAdLoadCallback'.


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x ] All existing and new tests are passing.
- [ x] I updated/added relevant documentation (doc comments with `///`).
- [x ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x ] I read and followed the [Flutter Style Guide].
- [x ] I signed the [CLA].
- [x ] I am willing to follow-up on review comments in a timely manner.
