### PR TITLE
Null check for adId argument.

### DIFF
--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsViewFactory.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsViewFactory.java
@@ -56,6 +56,9 @@ final class GoogleMobileAdsViewFactory extends PlatformViewFactory {
 
   @Override
   public PlatformView create(Context context, int viewId, Object args) {
+    if (args == null) {
+      return getErrorView(context, 0);
+    }
     final Integer adId = (Integer) args;
     FlutterAd ad = manager.adForId(adId);
     if (ad == null || ad.getPlatformView() == null) {

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -418,7 +418,7 @@ class AdSize {
     final num? height = await instanceManager.channel.invokeMethod<num?>(
       'AdSize#getAnchoredAdaptiveBannerAdSize',
       <String, Object?>{
-        'orientation': describeEnum(orientation),
+        'orientation': orientation.name,
         'width': width,
       },
     );

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -1015,8 +1015,7 @@ class AdMessageCodec extends StandardMessageCodec {
         Orientation? orientation;
         if (orientationStr != null) {
           orientation = Orientation.values.firstWhere(
-            (Orientation orientation) =>
-                orientation.name == orientationStr,
+            (Orientation orientation) => orientation.name == orientationStr,
           );
         }
         return AnchoredAdaptiveBannerAdSize(
@@ -1029,8 +1028,7 @@ class AdMessageCodec extends StandardMessageCodec {
             readValueOfType(buffer.getUint8(), buffer);
         return SmartBannerAdSize(
           Orientation.values.firstWhere(
-            (Orientation orientation) =>
-                orientation.name == orientationStr,
+            (Orientation orientation) => orientation.name == orientationStr,
           ),
         );
       case _valueAdSize:

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -923,7 +923,7 @@ class AdMessageCodec extends StandardMessageCodec {
       writeValue(buffer, value.message);
     } else if (value is AdapterInitializationState) {
       buffer.putUint8(_valueInitializationState);
-      writeValue(buffer, describeEnum(value));
+      writeValue(buffer, value.name);
     } else if (value is AdapterStatus) {
       buffer.putUint8(_valueAdapterStatus);
       writeValue(buffer, value.state);
@@ -1016,7 +1016,7 @@ class AdMessageCodec extends StandardMessageCodec {
         if (orientationStr != null) {
           orientation = Orientation.values.firstWhere(
             (Orientation orientation) =>
-                describeEnum(orientation) == orientationStr,
+                orientation.name == orientationStr,
           );
         }
         return AnchoredAdaptiveBannerAdSize(
@@ -1030,7 +1030,7 @@ class AdMessageCodec extends StandardMessageCodec {
         return SmartBannerAdSize(
           Orientation.values.firstWhere(
             (Orientation orientation) =>
-                describeEnum(orientation) == orientationStr,
+                orientation.name == orientationStr,
           ),
         );
       case _valueAdSize:
@@ -1256,14 +1256,14 @@ class AdMessageCodec extends StandardMessageCodec {
       buffer.putUint8(_valueAnchoredAdaptiveBannerAdSize);
       var orientationValue;
       if (value.orientation != null) {
-        orientationValue = describeEnum(value.orientation as Orientation);
+        orientationValue = (value.orientation as Orientation).name;
       }
       writeValue(buffer, orientationValue);
       writeValue(buffer, value.width);
     } else if (value is SmartBannerAdSize) {
       buffer.putUint8(_valueSmartBannerAdSize);
       if (defaultTargetPlatform == TargetPlatform.iOS) {
-        writeValue(buffer, describeEnum(value.orientation));
+        writeValue(buffer, value.orientation.name);
       }
     } else if (value is FluidAdSize) {
       buffer.putUint8(_valueFluidAdSize);

--- a/packages/google_mobile_ads/pubspec.yaml
+++ b/packages/google_mobile_ads/pubspec.yaml
@@ -44,10 +44,9 @@ dev_dependencies:
   build_runner: ^2.1.10
   flutter_test:
     sdk: flutter
-  flutter_plugin_tools: ^0.8.5
   webview_flutter_platform_interface: ^2.1.0
 
 
 environment:
-  sdk: ">=2.14.0 <3.0.0"
+  sdk: ">=2.15.0 <4.0.0"
   flutter: ">=3.7.0"


### PR DESCRIPTION
## Description

To avoid app crashing when the adId is null and therefore impossible to cast into an int value, this PR adds a null check and logs the error as the adId of '0' returning an empty View.

## Related Issues

* Resolves issue #672 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
