### PR TITLE
Remove deprecated API on AdMessageCodec.java

### DIFF
--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
@@ -32,6 +32,7 @@ import io.flutter.plugins.googlemobileads.nativetemplates.FlutterNativeTemplateF
 import io.flutter.plugins.googlemobileads.nativetemplates.FlutterNativeTemplateStyle;
 import io.flutter.plugins.googlemobileads.nativetemplates.FlutterNativeTemplateTextStyle;
 import io.flutter.plugins.googlemobileads.nativetemplates.FlutterNativeTemplateType;
+import java.lang.reflect.InvocationTargetException;
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -71,7 +72,7 @@ class AdMessageCodec extends StandardMessageCodec {
   @NonNull Context context;
   @NonNull final FlutterAdSize.AdSizeFactory adSizeFactory;
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings("deprecation") // Keeping for compatibility
   @Nullable
   private MediationNetworkExtrasProvider mediationNetworkExtrasProvider;
 
@@ -98,7 +99,7 @@ class AdMessageCodec extends StandardMessageCodec {
     this.context = context;
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings("deprecation") // Keeping for compatibility
   void setMediationNetworkExtrasProvider(
       @Nullable MediationNetworkExtrasProvider mediationNetworkExtrasProvider) {
     this.mediationNetworkExtrasProvider = mediationNetworkExtrasProvider;
@@ -307,11 +308,16 @@ class AdMessageCodec extends StandardMessageCodec {
         try {
           assert className != null;
           Class<?> cls = Class.forName(className);
-          FlutterMediationExtras flutterExtras = (FlutterMediationExtras) cls.newInstance();
+          FlutterMediationExtras flutterExtras = (FlutterMediationExtras) cls.getDeclaredConstructor()
+              .newInstance();
           flutterExtras.setMediationExtras(extras);
           return flutterExtras;
         } catch (ClassNotFoundException e) {
           Log.e("FlutterMediationExtras", "Class not found: " + className);
+        } catch (NoSuchMethodException e) {
+          Log.e("FlutterMediationExtras", "No such method found: " + className + ".getDeclaredConstructor()");
+        } catch (InvocationTargetException e) {
+          Log.e("FlutterMediationExtras", "Invocation Target Exception for: " + className);
         } catch (IllegalAccessException e) {
           Log.e("FlutterMediationExtras", "Illegal Access to " + className);
         } catch (InstantiationException e) {

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequest.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdManagerAdRequest.java
@@ -76,7 +76,7 @@ class FlutterAdManagerAdRequest extends FlutterAdRequest {
     }
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings("deprecation") // Keeping for compatibility
   private FlutterAdManagerAdRequest(
       @Nullable List<String> keywords,
       @Nullable String contentUrl,

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdRequest.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterAdRequest.java
@@ -37,7 +37,7 @@ class FlutterAdRequest {
   @Nullable private final Integer httpTimeoutMillis;
   @Nullable private final String mediationExtrasIdentifier;
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings("deprecation") // Keeping for compatibility
   @Nullable
   private final MediationNetworkExtrasProvider mediationNetworkExtrasProvider;
 
@@ -53,7 +53,7 @@ class FlutterAdRequest {
     @Nullable private Integer httpTimeoutMillis;
     @Nullable private String mediationExtrasIdentifier;
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("deprecation") // Keeping for compatibility
     @Nullable
     private MediationNetworkExtrasProvider mediationNetworkExtrasProvider;
 
@@ -105,7 +105,7 @@ class FlutterAdRequest {
     }
 
     @CanIgnoreReturnValue
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("deprecation") // Keeping for compatibility
     Builder setMediationNetworkExtrasProvider(
         @Nullable MediationNetworkExtrasProvider mediationNetworkExtrasProvider) {
       this.mediationNetworkExtrasProvider = mediationNetworkExtrasProvider;
@@ -154,7 +154,7 @@ class FlutterAdRequest {
       return mediationExtrasIdentifier;
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("deprecation") // Keeping for compatibility
     @Nullable
     protected MediationNetworkExtrasProvider getMediationNetworkExtrasProvider() {
       return mediationNetworkExtrasProvider;
@@ -190,7 +190,7 @@ class FlutterAdRequest {
     }
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings("deprecation") // Keeping for compatibility
   protected FlutterAdRequest(
       @Nullable List<String> keywords,
       @Nullable String contentUrl,
@@ -340,7 +340,8 @@ class FlutterAdRequest {
         && Objects.equals(httpTimeoutMillis, request.httpTimeoutMillis)
         && Objects.equals(mediationExtrasIdentifier, request.mediationExtrasIdentifier)
         && Objects.equals(mediationNetworkExtrasProvider, request.mediationNetworkExtrasProvider)
-        && Objects.equals(adMobExtras, request.adMobExtras);
+        && Objects.equals(adMobExtras, request.adMobExtras)
+        && Objects.equals(mediationExtras, request.mediationExtras);
   }
 
   @Override

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterMobileAdsWrapper.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterMobileAdsWrapper.java
@@ -84,9 +84,7 @@ public class FlutterMobileAdsWrapper {
   /** Register the webView for monetization. */
   public void registerWebView(int webViewId, FlutterEngine flutterEngine) {
     WebView webView = WebViewFlutterAndroidExternalApi.getWebView(flutterEngine, webViewId);
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-      Log.w(TAG, "MobileAds.registerWebView does not support API levels less than 21");
-    } else if (webView == null) {
+    if (webView == null) {
       Log.w(TAG, "MobileAds.registerWebView unable to find webView with id: " + webViewId);
     } else {
       MobileAds.registerWebView(webView);

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRequestAgentProvider.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/FlutterRequestAgentProvider.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
+import android.os.Build;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
 
@@ -25,7 +26,7 @@ class FlutterRequestAgentProvider {
   private void processGameAndNewsTemplateVersions(Context context) {
     try {
       ApplicationInfo info;
-      if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         info =
             context
                 .getApplicationContext()

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsPlugin.java
@@ -69,7 +69,7 @@ public class GoogleMobileAdsPlugin implements FlutterPlugin, ActivityAware, Meth
   @Nullable private UserMessagingPlatformManager userMessagingPlatformManager;
   private final Map<String, NativeAdFactory> nativeAdFactories = new HashMap<>();
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings("deprecation") // Keeping for compatibility
   @Nullable
   private MediationNetworkExtrasProvider mediationNetworkExtrasProvider;
 


### PR DESCRIPTION
## Description

Removes deprecate API usage on AdMessageCode java class. Also addresses some lint problems

## Related Issues

* https://github.com/googleads/googleads-mobile-flutter/issues/1242

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
