### PR TITLE
Added consentSyncId for UMP

### DIFF
--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/usermessagingplatform/ConsentRequestParametersWrapper.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/usermessagingplatform/ConsentRequestParametersWrapper.java
@@ -26,10 +26,15 @@ class ConsentRequestParametersWrapper {
 
   @Nullable private final ConsentDebugSettingsWrapper debugSettings;
 
+  @Nullable private final String consentSyncId;
+
   ConsentRequestParametersWrapper(
-      @Nullable Boolean tfuac, @Nullable ConsentDebugSettingsWrapper debugSettings) {
+      @Nullable Boolean tfuac,
+      @Nullable ConsentDebugSettingsWrapper debugSettings,
+      @Nullable String consentSyncId) {
     this.tfuac = tfuac;
     this.debugSettings = debugSettings;
+    this.consentSyncId = consentSyncId;
   }
 
   @Nullable
@@ -42,6 +47,11 @@ class ConsentRequestParametersWrapper {
     return debugSettings;
   }
 
+  @Nullable
+  String getConsentSyncId() {
+    return consentSyncId;
+  }
+
   /** Get as {@link ConsentRequestParameters}. */
   ConsentRequestParameters getAsConsentRequestParameters(Context context) {
     ConsentRequestParameters.Builder builder = new ConsentRequestParameters.Builder();
@@ -50,6 +60,9 @@ class ConsentRequestParametersWrapper {
     }
     if (debugSettings != null) {
       builder.setConsentDebugSettings(debugSettings.getAsConsentDebugSettings(context));
+    }
+    if (consentSyncId != null) {
+      builder.setConsentSyncId(consentSyncId);
     }
     return builder.build();
   }
@@ -64,11 +77,12 @@ class ConsentRequestParametersWrapper {
 
     ConsentRequestParametersWrapper other = (ConsentRequestParametersWrapper) obj;
     return Objects.equals(tfuac, other.getTfuac())
-        && Objects.equals(debugSettings, other.getDebugSettings());
+        && Objects.equals(debugSettings, other.getDebugSettings())
+        && Objects.equals(consentSyncId, other.getConsentSyncId());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(tfuac, debugSettings);
+    return Objects.hash(tfuac, debugSettings, consentSyncId);
   }
 }

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/usermessagingplatform/UserMessagingCodec.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/usermessagingplatform/UserMessagingCodec.java
@@ -47,6 +47,7 @@ public class UserMessagingCodec extends StandardMessageCodec {
       ConsentRequestParametersWrapper params = (ConsentRequestParametersWrapper) value;
       writeValue(stream, params.getTfuac());
       writeValue(stream, params.getDebugSettings());
+      writeValue(stream, params.getConsentSyncId());
     } else if (value instanceof ConsentDebugSettingsWrapper) {
       stream.write(VALUE_CONSENT_DEBUG_SETTINGS);
       ConsentDebugSettingsWrapper debugSettings = (ConsentDebugSettingsWrapper) value;
@@ -90,7 +91,8 @@ public class UserMessagingCodec extends StandardMessageCodec {
           Boolean tfuac = (Boolean) readValueOfType(buffer.get(), buffer);
           ConsentDebugSettingsWrapper debugSettings =
               (ConsentDebugSettingsWrapper) readValueOfType(buffer.get(), buffer);
-          return new ConsentRequestParametersWrapper(tfuac, debugSettings);
+          String consentSyncId = (String) readValueOfType(buffer.get(), buffer);
+          return new ConsentRequestParametersWrapper(tfuac, debugSettings, consentSyncId);
         }
       case VALUE_CONSENT_DEBUG_SETTINGS:
         {

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/usermessagingplatform/UserMessagingCodecTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/usermessagingplatform/UserMessagingCodecTest.java
@@ -41,7 +41,7 @@ public class UserMessagingCodecTest {
 
   @Test
   public void testConsentRequestParameters_null() {
-    ConsentRequestParametersWrapper params = new ConsentRequestParametersWrapper(null, null);
+    ConsentRequestParametersWrapper params = new ConsentRequestParametersWrapper(null, null, null);
     final ByteBuffer message = codec.encodeMessage(params);
     ConsentRequestParametersWrapper decoded =
         (ConsentRequestParametersWrapper) codec.decodeMessage((ByteBuffer) message.position(0));
@@ -52,7 +52,7 @@ public class UserMessagingCodecTest {
   public void testConsentRequestParameters_tfuacNull_debugSettingsDefined() {
     ConsentDebugSettingsWrapper debugSettings = new ConsentDebugSettingsWrapper(null, null);
     ConsentRequestParametersWrapper params =
-        new ConsentRequestParametersWrapper(null, debugSettings);
+        new ConsentRequestParametersWrapper(null, debugSettings, null);
     final ByteBuffer message = codec.encodeMessage(params);
     ConsentRequestParametersWrapper decoded =
         (ConsentRequestParametersWrapper) codec.decodeMessage((ByteBuffer) message.position(0));
@@ -61,7 +61,7 @@ public class UserMessagingCodecTest {
 
   @Test
   public void testConsentRequestParameters_tfuacDefined_debugSettingsNull() {
-    ConsentRequestParametersWrapper params = new ConsentRequestParametersWrapper(true, null);
+    ConsentRequestParametersWrapper params = new ConsentRequestParametersWrapper(true, null, null);
     final ByteBuffer message = codec.encodeMessage(params);
     ConsentRequestParametersWrapper decoded =
         (ConsentRequestParametersWrapper) codec.decodeMessage((ByteBuffer) message.position(0));
@@ -72,7 +72,17 @@ public class UserMessagingCodecTest {
   public void testConsentRequestParameters_tfuacDefined_debugSettingsDefined() {
     ConsentDebugSettingsWrapper debugSettings = new ConsentDebugSettingsWrapper(null, null);
     ConsentRequestParametersWrapper params =
-        new ConsentRequestParametersWrapper(true, debugSettings);
+        new ConsentRequestParametersWrapper(true, debugSettings, null);
+    final ByteBuffer message = codec.encodeMessage(params);
+    ConsentRequestParametersWrapper decoded =
+        (ConsentRequestParametersWrapper) codec.decodeMessage((ByteBuffer) message.position(0));
+    assertEquals(params, decoded);
+  }
+
+  @Test
+  public void testConsentRequestParameters_consentSyncIdDefined() {
+    ConsentRequestParametersWrapper params =
+        new ConsentRequestParametersWrapper(null, null, "syncId");
     final ByteBuffer message = codec.encodeMessage(params);
     ConsentRequestParametersWrapper decoded =
         (ConsentRequestParametersWrapper) codec.decodeMessage((ByteBuffer) message.position(0));

--- a/packages/google_mobile_ads/example/ios/RunnerTests/FLTUserMessagingPlatformReaderWriterTest.m
+++ b/packages/google_mobile_ads/example/ios/RunnerTests/FLTUserMessagingPlatformReaderWriterTest.m
@@ -57,6 +57,15 @@
                  requestParameters.debugSettings.testDeviceIdentifiers);
 }
 
+- (void)testRequestParams_withConsentSyncID {
+  UMPRequestParameters *requestParameters = [[UMPRequestParameters alloc] init];
+  requestParameters.consentSyncID = @"syncId123";
+  NSData *encodedMessage = [messageCodec encode:requestParameters];
+
+  UMPRequestParameters *decoded = [messageCodec decode:encodedMessage];
+  XCTAssertEqualObjects(decoded.consentSyncID, requestParameters.consentSyncID);
+}
+
 - (void)testConsentDebugSettings_default {
   UMPDebugSettings *debugSettings = [[UMPDebugSettings alloc] init];
   NSData *encodedMessage = [messageCodec encode:debugSettings];

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/UserMessagingPlatform/FLTUserMessagingPlatformReaderWriter.m
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/UserMessagingPlatform/FLTUserMessagingPlatformReaderWriter.m
@@ -86,6 +86,7 @@ typedef NS_ENUM(NSInteger, FLTUserMessagingPlatformField) {
     [self writeValue:[[NSNumber alloc]
                          initWithBool:params.tagForUnderAgeOfConsent]];
     [self writeValue:params.debugSettings];
+    [self writeValue:params.consentSyncID];
   } else if ([value isKindOfClass:[UMPDebugSettings class]]) {
     UMPDebugSettings *debugSettings = (UMPDebugSettings *)value;
     [self writeByte:FLTValueConsentDebugSettings];
@@ -111,6 +112,8 @@ typedef NS_ENUM(NSInteger, FLTUserMessagingPlatformField) {
     parameters.tagForUnderAgeOfConsent = tfuac.boolValue;
     UMPDebugSettings *debugSettings = [self readValueOfType:[self readByte]];
     parameters.debugSettings = debugSettings;
+    NSString *consentSyncId = [self readValueOfType:[self readByte]];
+    parameters.consentSyncID = consentSyncId;
     return parameters;
   }
   case FLTValueConsentDebugSettings: {

--- a/packages/google_mobile_ads/lib/src/ump/consent_request_parameters.dart
+++ b/packages/google_mobile_ads/lib/src/ump/consent_request_parameters.dart
@@ -20,6 +20,7 @@ class ConsentRequestParameters {
   ConsentRequestParameters({
     this.tagForUnderAgeOfConsent,
     this.consentDebugSettings,
+    this.consentSyncId,
   });
 
   /// Tag for underage of consent.
@@ -30,16 +31,20 @@ class ConsentRequestParameters {
   /// Debug settings to hardcode in test requests.
   ConsentDebugSettings? consentDebugSettings;
 
+  /// An identifier used to sync consent state across different screens/applications.
+  String? consentSyncId;
+
   @override
   bool operator ==(Object other) {
     return other is ConsentRequestParameters &&
         tagForUnderAgeOfConsent == other.tagForUnderAgeOfConsent &&
-        consentDebugSettings == other.consentDebugSettings;
+        consentDebugSettings == other.consentDebugSettings &&
+        consentSyncId == other.consentSyncId;
   }
 
   @override
   int get hashCode =>
-      Object.hash(tagForUnderAgeOfConsent, consentDebugSettings);
+      Object.hash(tagForUnderAgeOfConsent, consentDebugSettings, consentSyncId);
 }
 
 /// Debug settings to hardcode in test requests.

--- a/packages/google_mobile_ads/lib/src/ump/user_messaging_codec.dart
+++ b/packages/google_mobile_ads/lib/src/ump/user_messaging_codec.dart
@@ -31,6 +31,7 @@ class UserMessagingCodec extends StandardMessageCodec {
       buffer.putUint8(_valueConsentRequestParameters);
       writeValue(buffer, value.tagForUnderAgeOfConsent);
       writeValue(buffer, value.consentDebugSettings);
+      writeValue(buffer, value.consentSyncId);
     } else if (value is ConsentDebugSettings) {
       buffer.putUint8(_valueConsentDebugSettings);
       writeValue(buffer, value.debugGeography?.index);
@@ -56,9 +57,11 @@ class UserMessagingCodec extends StandardMessageCodec {
           buffer.getUint8(),
           buffer,
         );
+        String? consentSyncId = readValueOfType(buffer.getUint8(), buffer);
         return ConsentRequestParameters(
           tagForUnderAgeOfConsent: tfuac,
           consentDebugSettings: debugSettings,
+          consentSyncId: consentSyncId,
         );
       case _valueConsentDebugSettings:
         int? debugGeographyInt = readValueOfType(buffer.getUint8(), buffer);

--- a/packages/google_mobile_ads/test/ump/user_messaging_codec_test.dart
+++ b/packages/google_mobile_ads/test/ump/user_messaging_codec_test.dart
@@ -32,6 +32,18 @@ void main() {
       expect(params, decodedParams);
     });
 
+    test(
+      'encode and decode ConsentRequestParameters with consentSyncId',
+      () async {
+        ConsentRequestParameters params = ConsentRequestParameters(
+          consentSyncId: 'test-sync-id',
+        );
+        final ByteData? byteData = codec.encodeMessage(params);
+        ConsentRequestParameters decodedParams = codec.decodeMessage(byteData);
+        expect(params, decodedParams);
+      },
+    );
+
     test('encode and decode empty ConsentDebugSettings', () async {
       ConsentDebugSettings debugSettings = ConsentDebugSettings();
       ByteData? byteData = codec.encodeMessage(debugSettings);


### PR DESCRIPTION
## Description

Added setConsentSyncId() on ConsentRequestParameters.

## Related Issues

* Resolves https://github.com/googleads/googleads-mobile-flutter/issues/1423

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
