### PR TITLE
Ad recycling support for admob banners

### DIFF
--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -900,14 +900,11 @@ class BannerAd extends AdWithView {
     return await instanceManager.getAdSize(this);
   }
 
-  bool isReadyForReuse() {
-    // already loaded ad
+  bool get isMounted {
     final int? id = instanceManager.adIdFor(this);
-
     if (id != null) {
-      return !instanceManager.isWidgetAdIdMounted(id);
+      return instanceManager.isWidgetAdIdMounted(id);
     }
-    // not loaded ad
     return false;
   }
 }

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -900,6 +900,8 @@ class BannerAd extends AdWithView {
     return await instanceManager.getAdSize(this);
   }
 
+  /// Returns if the banner is mounted. A banner is mounted if it
+  /// is currently being used by an AdWidget.
   bool get isMounted {
     final int? id = instanceManager.adIdFor(this);
     if (id != null) {

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -899,6 +899,17 @@ class BannerAd extends AdWithView {
   Future<AdSize?> getPlatformAdSize() async {
     return await instanceManager.getAdSize(this);
   }
+
+  bool isReadyForReuse() {
+    // already loaded ad
+    final int? id = instanceManager.adIdFor(this);
+
+    if (id != null) {
+      return !instanceManager.isWidgetAdIdMounted(id);
+    }
+    // not loaded ad
+    return false;
+  }
 }
 
 /// An 'AdManagerBannerAd' that has fluid ad size.

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -900,8 +900,8 @@ class BannerAd extends AdWithView {
     return await instanceManager.getAdSize(this);
   }
 
-  /// Returns if the banner is mounted. A banner is mounted if it
-  /// is currently being used by an AdWidget.
+  /// Returns true if the ad Id is already mounted in a WidgetAd managed
+  /// by the instanceManager.
   bool get isMounted {
     final int? id = instanceManager.adIdFor(this);
     if (id != null) {

--- a/packages/google_mobile_ads/test/banner_ad_test.dart
+++ b/packages/google_mobile_ads/test/banner_ad_test.dart
@@ -321,5 +321,37 @@ void main() {
       expect(instanceManager.adFor(0), isNull);
       expect(instanceManager.adIdFor(banner), isNull);
     });
+
+    test('not reusable before loaded, and reusable after loaded', () {
+      final BannerAd banner = BannerAd(
+        adUnitId: 'test-ad-unit',
+        size: AdSize.banner,
+        listener: BannerAdListener(),
+        request: AdRequest(),
+      );
+
+      expect(instanceManager.adIdFor(banner), isNull);
+      expect(banner.isReadyForReuse(), isFalse);
+
+      banner.load();
+      final int? adId = instanceManager.adIdFor(banner);
+      expect(adId, isNotNull);
+      expect(banner.isReadyForReuse(), isTrue);
+    });
+
+    test('non-reusable after mounted, and back to reusable after unmounted', () {
+      final BannerAd banner = BannerAd(
+        adUnitId: 'test-ad-unit',
+        size: AdSize.banner,
+        listener: BannerAdListener(),
+        request: AdRequest(),
+      );
+      banner.load();
+      final int? adId = instanceManager.adIdFor(banner);
+      instanceManager.mountWidgetAdId(adId!);
+      expect(banner.isReadyForReuse(), isFalse);
+      instanceManager.unmountWidgetAdId(adId!);
+      expect(banner.isReadyForReuse(), isTrue);
+    });
   });
 }

--- a/packages/google_mobile_ads/test/banner_ad_test.dart
+++ b/packages/google_mobile_ads/test/banner_ad_test.dart
@@ -322,7 +322,7 @@ void main() {
       expect(instanceManager.adIdFor(banner), isNull);
     });
 
-    test('not reusable before loaded, and reusable after loaded', () {
+    test('isMounted returns correct value', () {
       final BannerAd banner = BannerAd(
         adUnitId: 'test-ad-unit',
         size: AdSize.banner,
@@ -331,27 +331,18 @@ void main() {
       );
 
       expect(instanceManager.adIdFor(banner), isNull);
-      expect(banner.isReadyForReuse(), isFalse);
+      expect(banner.isMounted, isFalse);
 
       banner.load();
       final int? adId = instanceManager.adIdFor(banner);
       expect(adId, isNotNull);
-      expect(banner.isReadyForReuse(), isTrue);
-    });
+      expect(banner.isMounted, isFalse);
 
-    test('non-reusable after mounted, and back to reusable after unmounted', () {
-      final BannerAd banner = BannerAd(
-        adUnitId: 'test-ad-unit',
-        size: AdSize.banner,
-        listener: BannerAdListener(),
-        request: AdRequest(),
-      );
-      banner.load();
-      final int? adId = instanceManager.adIdFor(banner);
       instanceManager.mountWidgetAdId(adId!);
-      expect(banner.isReadyForReuse(), isFalse);
+      expect(banner.isMounted, isTrue);
+
       instanceManager.unmountWidgetAdId(adId!);
-      expect(banner.isReadyForReuse(), isTrue);
+      expect(banner.isMounted, isFalse);
     });
   });
 }

