### PR TITLE
GMA SDK plugin major version bump to 9.0.0

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 9.0.0
+* Resolves pending start/stop method channel futures in AppStateNotifier Android. [PR 1438](https://github.com/googleads/googleads-mobile-flutter/pull/1438)
+* Updates GMA Android SDK dependencies:
+  * [Google Mobile Ads](https://developers.google.com/admob/android/quick-start) SDK version `25.3.0`.
+  * [Google Mobile Ads Next-Gen](https://developers.google.com/admob/android/next-gen/rel-notes) SDK version `1.1.0`.
+* Updates GMA [iOS](https://developers.google.com/admob/ios/rel-notes) dependency to `13.3.0`.
+* Uses latest UMP SDK:
+  * [Android](https://developers.google.com/admob/android/privacy/release-notes) UMP SDK version 4.0.0.
+  * [iOS](https://developers.google.com/admob/ios/privacy/download#release_notes) UMP SDK version 3.1.0.
+
 ## 8.0.0
 * Updates minimum Flutter SDK to 3.38.1
 * Updates Dart SDK low bound to 3.10.0.

--- a/packages/google_mobile_ads/android/build.gradle
+++ b/packages/google_mobile_ads/android/build.gradle
@@ -1,5 +1,5 @@
 group 'io.flutter.plugins.googlemobileads'
-version '8.0.0'
+version '9.0.0'
 
 buildscript {
     ext {
@@ -66,9 +66,9 @@ android {
     }
     dependencies {
         if (useNextGenSdk) {
-            api 'com.google.android.libraries.ads.mobile.sdk:ads-mobile-sdk:1.0.1'
+            api 'com.google.android.libraries.ads.mobile.sdk:ads-mobile-sdk:1.1.0'
         } else {
-            api 'com.google.android.gms:play-services-ads:25.1.0'
+            api 'com.google.android.gms:play-services-ads:25.3.0'
         }
         implementation 'com.google.android.ump:user-messaging-platform:4.0.0'
         implementation 'androidx.constraintlayout:constraintlayout:2.2.1'

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
@@ -17,7 +17,7 @@ package io.flutter.plugins.googlemobileads;
 /** Constants used in the plugin. */
 public class Constants {
   /** Version request agent. Should be bumped alongside plugin versions. */
-  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-8.0.0";
+  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-9.0.0";
   /** Prefix for news template */
   public static final String REQUEST_AGENT_NEWS_TEMPLATE_PREFIX = "News";
 

--- a/packages/google_mobile_ads/ios/google_mobile_ads.podspec
+++ b/packages/google_mobile_ads/ios/google_mobile_ads.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'google_mobile_ads'
-  s.version          = '8.0.0'
+  s.version          = '9.0.0'
   s.summary          = 'Google Mobile Ads plugin for Flutter.'
   s.description      = <<-DESC
 Google Mobile Ads plugin for Flutter.
@@ -15,7 +15,7 @@ Google Mobile Ads plugin for Flutter.
   s.source_files = 'google_mobile_ads/Sources/google_mobile_ads/**/*.{h,m}'
   s.public_header_files = 'google_mobile_ads/Sources/google_mobile_ads/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'Google-Mobile-Ads-SDK','~> 13.2.0'
+  s.dependency 'Google-Mobile-Ads-SDK','~> 13.3.0'
   s.dependency 'webview_flutter_wkwebview'
   s.ios.deployment_target = '13.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS' => 'armv7 arm64 x86_64' }

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Package.swift
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            url: "https://github.com/googleads/swift-package-manager-google-mobile-ads", from: "13.2.0"),
+            url: "https://github.com/googleads/swift-package-manager-google-mobile-ads", from: "13.3.0"),
         .package(name: "webview_flutter_wkwebview", path: "../webview_flutter_wkwebview"),
     ],
     targets: [

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/include/google_mobile_ads/FLTConstants.h
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/include/google_mobile_ads/FLTConstants.h
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /** Versioned request agent string. */
-#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-8.0.0"
+#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-9.0.0"

--- a/packages/google_mobile_ads/pubspec.yaml
+++ b/packages/google_mobile_ads/pubspec.yaml
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 name: google_mobile_ads
-version: 8.0.0
+version: 9.0.0
 description: Flutter plugin for Google Mobile Ads, supporting
   banner, interstitial (full-screen),  rewarded and native ads
 repository: https://github.com/googleads/googleads-mobile-flutter/tree/main/packages/google_mobile_ads


### PR DESCRIPTION
## Description

This Pull Request bumps the version of the google_mobile_ads plugin from 8.0.0 to 9.0.0, upgrades key Android and iOS SDK dependencies, and integrates a pending AppStateNotifier resolution.

## Related Issues

* Resolves https://github.com/googleads/googleads-mobile-flutter/issues/1436

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
