### PR TITLE
Support AdManagerBannerAd recycling by exposing isMounted on AdWithView

### DIFF
--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -665,6 +665,20 @@ abstract class AdWithView extends Ad {
   Future<void> load();
 }
 
+/// Mixin that exposes [isMounted] getter to check if an inline view ad
+/// is currently mounted in a widget.
+mixin AdWithViewMounted on AdWithView {
+  /// Returns true if the ad Id is already mounted in a WidgetAd managed
+  /// by the instanceManager.
+  bool get isMounted {
+    final int? id = instanceManager.adIdFor(this);
+    if (id != null) {
+      return instanceManager.isWidgetAdIdMounted(id);
+    }
+    return false;
+  }
+}
+
 /// An [Ad] that is overlaid on top of the UI.
 abstract class AdWithoutView extends Ad {
   /// Default constructor used by subclasses.
@@ -920,7 +934,7 @@ class _FluidAdWidgetState extends State<FluidAdWidget> {
 /// This ad can either be overlaid on top of all flutter widgets as a static
 /// view or displayed as a typical Flutter widget. To display as a widget,
 /// instantiate an [AdWidget] with this as a parameter.
-class BannerAd extends AdWithView {
+class BannerAd extends AdWithView with AdWithViewMounted {
   /// Creates a [BannerAd].
   ///
   /// A valid [adUnitId], nonnull [listener], and nonnull request is required.
@@ -957,16 +971,6 @@ class BannerAd extends AdWithView {
   /// The future will resolve to null if [load] has not been called yet.
   Future<AdSize?> getPlatformAdSize() async {
     return await instanceManager.getAdSize(this);
-  }
-
-  /// Returns true if the ad Id is already mounted in a WidgetAd managed
-  /// by the instanceManager.
-  bool get isMounted {
-    final int? id = instanceManager.adIdFor(this);
-    if (id != null) {
-      return instanceManager.isWidgetAdIdMounted(id);
-    }
-    return false;
   }
 
   /// Returns true if banner loaded is collapsible
@@ -1010,7 +1014,7 @@ class FluidAdManagerBannerAd extends AdManagerBannerAd {
 ///
 /// This ad can either be overlaid on top of all flutter widgets by passing this
 /// to an [AdWidget] after calling [load].
-class AdManagerBannerAd extends AdWithView {
+class AdManagerBannerAd extends AdWithView with AdWithViewMounted {
   /// Default constructor for [AdManagerBannerAd].
   ///
   /// [sizes], [adUnitId], [listener], and [request] are all required values.

--- a/packages/google_mobile_ads/test/admanager_banner_ad_test.dart
+++ b/packages/google_mobile_ads/test/admanager_banner_ad_test.dart
@@ -356,5 +356,28 @@ void main() {
       expect(instanceManager.adFor(0), isNull);
       expect(instanceManager.adIdFor(banner), isNull);
     });
+
+    test('isMounted returns correct value', () {
+      final AdManagerBannerAd banner = AdManagerBannerAd(
+        adUnitId: 'test-ad-unit',
+        sizes: [AdSize.banner],
+        listener: AdManagerBannerAdListener(),
+        request: AdManagerAdRequest(),
+      );
+
+      expect(instanceManager.adIdFor(banner), isNull);
+      expect(banner.isMounted, isFalse);
+
+      banner.load();
+      final int? adId = instanceManager.adIdFor(banner);
+      expect(adId, isNotNull);
+      expect(banner.isMounted, isFalse);
+
+      instanceManager.mountWidgetAdId(adId!);
+      expect(banner.isMounted, isTrue);
+
+      instanceManager.unmountWidgetAdId(adId);
+      expect(banner.isMounted, isFalse);
+    });
   });
 }


### PR DESCRIPTION
## Description

This PR supports ad view recycling for `AdManagerBannerAd`, enabling developers to reuse existing native ad views in scrollable lists (e.g., `ListView.builder`) rather than instantiating new views for every position.
By explicitly exposing the `isMounted` getter on `AdManagerBannerAd` (matching the existing behavior on `BannerAd`), `AdManagerBannerAd` instances can now correctly query whether their `WidgetAd` is currently mounted.

## Related Issues

Fixes #[1323](https://github.com/googleads/googleads-mobile-flutter/issues/1323)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