--- a/packages/google_mobile_ads/test/banner_ad_test.dart
+++ b/packages/google_mobile_ads/test/banner_ad_test.dart
@@ -341,7 +341,7 @@ void main() {
       instanceManager.mountWidgetAdId(adId!);
       expect(banner.isMounted, isTrue);
 
-      instanceManager.unmountWidgetAdId(adId!);
+      instanceManager.unmountWidgetAdId(adId);
       expect(banner.isMounted, isFalse);
     });
   });


### PR DESCRIPTION
## Description

We hear reports from several customers (e.g. a news app) that a scrollable list with multiple banners has very poor performance. This PR adds a new API to support recycling ad banners. 

Benchmark measuring in progress. Will share when the number is out.  

https://github.com/user-attachments/assets/033546ed-e23c-4148-9f05-9ebaa3432fb8

## How to use

### Original use case (video above)

For a scrolling list with multiple banners on screen. We keep an ivar `_banners` list to cache the banners. Then we just pull a free (unmounted) banner from the cache. 

```

  void main() {
    WidgetsFlutterBinding.ensureInitialized();
    MobileAds.instance.initialize();
    runApp(MyApp());
  }

  class MyAppState extends State<MyApp> {
   
    List<BannerAd> _banners = [];

    AdWidget _getBannerWidget() {
      BannerAd? bannerAd = _banners.firstWhereOrNull((banner) => !banner.isMounted);
      if (bannerAd != null) {
        // No need to create. Found a reusable banner ad
      } else {
        bannerAd = _createBannerAd();
        _banners.add(bannerAd!);
      }
      return AdWidget(ad: bannerAd!);
    }


    BannerAd _createBannerAd() {
      final String bannerId = Platform.isAndroid
        ? 'ca-app-pub-3940256099942544/6300978111'
        : 'ca-app-pub-3940256099942544/2934735716';
      final BannerAd bannerAd = BannerAd(
        adUnitId: bannerId,
        request: const AdRequest(),
        size: AdSize.banner,
        listener: const BannerAdListener(),
      );
      bannerAd.load();
      return bannerAd;
    }

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      theme: ThemeData.light(),
      title: 'Ad Example',
      home: Scaffold(
        appBar: AppBar(title: const Text('Ad Banners')),
        body: ListView.builder(
          itemCount: 250,
          itemBuilder: (BuildContext context, int index) {
            return index.isEven
                ? const SizedBox(height: 150, child: ColoredBox(color: Colors.yellow))
                : SizedBox(width: 320, height: 50, child: _getBannerWidget());
          },
        ),
      ),
    );
```

### LRU Cache

In above example, we always get the "first" free banner in the list: 
```
      BannerAd? bannerAd = _banners.firstWhereOrNull((banner) => !banner.isMounted);
```
But what if we want the "least recently used" banner? (so that users don't see the same banner that they have just seen). 

We can instead define a map `_banners`, to keep track of the time a banner is lastly used.  
```
  Map<BannerAd, DateTime> _banners = {};
```

Then we update `_getBannerWidget()` to sort the banners by time, and update time if needed:  

```
  AdWidget _getBannerWidget() {
    BannerAd? bannerAd = _banners.entries.toList()
        .sortedBy((a) => a.value)
        .map((entry) => entry.key)
        .firstWhereOrNull((banner) => !banner.isMounted);

    if (bannerAd != null) {
        // No need to create. Found a reusable banner ad
    } else {
      bannerAd = _createBannerAd();
    }
    _banners[bannerAd!] = DateTime.now();
    return AdWidget(ad: bannerAd!);
}
```

### Minimum cache size

If the gaps between banners are big, we may end up with just 1 or 2 banners in the cache. 

If we don't want users to see the same banner over and over again, we can have a minimum cache size. In the example below, we have a minimum cache size of 5: 

```
  AdWidget _getBannerWidget() {
    BannerAd? bannerAd = _banners.entries.toList()
        .sortedBy((a) => a.value)
        .map((entry) => entry.key)
        .firstWhereOrNull((banner) => !banner.isMounted);

    if (_banners.entries.length >= 5 && bannerAd != null) {
        // No need to create. Found a reusable banner ad
    } else {
      bannerAd = _createBannerAd();
    }
    _banners[bannerAd!] = DateTime.now();
    return AdWidget(ad: bannerAd!);
}
```


### Stable Rows

If we want the same row to use the same banner, we can use cache list and do `banner_index % cache_size`. 

Here we assume we keep 3 banners in the list: 

```
    List<BannerAd> _banners = [];
...

    BannerAd bannerAd = _banners[bannerIndex % 3];
```

However, if there happens to be more than 3 banners on screen, we can't re-use it anymore. We will have to create a new banner. 

```
if (bannerAd.isMounted) {
  bannerAd = _createBannerAd();
}
```

## Related Issues

Fixes https://github.com/flutter/flutter/issues/158944

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
