### PR TITLE
DT Echange Adapter | Updated adapter versions.

### DIFF
--- a/packages/mediation/gma_mediation_dtexchange/CHANGELOG.md
+++ b/packages/mediation/gma_mediation_dtexchange/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 1.0.0
+## DT Exchange Flutter Mediation Adapter Changelog
 
+#### 1.0.0
 * Initial release.
-* Verified compatibility with DT Exchange Android adapter version 8.2.6.1
-* Verified compatibility with DT Exchange iOS adapter version 8.2.7.0
+* Verified compatibility with DT Exchange Android adapter version 8.2.7.0.
+* Verified compatibility with DT Exchange iOS adapter version 8.2.8.0.
+* Built and tested with the Google Mobile Ads Flutter Plugin version 5.1.0.

--- a/packages/mediation/gma_mediation_dtexchange/android/build.gradle
+++ b/packages/mediation/gma_mediation_dtexchange/android/build.gradle
@@ -50,7 +50,7 @@ android {
     }
 
     dependencies {
-        implementation 'com.google.ads.mediation:fyber:8.2.6.1'
+        implementation 'com.google.ads.mediation:fyber:8.2.7.0'
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
     }

--- a/packages/mediation/gma_mediation_dtexchange/ios/gma_mediation_dtexchange.podspec
+++ b/packages/mediation/gma_mediation_dtexchange/ios/gma_mediation_dtexchange.podspec
@@ -16,7 +16,7 @@ Mediation Adapter for DT Exchange to use with Google Mobile Ads.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'GoogleMobileAdsMediationFyber', '~> 8.2.7.0'
+  s.dependency 'GoogleMobileAdsMediationFyber', '~> 8.2.8.0'
   s.platform = :ios, '12.0'
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/packages/mediation/gma_mediation_dtexchange/pubspec.yaml
+++ b/packages/mediation/gma_mediation_dtexchange/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_mobile_ads: ^5.0.0
+  google_mobile_ads: ^5.1.0
   plugin_platform_interface: ^2.0.2
 
 dev_dependencies:


### PR DESCRIPTION
## Description

Updates the adapter versions, the google_mobile_ads plugin version and CHANGELOG.
There is no need to version bump the gma_mediation_dtexchange flutter plugin since there has not been an initial release.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
