### PR TITLE
Updated Adapters' iOS Framework to become static libraries

### DIFF
--- a/packages/mediation/gma_mediation_applovin/ios/gma_mediation_applovin.podspec
+++ b/packages/mediation/gma_mediation_applovin/ios/gma_mediation_applovin.podspec
@@ -18,6 +18,7 @@ Mediation Adapter for AppLovin to use with Google Mobile Ads.
   s.dependency 'Flutter'
   s.dependency 'GoogleMobileAdsMediationAppLovin', '~> 12.4.2.0'
   s.platform = :ios, '12.0'
+  s.static_framework = true
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/packages/mediation/gma_mediation_dtexchange/ios/gma_mediation_dtexchange.podspec
+++ b/packages/mediation/gma_mediation_dtexchange/ios/gma_mediation_dtexchange.podspec
@@ -18,6 +18,7 @@ Mediation Adapter for DT Exchange to use with Google Mobile Ads.
   s.dependency 'Flutter'
   s.dependency 'GoogleMobileAdsMediationFyber', '~> 8.2.8.0'
   s.platform = :ios, '12.0'
+  s.static_framework = true
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.swift_version = '5.0'

--- a/packages/mediation/gma_mediation_inmobi/ios/gma_mediation_inmobi.podspec
+++ b/packages/mediation/gma_mediation_inmobi/ios/gma_mediation_inmobi.podspec
@@ -18,6 +18,7 @@ Mediation Adapter for InMobi to use with Google Mobile Ads.
   s.dependency 'Flutter'
   s.dependency 'GoogleMobileAdsMediationInMobi', '~> 10.7.2.0'
   s.platform = :ios, '12.0'
+  s.static_framework = true
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/packages/mediation/gma_mediation_ironsource/ios/gma_mediation_ironsource.podspec
+++ b/packages/mediation/gma_mediation_ironsource/ios/gma_mediation_ironsource.podspec
@@ -18,6 +18,7 @@ Mediation Adapter for ironSource to use with Google Mobile Ads.
   s.dependency 'Flutter'
   s.dependency 'GoogleMobileAdsMediationIronSource', '~>8.0.0.0.0'
   s.platform = :ios, '12.0'
+  s.static_framework = true
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/packages/mediation/gma_mediation_liftoffmonetize/ios/gma_mediation_liftoffmonetize.podspec
+++ b/packages/mediation/gma_mediation_liftoffmonetize/ios/gma_mediation_liftoffmonetize.podspec
@@ -18,6 +18,7 @@ Mediation Adapter for Liftoff Monetize to use with Google Mobile Ads.
   s.dependency 'GoogleMobileAdsMediationVungle', '~>7.3.2.0'
   s.dependency 'Flutter'
   s.platform = :ios, '12.0'
+  s.static_framework = true
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/packages/mediation/gma_mediation_meta/ios/gma_mediation_meta.podspec
+++ b/packages/mediation/gma_mediation_meta/ios/gma_mediation_meta.podspec
@@ -18,6 +18,7 @@ Mediation Adapter for Meta Audience Network to use with Google Mobile Ads.
   s.dependency 'Flutter'
   s.dependency 'GoogleMobileAdsMediationFacebook', '~> 6.15.0'
   s.platform = :ios, '12.0'
+  s.static_framework = true
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/packages/mediation/gma_mediation_mintegral/ios/gma_mediation_mintegral.podspec
+++ b/packages/mediation/gma_mediation_mintegral/ios/gma_mediation_mintegral.podspec
@@ -18,6 +18,7 @@ Mediation Adapter for Mintegral to use with Google Mobile Ads.
   s.dependency 'Flutter'
   s.dependency 'GoogleMobileAdsMediationMintegral', '~>7.6.3.0'
   s.platform = :ios, '12.0'
+  s.static_framework = true
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/packages/mediation/gma_mediation_pangle/ios/gma_mediation_pangle.podspec
+++ b/packages/mediation/gma_mediation_pangle/ios/gma_mediation_pangle.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |s|
   s.dependency 'Flutter'
   s.dependency 'GoogleMobileAdsMediationPangle', '~> 5.9.0.7.0'
   s.platform = :ios, '12.0'
+  s.static_framework = true
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/packages/mediation/gma_mediation_unity/ios/gma_mediation_unity.podspec
+++ b/packages/mediation/gma_mediation_unity/ios/gma_mediation_unity.podspec
@@ -18,6 +18,7 @@ Mediation Adapter for Unity Ads to use with Google Mobile Ads.
   s.dependency 'Flutter'
   s.dependency 'GoogleMobileAdsMediationUnity', '~>4.10.0.0'
   s.platform = :ios, '12.0'
+  s.static_framework = true
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
## Description

For all Mediation Adapters, updated the `podspec` file as static libraries. Future release PRs will be done for each adapter later.

## Related Issues

https://github.com/googleads/googleads-mobile-flutter/issues/1107

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
