### PR TITLE
Added UIScene support to samples

### DIFF
--- a/samples/admob/app_open_example/ios/Runner/AppDelegate.swift
+++ b/samples/admob/app_open_example/ios/Runner/AppDelegate.swift
@@ -16,12 +16,15 @@ import UIKit
 import Flutter
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/samples/admob/app_open_example/ios/Runner/Info.plist
+++ b/samples/admob/app_open_example/ios/Runner/Info.plist
@@ -28,6 +28,27 @@
 		<string>LaunchScreen</string>
 		<key>UIMainStoryboardFile</key>
 		<string>Main</string>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+     <key>UIApplicationSupportsMultipleScenes</key>
+     <false/>
+     <key>UISceneConfigurations</key>
+     <dict>
+     <key>UIWindowSceneSessionRoleApplication</key>
+       <array>
+         <dict>
+           <key>UISceneClassName</key>
+           <string>UIWindowScene</string>
+           <key>UISceneDelegateClassName</key>
+           <string>FlutterSceneDelegate</string>
+           <key>UISceneConfigurationName</key>
+           <string>flutter</string>
+           <key>UISceneStoryboardFile</key>
+           <string>Main</string>
+         </dict>
+       </array>
+      </dict>
+    </dict>
 		<key>UISupportedInterfaceOrientations</key>
 		<array>
 			<string>UIInterfaceOrientationPortrait</string>

--- a/samples/admob/banner_example/ios/Runner/AppDelegate.swift
+++ b/samples/admob/banner_example/ios/Runner/AppDelegate.swift
@@ -1,13 +1,30 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import UIKit
 import Flutter
 
-@UIApplicationMain
-@objc class AppDelegate: FlutterAppDelegate {
+@main
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/samples/admob/banner_example/ios/Runner/Info.plist
+++ b/samples/admob/banner_example/ios/Runner/Info.plist
@@ -28,6 +28,27 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
+	<key>UIApplicationSceneManifest</key>
+      <dict>
+       <key>UIApplicationSupportsMultipleScenes</key>
+       <false/>
+       <key>UISceneConfigurations</key>
+       <dict>
+       <key>UIWindowSceneSessionRoleApplication</key>
+         <array>
+           <dict>
+             <key>UISceneClassName</key>
+             <string>UIWindowScene</string>
+             <key>UISceneDelegateClassName</key>
+             <string>FlutterSceneDelegate</string>
+             <key>UISceneConfigurationName</key>
+             <string>flutter</string>
+             <key>UISceneStoryboardFile</key>
+             <string>Main</string>
+           </dict>
+         </array>
+        </dict>
+      </dict>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/samples/admob/interstitial_example/ios/Runner/AppDelegate.swift
+++ b/samples/admob/interstitial_example/ios/Runner/AppDelegate.swift
@@ -1,13 +1,30 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import UIKit
 import Flutter
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/samples/admob/interstitial_example/ios/Runner/Info.plist
+++ b/samples/admob/interstitial_example/ios/Runner/Info.plist
@@ -28,6 +28,27 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
+	   <key>UIApplicationSceneManifest</key>
+      <dict>
+       <key>UIApplicationSupportsMultipleScenes</key>
+       <false/>
+       <key>UISceneConfigurations</key>
+       <dict>
+       <key>UIWindowSceneSessionRoleApplication</key>
+         <array>
+           <dict>
+             <key>UISceneClassName</key>
+             <string>UIWindowScene</string>
+             <key>UISceneDelegateClassName</key>
+             <string>FlutterSceneDelegate</string>
+             <key>UISceneConfigurationName</key>
+             <string>flutter</string>
+             <key>UISceneStoryboardFile</key>
+             <string>Main</string>
+           </dict>
+         </array>
+        </dict>
+      </dict>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/samples/admob/native_platform_example/ios/Runner/AppDelegate.swift
+++ b/samples/admob/native_platform_example/ios/Runner/AppDelegate.swift
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import UIKit
 import Flutter
 

--- a/samples/admob/native_platform_example/ios/Runner/AppDelegate.swift
+++ b/samples/admob/native_platform_example/ios/Runner/AppDelegate.swift
@@ -61,15 +61,22 @@ import Flutter
 }
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
-
-    FLTGoogleMobileAdsPlugin.registerNativeAdFactory(self, factoryId: "adFactoryExample", nativeAdFactory: NativeAdFactoryExample())
-
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+
+    FLTGoogleMobileAdsPlugin.registerNativeAdFactory(
+      engineBridge.pluginRegistry,
+      factoryId: "adFactoryExample",
+      nativeAdFactory: NativeAdFactoryExample()
+    )
+  }
 }
