### PR TITLE
Update admob samples to 9.0.0

### DIFF
--- a/samples/admob/app_open_example/pubspec.yaml
+++ b/samples/admob/app_open_example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_mobile_ads: ^8.0.0
+  google_mobile_ads: ^9.0.0
 
 dev_dependencies:
   flutter_test:

--- a/samples/admob/banner_example/pubspec.yaml
+++ b/samples/admob/banner_example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_mobile_ads: ^8.0.0
+  google_mobile_ads: ^9.0.0
 
 dev_dependencies:
   flutter_test:

--- a/samples/admob/interstitial_example/pubspec.yaml
+++ b/samples/admob/interstitial_example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_mobile_ads: ^8.0.0
+  google_mobile_ads: ^9.0.0
 
 dev_dependencies:
   flutter_test:

--- a/samples/admob/mediation_example/pubspec.yaml
+++ b/samples/admob/mediation_example/pubspec.yaml
@@ -23,7 +23,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_mobile_ads: ^8.0.0
+  google_mobile_ads: ^9.0.0
 
   # The following adds the Cupertino Icons font to your application.
 

--- a/samples/admob/native_platform_example/pubspec.yaml
+++ b/samples/admob/native_platform_example/pubspec.yaml
@@ -30,7 +30,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_mobile_ads: ^8.0.0
+  google_mobile_ads: ^9.0.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/samples/admob/native_template_example/pubspec.yaml
+++ b/samples/admob/native_template_example/pubspec.yaml
@@ -30,7 +30,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_mobile_ads: ^8.0.0
+  google_mobile_ads: ^9.0.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/samples/admob/rewarded_example/pubspec.yaml
+++ b/samples/admob/rewarded_example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_mobile_ads: ^8.0.0
+  google_mobile_ads: ^9.0.0
 
 dev_dependencies:
   flutter_test:

--- a/samples/admob/rewarded_interstitial_example/pubspec.yaml
+++ b/samples/admob/rewarded_interstitial_example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_mobile_ads: ^8.0.0
+  google_mobile_ads: ^9.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description

Updates the /admob samples to build against version `9.0.0` of the `google_mobile_ads` plugin. 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
