### PR TITLE
MobileAds.init from a Background thread

### DIFF
--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterMobileAdsWrapper.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterMobileAdsWrapper.java
@@ -36,7 +36,14 @@ public class FlutterMobileAdsWrapper {
   /** Initializes the sdk. */
   public void initialize(
       @NonNull Context context, @NonNull OnInitializationCompleteListener listener) {
-    MobileAds.initialize(context, listener);
+    new Thread(
+            new Runnable() {
+              @Override
+              public void run() {
+                MobileAds.initialize(context, listener);
+              }
+            })
+        .start();
   }
 
   /** Wrapper for setAppMuted. */

--- a/samples/admob/mediation_example/ios/Podfile
+++ b/samples/admob/mediation_example/ios/Podfile
@@ -37,4 +37,4 @@ post_install do |installer|
   end
 end
 
-pod 'GoogleMobileAdsMediationAppLovin'
+pod 'GoogleMobileAdsMediationAppLovin', '< 13.0.0.0'

--- a/samples/admob/mediation_example/ios/Runner/AppDelegate.m
+++ b/samples/admob/mediation_example/ios/Runner/AppDelegate.m
@@ -43,7 +43,11 @@
             binaryMessenger:controller.binaryMessenger];
   [methodChannel setMethodCallHandler:^(FlutterMethodCall *call,
                                         FlutterResult result) {
-    if ([call.method isEqualToString:@"setHasUserConsent"]) {
+    if ([call.method isEqualToString:@"setIsAgeRestrictedUser"]) {
+      [ALPrivacySettings
+          setIsAgeRestrictedUser:call.arguments[@"isAgeRestricted"]];
+      result(nil);
+    } else if ([call.method isEqualToString:@"setHasUserConsent"]) {
       [ALPrivacySettings setHasUserConsent:call.arguments[@"hasUserConsent"]];
       result(nil);
     } else {

--- a/samples/admob/mediation_example/ios/Runner/AppDelegate.m
+++ b/samples/admob/mediation_example/ios/Runner/AppDelegate.m
@@ -43,11 +43,7 @@
             binaryMessenger:controller.binaryMessenger];
   [methodChannel setMethodCallHandler:^(FlutterMethodCall *call,
                                         FlutterResult result) {
-    if ([call.method isEqualToString:@"setIsAgeRestrictedUser"]) {
-      [ALPrivacySettings
-          setIsAgeRestrictedUser:call.arguments[@"isAgeRestricted"]];
-      result(nil);
-    } else if ([call.method isEqualToString:@"setHasUserConsent"]) {
+    if ([call.method isEqualToString:@"setHasUserConsent"]) {
       [ALPrivacySettings setHasUserConsent:call.arguments[@"hasUserConsent"]];
       result(nil);
     } else {


### PR DESCRIPTION
## Description

Calling MobileAds init from background thread.

## Related Issues

https://github.com/googleads/googleads-mobile-flutter/issues/1135

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
