### PR TITLE
Fixes Native Ads template for iOS | Increases minimum Flutter version

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Adds `isCollapsible` API. [FR 1294](https://github.com/googleads/googleads-mobile-flutter/issues/1294)
 * Renamed method name to avoid possible name collision. [FR 1394](https://github.com/googleads/googleads-mobile-flutter/issues/1394)
 * Migrated to use UISceneDelegate protocol. [Issue 1391](https://github.com/googleads/googleads-mobile-flutter/issues/1391)
+* New to Anchored adaptive banner ads:
+  * The following APIs have been deprecated for their replacement:
+    * The `getCurrentOrientationAnchoredAdaptiveBannerAdSize` function is deprecated. Instead, use the `getLargeAnchoredAdaptiveBannerAdSize` function.
+    * The `getAnchoredAdaptiveBannerAdSize` function is deprecated. Instead, use the `getLargeAnchoredAdaptiveBannerAdSizeWithOrientation` function.
 * Updates GMA [Android](https://developers.google.com/admob/android/rel-notes) dependency to 25.1.0
 * Updates GMA [iOS](https://developers.google.com/admob/ios/rel-notes) dependency to 13.2.0
 * Uses latest UMP SDK:

--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 8.0.0
+* Updates minimum Flutter SDK to 3.38.1
+* Updates Dart SDK low bound to 3.10.0.
 * Adds Swift Package Manager Support for the plugin. [PR 1395](https://github.com/googleads/googleads-mobile-flutter/pull/1395)
 * Adds `isCollapsible` API. [FR 1294](https://github.com/googleads/googleads-mobile-flutter/issues/1294)
 * Renamed method name to avoid possible name collision. [FR 1394](https://github.com/googleads/googleads-mobile-flutter/issues/1394)

--- a/packages/google_mobile_ads/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/google_mobile_ads/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/NativeTemplates/FLTNativeTemplateType.m
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/NativeTemplates/FLTNativeTemplateType.m
@@ -14,6 +14,10 @@
 
 #import "FLTNativeTemplateType.h"
 
+#ifndef SWIFTPM_MODULE_BUNDLE
+    #define SWIFTPM_MODULE_BUNDLE [NSBundle bundleForClass:[FLTGoogleMobileAdsPlugin class]]
+#endif
+
 @implementation FLTNativeTemplateType {
   int _intValue;
 }
@@ -39,12 +43,26 @@
 }
 
 - (GADTTemplateView *_Nonnull)templateView {
-  // Bundle file name is declared in podspec
-  id bundleURL = [NSBundle.mainBundle URLForResource:@"google_mobile_ads"
-                                       withExtension:@"bundle"];
-  NSBundle *bundle = [NSBundle bundleWithURL:bundleURL];
+  // Bundle file name is declared in Package.swift or podspec
+  NSBundle *adsBundle = nil;
+
+  NSURL *bundleURL = [[NSBundle mainBundle] URLForResource:@"google_mobile_ads"
+                                             withExtension:@"bundle"];
+  if (bundleURL) {
+    adsBundle = [NSBundle bundleWithURL:bundleURL];
+  } else {
+    #ifdef SWIFTPM_MODULE_BUNDLE
+      adsBundle = SWIFTPM_MODULE_BUNDLE;
+    #else
+      adsBundle = [NSBundle bundleForClass:[self class]];
+    #endif
+  }
+  if (!adsBundle) {
+    adsBundle = [NSBundle mainBundle];
+  }
+
   GADTTemplateView *templateView =
-      [bundle loadNibNamed:self.xibName owner:nil options:nil].firstObject;
+    [adsBundle loadNibNamed:self.xibName owner:nil options:nil].firstObject;
   return templateView;
 }
 

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/NativeTemplates/FLTNativeTemplateType.m
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/NativeTemplates/FLTNativeTemplateType.m
@@ -15,7 +15,7 @@
 #import "FLTNativeTemplateType.h"
 
 #ifndef SWIFTPM_MODULE_BUNDLE
-    #define SWIFTPM_MODULE_BUNDLE [NSBundle bundleForClass:[FLTGoogleMobileAdsPlugin class]]
+    #define SWIFTPM_MODULE_BUNDLE [NSBundle bundleForClass:[self class]]
 #endif
 
 @implementation FLTNativeTemplateType {

--- a/packages/google_mobile_ads/pubspec.yaml
+++ b/packages/google_mobile_ads/pubspec.yaml
@@ -48,5 +48,5 @@ dev_dependencies:
 
 
 environment:
-  sdk: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.1"
+  sdk: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.1"


### PR DESCRIPTION
## Description

* Updates minimum Flutter SDK to 3.38.1
* Updates Dart SDK low bound to 3.10.0.
* Fixes native ads templates which required Resources not taken from the Package.swift file

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
