### PR TITLE
Version bump to 9.1.0

### DIFF
--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 9.1.0
+* Adding Ad Preloading APIs. [PR 1445](https://github.com/googleads/googleads-mobile-flutter/pull/1445)
+* Support `AdManagerBannerAd` recycling by exposing `isMounted`. [PR 1443](https://github.com/googleads/googleads-mobile-flutter/pull/1443)
+* Uses latest UMP SDK:
+  * [Android](https://developers.google.com/admob/android/privacy/release-notes) UMP SDK version 4.0.0.
+  * [iOS](https://developers.google.com/admob/ios/privacy/download#release_notes) UMP SDK version 3.1.0.
+
 ## 9.0.0
 * Resolves pending start/stop method channel futures in AppStateNotifier Android. [PR 1438](https://github.com/googleads/googleads-mobile-flutter/pull/1438)
 * Updates GMA Android SDK dependencies:

--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## 9.1.0
 * Adding Ad Preloading APIs. [PR 1445](https://github.com/googleads/googleads-mobile-flutter/pull/1445)
 * Support `AdManagerBannerAd` recycling by exposing `isMounted`. [PR 1443](https://github.com/googleads/googleads-mobile-flutter/pull/1443)
+* Updates GMA Android SDK dependencies:
+  * [Google Mobile Ads](https://developers.google.com/admob/android/quick-start) SDK version `25.4.0`.
+  * [Google Mobile Ads Next-Gen](https://developers.google.com/admob/android/next-gen/rel-notes) SDK version `1.2.1`.
+* Updates GMA [iOS](https://developers.google.com/admob/ios/rel-notes) dependency to `13.6.0`.
 * Uses latest UMP SDK:
   * [Android](https://developers.google.com/admob/android/privacy/release-notes) UMP SDK version 4.0.0.
   * [iOS](https://developers.google.com/admob/ios/privacy/download#release_notes) UMP SDK version 3.1.0.

--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -6,8 +6,8 @@
 * Null-safe return values across the plugin. [PR 1461](https://github.com/googleads/googleads-mobile-flutter/pull/1461)
 * Updates GMA Android SDK dependencies:
   * [Google Mobile Ads](https://developers.google.com/admob/android/quick-start) SDK version `25.4.0`.
-  * [Google Mobile Ads Next-Gen](https://developers.google.com/admob/android/next-gen/rel-notes) SDK version `1.2.1`.
-* Updates GMA [iOS](https://developers.google.com/admob/ios/rel-notes) dependency to `13.6.0`.
+  * [Google Mobile Ads Next-Gen](https://developers.google.com/admob/android/next-gen/rel-notes) SDK version `1.3.1`.
+* Updates GMA [iOS](https://developers.google.com/admob/ios/rel-notes) dependency to `13.7.0`.
 * Uses latest UMP SDK:
   * [Android](https://developers.google.com/admob/android/privacy/release-notes) UMP SDK version 4.0.0.
   * [iOS](https://developers.google.com/admob/ios/privacy/download#release_notes) UMP SDK version 3.1.0.

--- a/packages/google_mobile_ads/CHANGELOG.md
+++ b/packages/google_mobile_ads/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 9.1.0
 * Adding Ad Preloading APIs. [PR 1445](https://github.com/googleads/googleads-mobile-flutter/pull/1445)
 * Support `AdManagerBannerAd` recycling by exposing `isMounted`. [PR 1443](https://github.com/googleads/googleads-mobile-flutter/pull/1443)
+* Added `setConsentSyncId()` on `ConsentRequestParameters`. [PR 1452](https://github.com/googleads/googleads-mobile-flutter/pull/1452)
+* Introduces `ageRestrictedTreatment` property to `RequestConfiguration`. [PR 1455](https://github.com/googleads/googleads-mobile-flutter/pull/1455)
+* Null-safe return values across the plugin. [PR 1461](https://github.com/googleads/googleads-mobile-flutter/pull/1461)
 * Updates GMA Android SDK dependencies:
   * [Google Mobile Ads](https://developers.google.com/admob/android/quick-start) SDK version `25.4.0`.
   * [Google Mobile Ads Next-Gen](https://developers.google.com/admob/android/next-gen/rel-notes) SDK version `1.2.1`.

--- a/packages/google_mobile_ads/android/build.gradle
+++ b/packages/google_mobile_ads/android/build.gradle
@@ -1,5 +1,5 @@
 group 'io.flutter.plugins.googlemobileads'
-version '9.0.0'
+version '9.1.0'
 
 buildscript {
     ext {

--- a/packages/google_mobile_ads/android/build.gradle
+++ b/packages/google_mobile_ads/android/build.gradle
@@ -66,7 +66,7 @@ android {
     }
     dependencies {
         if (useNextGenSdk) {
-            api 'com.google.android.libraries.ads.mobile.sdk:ads-mobile-sdk:1.2.1'
+            api 'com.google.android.libraries.ads.mobile.sdk:ads-mobile-sdk:1.3.1'
         } else {
             api 'com.google.android.gms:play-services-ads:25.4.0'
         }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/Constants.java
@@ -17,7 +17,7 @@ package io.flutter.plugins.googlemobileads;
 /** Constants used in the plugin. */
 public class Constants {
   /** Version request agent. Should be bumped alongside plugin versions. */
-  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-9.0.0";
+  public static final String REQUEST_AGENT_PREFIX_VERSIONED = "Flutter-GMA-9.1.0";
   /** Prefix for news template */
   public static final String REQUEST_AGENT_NEWS_TEMPLATE_PREFIX = "News";
 

--- a/packages/google_mobile_ads/ios/google_mobile_ads.podspec
+++ b/packages/google_mobile_ads/ios/google_mobile_ads.podspec
@@ -15,7 +15,7 @@ Google Mobile Ads plugin for Flutter.
   s.source_files = 'google_mobile_ads/Sources/google_mobile_ads/**/*.{h,m}'
   s.public_header_files = 'google_mobile_ads/Sources/google_mobile_ads/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'Google-Mobile-Ads-SDK','~> 13.3'
+  s.dependency 'Google-Mobile-Ads-SDK','~> 13.6'
   s.dependency 'webview_flutter_wkwebview'
   s.ios.deployment_target = '13.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS' => 'armv7 arm64 x86_64' }

--- a/packages/google_mobile_ads/ios/google_mobile_ads.podspec
+++ b/packages/google_mobile_ads/ios/google_mobile_ads.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'google_mobile_ads'
-  s.version          = '9.0.0'
+  s.version          = '9.1.0'
   s.summary          = 'Google Mobile Ads plugin for Flutter.'
   s.description      = <<-DESC
 Google Mobile Ads plugin for Flutter.

--- a/packages/google_mobile_ads/ios/google_mobile_ads.podspec
+++ b/packages/google_mobile_ads/ios/google_mobile_ads.podspec
@@ -15,7 +15,7 @@ Google Mobile Ads plugin for Flutter.
   s.source_files = 'google_mobile_ads/Sources/google_mobile_ads/**/*.{h,m}'
   s.public_header_files = 'google_mobile_ads/Sources/google_mobile_ads/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'Google-Mobile-Ads-SDK','~> 13.6'
+  s.dependency 'Google-Mobile-Ads-SDK','~> 13.7'
   s.dependency 'webview_flutter_wkwebview'
   s.ios.deployment_target = '13.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS' => 'armv7 arm64 x86_64' }

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Package.swift
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            url: "https://github.com/googleads/swift-package-manager-google-mobile-ads", from: "13.3.0"),
+            url: "https://github.com/googleads/swift-package-manager-google-mobile-ads", from: "13.6.0"),
         .package(name: "webview_flutter_wkwebview", path: "../webview_flutter_wkwebview"),
     ],
     targets: [

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Package.swift
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            url: "https://github.com/googleads/swift-package-manager-google-mobile-ads", from: "13.6.0"),
+            url: "https://github.com/googleads/swift-package-manager-google-mobile-ads", from: "13.7.0"),
         .package(name: "webview_flutter_wkwebview", path: "../webview_flutter_wkwebview"),
     ],
     targets: [

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/include/google_mobile_ads/FLTConstants.h
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/include/google_mobile_ads/FLTConstants.h
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /** Versioned request agent string. */
-#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-9.0.0"
+#define FLT_REQUEST_AGENT_VERSIONED @"Flutter-GMA-9.1.0"

--- a/packages/google_mobile_ads/lib/src/ad_listeners.dart
+++ b/packages/google_mobile_ads/lib/src/ad_listeners.dart
@@ -228,7 +228,7 @@ class NativeAdListener extends AdWithViewListener {
 }
 
 /// Callback events for for full screen ads, such as Rewarded and Interstitial.
-class FullScreenContentCallback<Ad> {
+class FullScreenContentCallback<T extends Ad> {
   /// Construct a new [FullScreenContentCallback].
   ///
   /// [Ad.dispose] should be called from [onAdFailedToShowFullScreenContent]
@@ -243,22 +243,22 @@ class FullScreenContentCallback<Ad> {
   });
 
   /// Called when an ad shows full screen content.
-  final GenericAdEventCallback<Ad>? onAdShowedFullScreenContent;
+  final GenericAdEventCallback<T>? onAdShowedFullScreenContent;
 
   /// Called when an ad dismisses full screen content.
-  final GenericAdEventCallback<Ad>? onAdDismissedFullScreenContent;
+  final GenericAdEventCallback<T>? onAdDismissedFullScreenContent;
 
   /// For iOS only. Called before dismissing a full screen view.
-  final GenericAdEventCallback<Ad>? onAdWillDismissFullScreenContent;
+  final GenericAdEventCallback<T>? onAdWillDismissFullScreenContent;
 
   /// Called when an ad impression occurs.
-  final GenericAdEventCallback<Ad>? onAdImpression;
+  final GenericAdEventCallback<T>? onAdImpression;
 
   /// Called when an ad is clicked.
-  final GenericAdEventCallback<Ad>? onAdClicked;
+  final GenericAdEventCallback<T>? onAdClicked;
 
   /// Called when ad fails to show full screen content.
-  final void Function(Ad ad, AdError error)? onAdFailedToShowFullScreenContent;
+  final void Function(T ad, AdError error)? onAdFailedToShowFullScreenContent;
 }
 
 /// Generic parent class for ad load callbacks.

--- a/packages/google_mobile_ads/pubspec.yaml
+++ b/packages/google_mobile_ads/pubspec.yaml
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 name: google_mobile_ads
-version: 9.0.0
+version: 9.1.0
 description: Flutter plugin for Google Mobile Ads, supporting
   banner, interstitial (full-screen),  rewarded and native ads
 repository: https://github.com/googleads/googleads-mobile-flutter/tree/main/packages/google_mobile_ads


### PR DESCRIPTION
## Description

Version bumping the `google_mobile_ads` plugin to `9.1.0`.

This also fixes an issue with the `Static analysis` of the pana tool regarding the `Ad` class used in the `FullScreenContentCallback` class so that the total pana score is `160` again.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
