### PR TITLE
[Sample] Update samples to use google_mobile_ads version 6.0.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,7 +62,9 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: 0  
+          fetch-depth: 0
+      - name: Select Xcode version
+        run: sudo xcode-select -s '/Applications/Xcode_16.2.0.app/Contents/Developer'  
       - name: "Install Flutter"
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"

--- a/samples/admob/app_open_example/android/app/build.gradle
+++ b/samples/admob/app_open_example/android/app/build.gradle
@@ -45,7 +45,7 @@ android {
         applicationId "com.example.app_open_example"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/samples/admob/app_open_example/android/settings.gradle
+++ b/samples/admob/app_open_example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.2.1" apply false
-    id "org.jetbrains.kotlin.android" version "1.9.0" apply false
+    id "com.android.application" version "8.6.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 
 include ":app"

--- a/samples/admob/app_open_example/pubspec.yaml
+++ b/samples/admob/app_open_example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_mobile_ads: ^5.3.1
+  google_mobile_ads: ^6.0.0
 
 dev_dependencies:
   flutter_test:

--- a/samples/admob/banner_example/android/app/build.gradle
+++ b/samples/admob/banner_example/android/app/build.gradle
@@ -45,7 +45,7 @@ android {
         applicationId "com.example.banner_example"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/samples/admob/banner_example/lib/main.dart
+++ b/samples/admob/banner_example/lib/main.dart
@@ -67,8 +67,10 @@ class BannerExampleState extends State<BannerExample> {
         body: OrientationBuilder(
           builder: (context, orientation) {
             if (_currentOrientation != orientation) {
-              _isLoaded = false;
-              _loadAd();
+              if (_currentOrientation != null) {
+                _isLoaded = false;
+                _loadAd();
+              }
               _currentOrientation = orientation;
             }
             return Stack(

--- a/samples/admob/banner_example/pubspec.yaml
+++ b/samples/admob/banner_example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_mobile_ads: ^5.3.1
+  google_mobile_ads: ^6.0.0
 
 dev_dependencies:
   flutter_test:

--- a/samples/admob/interstitial_example/android/app/build.gradle
+++ b/samples/admob/interstitial_example/android/app/build.gradle
@@ -45,7 +45,7 @@ android {
         applicationId "com.example.interstitial_example"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/samples/admob/interstitial_example/android/settings.gradle
+++ b/samples/admob/interstitial_example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.9.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 
 include ":app"

--- a/samples/admob/interstitial_example/pubspec.yaml
+++ b/samples/admob/interstitial_example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_mobile_ads: ^5.3.1
+  google_mobile_ads: ^6.0.0
 
 dev_dependencies:
   flutter_test:

--- a/samples/admob/mediation_example/android/app/build.gradle
+++ b/samples/admob/mediation_example/android/app/build.gradle
@@ -43,7 +43,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.mediationexample"
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/samples/admob/mediation_example/android/settings.gradle
+++ b/samples/admob/mediation_example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.9.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 
 include ":app"

--- a/samples/admob/mediation_example/ios/Podfile
+++ b/samples/admob/mediation_example/ios/Podfile
@@ -37,4 +37,4 @@ post_install do |installer|
   end
 end
 
-pod 'GoogleMobileAdsMediationAppLovin', '< 13.0.0.0'
+pod 'GoogleMobileAdsMediationAppLovin'

--- a/samples/admob/mediation_example/ios/Runner/AppDelegate.m
+++ b/samples/admob/mediation_example/ios/Runner/AppDelegate.m
@@ -43,12 +43,11 @@
             binaryMessenger:controller.binaryMessenger];
   [methodChannel setMethodCallHandler:^(FlutterMethodCall *call,
                                         FlutterResult result) {
-    if ([call.method isEqualToString:@"setIsAgeRestrictedUser"]) {
-      [ALPrivacySettings
-          setIsAgeRestrictedUser:call.arguments[@"isAgeRestricted"]];
-      result(nil);
-    } else if ([call.method isEqualToString:@"setHasUserConsent"]) {
+    if ([call.method isEqualToString:@"setHasUserConsent"]) {
       [ALPrivacySettings setHasUserConsent:call.arguments[@"hasUserConsent"]];
+      result(nil);
+    } else if ([call.method isEqualToString:@"setDoNotSell"]) {
+      [ALPrivacySettings setDoNotSell:call.arguments[@"isDoNotSell"]];
       result(nil);
     } else {
       result(FlutterMethodNotImplemented);

--- a/samples/admob/mediation_example/pubspec.yaml
+++ b/samples/admob/mediation_example/pubspec.yaml
@@ -23,7 +23,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_mobile_ads: ^5.3.1
+  google_mobile_ads: ^6.0.0
 
   # The following adds the Cupertino Icons font to your application.
 

--- a/samples/admob/native_platform_example/android/app/build.gradle
+++ b/samples/admob/native_platform_example/android/app/build.gradle
@@ -45,7 +45,7 @@ android {
         applicationId "com.example.native_platform_example"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion 21
+        minSdkVersion 23
         multiDexEnabled true
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()

--- a/samples/admob/native_platform_example/android/settings.gradle
+++ b/samples/admob/native_platform_example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.9.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 
 include ":app"

--- a/samples/admob/native_platform_example/ios/Runner/AppDelegate.swift
+++ b/samples/admob/native_platform_example/ios/Runner/AppDelegate.swift
@@ -2,13 +2,13 @@ import UIKit
 import Flutter
 
 @objc class NativeAdFactoryExample: NSObject, FLTNativeAdFactory {
-  func createNativeAd(_ nativeAd: GADNativeAd, customOptions: [AnyHashable : Any]? = nil) -> GADNativeAdView? {
+  func createNativeAd(_ nativeAd: NativeAd, customOptions: [AnyHashable : Any]? = nil) -> NativeAdView? {
 
     // Create and place ad in view hierarchy.
     let nativeAdView = Bundle.main.loadNibNamed(
             "NativeAdView",
             owner: nil,
-            options: nil)?.first as! GADNativeAdView
+            options: nil)?.first as! NativeAdView
 
     // Associate the native ad view with the native ad object. This is
     // required to make the ad clickable.

--- a/samples/admob/native_platform_example/pubspec.yaml
+++ b/samples/admob/native_platform_example/pubspec.yaml
@@ -30,7 +30,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_mobile_ads: ^5.3.1
+  google_mobile_ads: ^6.0.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/samples/admob/native_template_example/android/app/build.gradle
+++ b/samples/admob/native_template_example/android/app/build.gradle
@@ -45,7 +45,7 @@ android {
         applicationId "com.example.native_template_example"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion 21
+        minSdkVersion 23
         multiDexEnabled true
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()

--- a/samples/admob/native_template_example/android/settings.gradle
+++ b/samples/admob/native_template_example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.9.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 
 include ":app"

--- a/samples/admob/native_template_example/pubspec.yaml
+++ b/samples/admob/native_template_example/pubspec.yaml
@@ -30,7 +30,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_mobile_ads: ^5.3.1
+  google_mobile_ads: ^6.0.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/samples/admob/rewarded_example/android/app/build.gradle
+++ b/samples/admob/rewarded_example/android/app/build.gradle
@@ -45,7 +45,7 @@ android {
         applicationId "com.example.rewarded_example"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion 21
+        minSdkVersion 23
         multiDexEnabled true
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()

--- a/samples/admob/rewarded_example/android/settings.gradle
+++ b/samples/admob/rewarded_example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.9.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 
 include ":app"

--- a/samples/admob/rewarded_example/pubspec.yaml
+++ b/samples/admob/rewarded_example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_mobile_ads: ^5.3.1
+  google_mobile_ads: ^6.0.0
 
 dev_dependencies:
   flutter_test:

--- a/samples/admob/rewarded_interstitial_example/android/app/build.gradle
+++ b/samples/admob/rewarded_interstitial_example/android/app/build.gradle
@@ -45,7 +45,7 @@ android {
         applicationId "com.example.rewarded_interstitial_example"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion 21
+        minSdkVersion 23
         multiDexEnabled true
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()

--- a/samples/admob/rewarded_interstitial_example/android/settings.gradle
+++ b/samples/admob/rewarded_interstitial_example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.9.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 
 include ":app"

--- a/samples/admob/rewarded_interstitial_example/pubspec.yaml
+++ b/samples/admob/rewarded_interstitial_example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_mobile_ads: ^5.3.1
+  google_mobile_ads: ^6.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description

- Update samples to use `6.0.0`.
- Fixed a bug in `banner_example` that would duplicate ad requests on first ad load. 
- Updated `native_platform_example` to use GMA iOS v12 Swift APIs.
- Replaced outdated API in `mediation_example` for AppLovin.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
