### PR TITLE
Removed swift setup on Workflows which seem not needed anymore

### DIFF
--- a/.github/workflows/gma_mediation_applovin.yaml
+++ b/.github/workflows/gma_mediation_applovin.yaml
@@ -53,9 +53,6 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 40
     steps:
-      - uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: "5.7.2"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0

--- a/.github/workflows/gma_mediation_dtexchange.yaml
+++ b/.github/workflows/gma_mediation_dtexchange.yaml
@@ -53,9 +53,6 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 40
     steps:
-      - uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: "6.0.0"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0

--- a/.github/workflows/gma_mediation_ironsource.yaml
+++ b/.github/workflows/gma_mediation_ironsource.yaml
@@ -52,9 +52,6 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 40
     steps:
-      - uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: "6.0.0"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0

--- a/.github/workflows/gma_mediation_liftoffmonetize.yaml
+++ b/.github/workflows/gma_mediation_liftoffmonetize.yaml
@@ -53,9 +53,6 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 40
     steps:
-      - uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: "5.7.2"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0

--- a/.github/workflows/gma_mediation_unity.yaml
+++ b/.github/workflows/gma_mediation_unity.yaml
@@ -53,9 +53,6 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 40
     steps:
-      - uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: "6.0.0"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0

--- a/.github/workflows/google_mobile_ads.yaml
+++ b/.github/workflows/google_mobile_ads.yaml
@@ -56,9 +56,6 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 40
     steps:
-      - uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: "6.0.0"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Description

When you build an iOS app, you are supposed to use the Swift compiler that is specifically bundled inside Xcode.

The `swift-actions/setup-swift` action is setting environment variables which effectively hijacked Xcode, forcing xcodebuild to use a generic, standalone Swift compiler instead of Xcode's custom-tuned iOS Swift compiler.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