+

--- a/samples/admob/native_platform_example/ios/Runner/Info.plist
+++ b/samples/admob/native_platform_example/ios/Runner/Info.plist
@@ -30,6 +30,27 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
+	<key>UIApplicationSceneManifest</key>
+      <dict>
+       <key>UIApplicationSupportsMultipleScenes</key>
+       <false/>
+       <key>UISceneConfigurations</key>
+       <dict>
+       <key>UIWindowSceneSessionRoleApplication</key>
+         <array>
+           <dict>
+             <key>UISceneClassName</key>
+             <string>UIWindowScene</string>
+             <key>UISceneDelegateClassName</key>
+             <string>FlutterSceneDelegate</string>
+             <key>UISceneConfigurationName</key>
+             <string>flutter</string>
+             <key>UISceneStoryboardFile</key>
+             <string>Main</string>
+           </dict>
+         </array>
+        </dict>
+      </dict>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/samples/admob/native_template_example/ios/Runner/AppDelegate.swift
+++ b/samples/admob/native_template_example/ios/Runner/AppDelegate.swift
@@ -1,13 +1,30 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import UIKit
 import Flutter
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/samples/admob/native_template_example/ios/Runner/Info.plist
+++ b/samples/admob/native_template_example/ios/Runner/Info.plist
@@ -34,6 +34,27 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
+	<key>UIApplicationSceneManifest</key>
+      <dict>
+       <key>UIApplicationSupportsMultipleScenes</key>
+       <false/>
+       <key>UISceneConfigurations</key>
+       <dict>
+       <key>UIWindowSceneSessionRoleApplication</key>
+         <array>
+           <dict>
+             <key>UISceneClassName</key>
+             <string>UIWindowScene</string>
+             <key>UISceneDelegateClassName</key>
+             <string>FlutterSceneDelegate</string>
+             <key>UISceneConfigurationName</key>
+             <string>flutter</string>
+             <key>UISceneStoryboardFile</key>
+             <string>Main</string>
+           </dict>
+         </array>
+        </dict>
+      </dict>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/samples/admob/rewarded_example/ios/Runner/AppDelegate.swift
+++ b/samples/admob/rewarded_example/ios/Runner/AppDelegate.swift
@@ -1,13 +1,30 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import UIKit
 import Flutter
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/samples/admob/rewarded_example/ios/Runner/Info.plist
+++ b/samples/admob/rewarded_example/ios/Runner/Info.plist
@@ -28,6 +28,27 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
+	 <key>UIApplicationSceneManifest</key>
+      <dict>
+       <key>UIApplicationSupportsMultipleScenes</key>
+       <false/>
+       <key>UISceneConfigurations</key>
+       <dict>
+       <key>UIWindowSceneSessionRoleApplication</key>
+         <array>
+           <dict>
+             <key>UISceneClassName</key>
+             <string>UIWindowScene</string>
+             <key>UISceneDelegateClassName</key>
+             <string>FlutterSceneDelegate</string>
+             <key>UISceneConfigurationName</key>
+             <string>flutter</string>
+             <key>UISceneStoryboardFile</key>
+             <string>Main</string>
+           </dict>
+         </array>
+        </dict>
+      </dict>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/samples/admob/rewarded_interstitial_example/ios/Runner/AppDelegate.swift
+++ b/samples/admob/rewarded_interstitial_example/ios/Runner/AppDelegate.swift
@@ -1,13 +1,30 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import UIKit
 import Flutter
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/samples/admob/rewarded_interstitial_example/ios/Runner/Info.plist
+++ b/samples/admob/rewarded_interstitial_example/ios/Runner/Info.plist
@@ -28,6 +28,27 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
+  <key>UIApplicationSceneManifest</key>
+      <dict>
+       <key>UIApplicationSupportsMultipleScenes</key>
+       <false/>
+       <key>UISceneConfigurations</key>
+       <dict>
+       <key>UIWindowSceneSessionRoleApplication</key>
+         <array>
+           <dict>
+             <key>UISceneClassName</key>
+             <string>UIWindowScene</string>
+             <key>UISceneDelegateClassName</key>
+             <string>FlutterSceneDelegate</string>
+             <key>UISceneConfigurationName</key>
+             <string>flutter</string>
+             <key>UISceneStoryboardFile</key>
+             <string>Main</string>
+           </dict>
+         </array>
+        </dict>
+      </dict>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
## Description

Migrated to UIScene support https://docs.flutter.dev/release/breaking-changes/uiscenedelegate to modernize latest iOS application lifecycle management

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
