### PR TITLE
Updated UI for app open ad to include instructions to see ad

### DIFF
--- a/samples/admob/app_open_example/lib/main.dart
+++ b/samples/admob/app_open_example/lib/main.dart
@@ -95,25 +95,16 @@ class _HomePageState extends State<HomePage> {
         title: const Text('App Open Demo Home Page'),
         actions: _appBarActions(),
       ),
-      body: Center(
+      body: const Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
             Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
+              'Leave and switch back to the app to see the ad.',
             ),
           ],
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 

--- a/samples/admob/app_open_example/lib/main.dart
+++ b/samples/admob/app_open_example/lib/main.dart
@@ -53,7 +53,6 @@ class _HomePageState extends State<HomePage> {
   final _appOpenAdManager = AppOpenAdManager();
   var _isMobileAdsInitializeCalled = false;
   var _isPrivacyOptionsRequired = false;
-  int _counter = 0;
   late AppLifecycleReactor _appLifecycleReactor;
 
   @override
@@ -80,12 +79,6 @@ class _HomePageState extends State<HomePage> {
 
     // This sample attempts to load ads using consent obtained in the previous session.
     _initializeMobileAdsSDK();
-  }
-
-  void _incrementCounter() {
-    setState(() {
-      _counter++;
-    });
   }
 
   @override


### PR DESCRIPTION
## Description

Replaced the default text with instructions to trigger an app open ad.

## Related Issues

https://github.com/googleads/googleads-mobile-flutter/issues/1162

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
