### PR TITLE
Update google_mobile_ads.yaml to use java 17

### DIFF
--- a/.github/workflows/google_mobile_ads.yaml
+++ b/.github/workflows/google_mobile_ads.yaml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin' 
-          java-version: '11'
+          java-version: '17'
       - name: "Install Flutter"
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"

--- a/packages/google_mobile_ads/android/build.gradle
+++ b/packages/google_mobile_ads/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:8.0.1'
     }
 }
 

--- a/packages/google_mobile_ads/android/build.gradle
+++ b/packages/google_mobile_ads/android/build.gradle
@@ -22,6 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    if (project.android.hasProperty('namespace')) {
+        namespace 'io.flutter.plugins.googlemobileads'
+    }
+    
     compileSdkVersion 33
 
     defaultConfig {

--- a/packages/google_mobile_ads/android/build.gradle
+++ b/packages/google_mobile_ads/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.1'
+        classpath 'com.android.tools.build:gradle:8.0.2'
     }
 }
 
@@ -39,13 +39,13 @@ android {
       api 'com.google.android.gms:play-services-ads:22.4.0'
       implementation 'com.google.android.ump:user-messaging-platform:2.1.0'
       implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-      implementation 'androidx.lifecycle:lifecycle-process:2.2.0'
+      implementation 'androidx.lifecycle:lifecycle-process:2.6.2'
       implementation 'com.google.errorprone:error_prone_annotations:2.16'
-      testImplementation 'junit:junit:4.12'
+      testImplementation 'junit:junit:4.13.2'
       testImplementation 'org.hamcrest:hamcrest:2.2'
-      testImplementation 'org.mockito:mockito-inline:3.9.0'
-      testImplementation 'org.robolectric:robolectric:4.4'
-      testImplementation 'androidx.test:core:1.3.0'
+      testImplementation 'org.mockito:mockito-inline:5.2.0'
+      testImplementation 'org.robolectric:robolectric:4.10.3'
+      testImplementation 'androidx.test:core:1.5.0'
 
     }
   testOptions {

--- a/packages/google_mobile_ads/android/build.gradle
+++ b/packages/google_mobile_ads/android/build.gradle
@@ -30,6 +30,7 @@ android {
 
     defaultConfig {
         minSdkVersion 19
+        multiDexEnabled true
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/packages/google_mobile_ads/android/build.gradle
+++ b/packages/google_mobile_ads/android/build.gradle
@@ -35,7 +35,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-      api 'com.google.android.gms:play-services-ads:22.0.0'
+      api 'com.google.android.gms:play-services-ads:22.4.0'
       implementation 'com.google.android.ump:user-messaging-platform:2.1.0'
       implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
       implementation 'androidx.lifecycle:lifecycle-process:2.2.0'

--- a/packages/google_mobile_ads/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/google_mobile_ads/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Aug 06 00:12:49 EDT 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/packages/google_mobile_ads/example/android/app/build.gradle
+++ b/packages/google_mobile_ads/example/android/app/build.gradle
@@ -40,6 +40,7 @@ android {
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        multiDexEnabled true
     }
 
     buildTypes {

--- a/packages/google_mobile_ads/example/android/app/build.gradle
+++ b/packages/google_mobile_ads/example/android/app/build.gradle
@@ -49,8 +49,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 }
 

--- a/packages/google_mobile_ads/example/android/app/build.gradle
+++ b/packages/google_mobile_ads/example/android/app/build.gradle
@@ -27,6 +27,8 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 33
 
+    namespace 'io.flutter.plugins.googlemobileadsexample'
+
     lintOptions {
         disable 'InvalidPackage'
     }

--- a/packages/google_mobile_ads/example/android/build.gradle
+++ b/packages/google_mobile_ads/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:8.0.1'
     }
 }
 

--- a/packages/google_mobile_ads/example/android/build.gradle
+++ b/packages/google_mobile_ads/example/android/build.gradle
@@ -1,3 +1,5 @@
+package example.android
+
 buildscript {
     repositories {
         google()
@@ -24,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/packages/google_mobile_ads/example/android/build.gradle
+++ b/packages/google_mobile_ads/example/android/build.gradle
@@ -1,5 +1,3 @@
-package example.android
-
 buildscript {
     repositories {
         google()

--- a/packages/google_mobile_ads/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/google_mobile_ads/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip


### PR DESCRIPTION
## Description

In preparation for updating the gradle plugin used by the android this PR updates the java version used by the setup-java action to java 17

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
