### PR TITLE
[Sample] [Adaptive_banner] Using orientationBuilder to detect orientation changes

### DIFF
--- a/samples/admob/adaptive_banner_example/lib/main.dart
+++ b/samples/admob/adaptive_banner_example/lib/main.dart
@@ -44,14 +44,6 @@ class AdaptiveBannerExampleState extends State<AdaptiveBannerExample> {
       ? 'ca-app-pub-3940256099942544/6300978111'
       : 'ca-app-pub-3940256099942544/2934735716';
 
-  // @override
-  // void didChangeDependencies() {
-  //   super.didChangeDependencies();
-  //
-  //   _isLoaded = false;
-  //   _loadAd();
-  // }
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(

--- a/samples/admob/adaptive_banner_example/lib/main.dart
+++ b/samples/admob/adaptive_banner_example/lib/main.dart
@@ -38,43 +38,53 @@ class AdaptiveBannerExample extends StatefulWidget {
 class AdaptiveBannerExampleState extends State<AdaptiveBannerExample> {
   BannerAd? _bannerAd;
   bool _isLoaded = false;
+  Orientation? _currentOrientation;
 
   final String _adUnitId = Platform.isAndroid
       ? 'ca-app-pub-3940256099942544/6300978111'
       : 'ca-app-pub-3940256099942544/2934735716';
 
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-
-    _isLoaded = false;
-    _loadAd();
-  }
+  // @override
+  // void didChangeDependencies() {
+  //   super.didChangeDependencies();
+  //
+  //   _isLoaded = false;
+  //   _loadAd();
+  // }
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Adaptive Banner Example',
-      home: Scaffold(
-          appBar: AppBar(
-            title: const Text('Adaptive Banner Example'),
-          ),
-          body: Stack(
-            children: [
-              if (_bannerAd != null && _isLoaded)
-                Align(
-                  alignment: Alignment.bottomCenter,
-                  child: SafeArea(
-                    child: SizedBox(
-                      width: _bannerAd!.size.width.toDouble(),
-                      height: _bannerAd!.size.height.toDouble(),
-                      child: AdWidget(ad: _bannerAd!),
-                    ),
-                  ),
-                )
-            ],
-          )),
-    );
+        title: 'Adaptive Banner Example',
+        home: Scaffold(
+            appBar: AppBar(
+              title: const Text('Adaptive Banner Example'),
+            ),
+            body: OrientationBuilder(
+              builder: (context, orientation) {
+                if (_currentOrientation != orientation) {
+                  _isLoaded = false;
+                  _loadAd();
+                  _currentOrientation = orientation;
+                }
+
+                return Stack(
+                  children: [
+                    if (_bannerAd != null && _isLoaded)
+                      Align(
+                        alignment: Alignment.bottomCenter,
+                        child: SafeArea(
+                          child: SizedBox(
+                            width: _bannerAd!.size.width.toDouble(),
+                            height: _bannerAd!.size.height.toDouble(),
+                            child: AdWidget(ad: _bannerAd!),
+                          ),
+                        ),
+                      )
+                  ],
+                );
+              },
+            )));
   }
 
   /// Loads and shows a banner ad.


### PR DESCRIPTION
## Description

Updated the sample to not query `didChangeDependencies()` for orientation changes. Now uses `OrientationBuilder`. Allegedly resolves https://github.com/googleads/googleads-mobile-flutter/issues/977 and https://github.com/googleads/googleads-mobile-flutter/issues/982

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
