### PR TITLE
Updated InMobi iOS to 10.7.2.0, google_mobile_ads to 5.1.0 and CHANGELOG

### DIFF
--- a/packages/mediation/gma_mediation_inmobi/CHANGELOG.md
+++ b/packages/mediation/gma_mediation_inmobi/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 1.0.0
+## InMobi Flutter Mediation Adapter Changelog
 
+#### 1.0.0
 * Initial release.
-* Verified compatibility with InMobi Android adapter version 10.6.7.1
-* Verified compatibility with InMobi iOS adapter version 10.7.1.0
+* Verified compatibility with InMobi Android adapter version 10.6.7.1.
+* Verified compatibility with InMobi iOS adapter version 10.7.2.0.
+* Built and tested with the Google Mobile Ads Flutter Plugin version 5.1.0.

--- a/packages/mediation/gma_mediation_inmobi/example/ios/Podfile
+++ b/packages/mediation/gma_mediation_inmobi/example/ios/Podfile
@@ -1,0 +1,44 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '12.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/packages/mediation/gma_mediation_inmobi/ios/gma_mediation_inmobi.podspec
+++ b/packages/mediation/gma_mediation_inmobi/ios/gma_mediation_inmobi.podspec
@@ -16,7 +16,7 @@ Mediation Adapter for InMobi to use with Google Mobile Ads.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'GoogleMobileAdsMediationInMobi', '~> 10.7.1.0'
+  s.dependency 'GoogleMobileAdsMediationInMobi', '~> 10.7.2.0'
   s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/packages/mediation/gma_mediation_inmobi/pubspec.yaml
+++ b/packages/mediation/gma_mediation_inmobi/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_mobile_ads: ^5.0.0
+  google_mobile_ads: ^5.1.0
   plugin_platform_interface: ^2.0.2
 
 dev_dependencies:


### PR DESCRIPTION
## Description

Updated iOS adapter of InMobi and the google_mobile_ads. This is previous to the initial pub.dev release so no need to bump the version.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
