### PR TITLE
Added Tiramasu support with version check for older versions of getApplicationInfo() API

### DIFF
--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRequestAgentProvider.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRequestAgentProvider.java
@@ -30,7 +30,8 @@ class FlutterRequestAgentProvider {
             context
                 .getApplicationContext()
                 .getPackageManager()
-                .getApplicationInfo(context.getPackageName(),
+                .getApplicationInfo(
+                    context.getPackageName(),
                     PackageManager.ApplicationInfoFlags.of(PackageManager.GET_META_DATA));
       } else {
         info =

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRequestAgentProvider.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRequestAgentProvider.java
@@ -24,11 +24,18 @@ class FlutterRequestAgentProvider {
 
   private void processGameAndNewsTemplateVersions(Context context) {
     try {
-      ApplicationInfo info =
-          context
-              .getApplicationContext()
-              .getPackageManager()
-              .getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+      ApplicationInfo info;
+      if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+        info = context
+            .getApplicationContext()
+            .getPackageManager()
+            .getApplicationInfo(context.getPackageName(), PackageManager.ApplicationInfoFlags.of(PackageManager.GET_META_DATA));
+      } else {
+        info = context
+            .getApplicationContext()
+            .getPackageManager()
+            .getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+      }
       Bundle metaData = info.metaData;
       if (metaData != null) {
         gameTemplateVersion = info.metaData.getString(GAME_VERSION_KEY);

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRequestAgentProvider.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRequestAgentProvider.java
@@ -17,10 +17,8 @@ class FlutterRequestAgentProvider {
   static final String NEWS_VERSION_KEY =
       "io.flutter.plugins.googlemobileads.FLUTTER_NEWS_TEMPLATE_VERSION";
 
-  @Nullable
-  private String newsTemplateVersion;
-  @Nullable
-  private String gameTemplateVersion;
+  @Nullable private String newsTemplateVersion;
+  @Nullable private String gameTemplateVersion;
 
   FlutterRequestAgentProvider(Context context) {
     processGameAndNewsTemplateVersions(context);
@@ -30,16 +28,18 @@ class FlutterRequestAgentProvider {
     try {
       ApplicationInfo info;
       if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
-        info = context
-            .getApplicationContext()
-            .getPackageManager()
-            .getApplicationInfo(context.getPackageName(),
-                PackageManager.ApplicationInfoFlags.of(PackageManager.GET_META_DATA));
+        info =
+            context
+                .getApplicationContext()
+                .getPackageManager()
+                .getApplicationInfo(context.getPackageName(),
+                    PackageManager.ApplicationInfoFlags.of(PackageManager.GET_META_DATA));
       } else {
-        info = context
-            .getApplicationContext()
-            .getPackageManager()
-            .getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+        info =
+            context
+                .getApplicationContext()
+                .getPackageManager()
+                .getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
       }
       Bundle metaData = info.metaData;
       if (metaData != null) {

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRequestAgentProvider.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRequestAgentProvider.java
@@ -7,7 +7,9 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
 
-/** Class that helps detect whether the news or game template is being used. */
+/**
+ * Class that helps detect whether the news or game template is being used.
+ */
 class FlutterRequestAgentProvider {
 
   static final String GAME_VERSION_KEY =
@@ -15,8 +17,10 @@ class FlutterRequestAgentProvider {
   static final String NEWS_VERSION_KEY =
       "io.flutter.plugins.googlemobileads.FLUTTER_NEWS_TEMPLATE_VERSION";
 
-  @Nullable private String newsTemplateVersion;
-  @Nullable private String gameTemplateVersion;
+  @Nullable
+  private String newsTemplateVersion;
+  @Nullable
+  private String gameTemplateVersion;
 
   FlutterRequestAgentProvider(Context context) {
     processGameAndNewsTemplateVersions(context);
@@ -29,7 +33,8 @@ class FlutterRequestAgentProvider {
         info = context
             .getApplicationContext()
             .getPackageManager()
-            .getApplicationInfo(context.getPackageName(), PackageManager.ApplicationInfoFlags.of(PackageManager.GET_META_DATA));
+            .getApplicationInfo(context.getPackageName(),
+                PackageManager.ApplicationInfoFlags.of(PackageManager.GET_META_DATA));
       } else {
         info = context
             .getApplicationContext()

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRequestAgentProvider.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRequestAgentProvider.java
@@ -7,9 +7,7 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
 
-/**
- * Class that helps detect whether the news or game template is being used.
- */
+/** Class that helps detect whether the news or game template is being used. */
 class FlutterRequestAgentProvider {
 
   static final String GAME_VERSION_KEY =

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterRequestAgentProviderTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterRequestAgentProviderTest.java
@@ -14,7 +14,10 @@
 
 package io.flutter.plugins.googlemobileads;
 
+import static android.os.Build.VERSION_CODES.S;
+import static android.os.Build.VERSION_CODES.TIRAMISU;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -29,9 +32,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 /** Tests {@link FlutterRequestAgentProvider}. */
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk = {S, TIRAMISU})
 public class FlutterRequestAgentProviderTest {
 
   private Context mockContext;
@@ -50,12 +55,12 @@ public class FlutterRequestAgentProviderTest {
     doReturn(mockContext).when(mockContext).getApplicationContext();
     doReturn(mockPackageManager).when(mockContext).getPackageManager();
     doReturn(PACKAGE_NAME).when(mockContext).getPackageName();
-    if (Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+    if (Build.VERSION.SDK_INT >= TIRAMISU) {
       doReturn(mockApplicationInfo)
           .when(mockPackageManager)
           .getApplicationInfo(
               eq(PACKAGE_NAME),
-              eq(PackageManager.ApplicationInfoFlags.of(PackageManager.GET_META_DATA)));
+              any());
     } else {
       doReturn(mockApplicationInfo)
           .when(mockPackageManager)

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterRequestAgentProviderTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterRequestAgentProviderTest.java
@@ -50,7 +50,7 @@ public class FlutterRequestAgentProviderTest {
     doReturn(mockContext).when(mockContext).getApplicationContext();
     doReturn(mockPackageManager).when(mockContext).getPackageManager();
     doReturn(PACKAGE_NAME).when(mockContext).getPackageName();
-    if (Build.VERSION.SDK_INT >= 33) {
+    if (Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
       doReturn(mockApplicationInfo)
           .when(mockPackageManager)
           .getApplicationInfo(

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterRequestAgentProviderTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterRequestAgentProviderTest.java
@@ -15,6 +15,7 @@
 package io.flutter.plugins.googlemobileads;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -23,11 +24,13 @@ import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
+import android.os.Build;
 import android.os.Bundle;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 /** Tests {@link FlutterRequestAgentProvider}. */
 @RunWith(RobolectricTestRunner.class)
@@ -49,9 +52,17 @@ public class FlutterRequestAgentProviderTest {
     doReturn(mockContext).when(mockContext).getApplicationContext();
     doReturn(mockPackageManager).when(mockContext).getPackageManager();
     doReturn(PACKAGE_NAME).when(mockContext).getPackageName();
-    doReturn(mockApplicationInfo)
-        .when(mockPackageManager)
-        .getApplicationInfo(eq(PACKAGE_NAME), eq(PackageManager.GET_META_DATA));
+    if (Build.VERSION.SDK_INT >= 33) {
+      doReturn(mockApplicationInfo)
+          .when(mockPackageManager)
+          .getApplicationInfo(
+              eq(PACKAGE_NAME),
+              eq(PackageManager.ApplicationInfoFlags.of(PackageManager.GET_META_DATA)));
+    } else {
+      doReturn(mockApplicationInfo)
+          .when(mockPackageManager)
+          .getApplicationInfo(eq(PACKAGE_NAME), eq(PackageManager.GET_META_DATA));
+    }
   }
 
   @Test

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterRequestAgentProviderTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterRequestAgentProviderTest.java
@@ -15,7 +15,6 @@
 package io.flutter.plugins.googlemobileads;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -30,7 +29,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 /** Tests {@link FlutterRequestAgentProvider}. */
 @RunWith(RobolectricTestRunner.class)

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterRequestAgentProviderTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterRequestAgentProviderTest.java
@@ -58,9 +58,7 @@ public class FlutterRequestAgentProviderTest {
     if (Build.VERSION.SDK_INT >= TIRAMISU) {
       doReturn(mockApplicationInfo)
           .when(mockPackageManager)
-          .getApplicationInfo(
-              eq(PACKAGE_NAME),
-              any());
+          .getApplicationInfo(eq(PACKAGE_NAME), any());
     } else {
       doReturn(mockApplicationInfo)
           .when(mockPackageManager)


### PR DESCRIPTION
## Description

getApplicationInfo(String, Int) is deprecated in API 33. Added check to use more modern API while still supporting <= 33 API versions. 

## Related Issues

### Issues Resolved
- https://github.com/googleads/googleads-mobile-flutter/issues/1089

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
