### PR TITLE
Fix Null type in FlutterLoadAdError domain for adsNextGenSdk

### DIFF
--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAd.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAd.java
@@ -335,7 +335,10 @@ abstract class FlutterAd {
 
       if (error.getResponseInfo() != null) {
         responseInfo = new FlutterResponseInfo(error.getResponseInfo());
-        domain = responseInfo.getMediationAdapterClassName();
+        String adapterClassName = responseInfo.getMediationAdapterClassName();
+        domain = adapterClassName != null
+            ? adapterClassName
+            : "com.google.android.libraries.ads.mobile.sdk";
       } else {
         domain = "com.google.android.libraries.ads.mobile.sdk";
       }

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -1163,8 +1163,8 @@ class AdMessageCodec extends StandardMessageCodec {
         );
       case _valueRewardItem:
         return RewardItem(
-          readValueOfType(buffer.getUint8(), buffer),
-          readValueOfType(buffer.getUint8(), buffer),
+          readValueOfType(buffer.getUint8(), buffer) ?? 0,
+          _safeReadString(buffer),
         );
       case _valueResponseInfo:
         return ResponseInfo(
@@ -1249,7 +1249,7 @@ class AdMessageCodec extends StandardMessageCodec {
           buffer.getUint8(),
           buffer,
         );
-        final String description = readValueOfType(buffer.getUint8(), buffer);
+        final String description = _safeReadString(buffer);
 
         double latency = readValueOfType(buffer.getUint8(), buffer).toDouble();
         // Android provides this value as an int in milliseconds while iOS

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -1598,6 +1598,31 @@ void main() {
       expect(result.type, 'type');
     });
 
+    test('encode/decode $RewardItem with null values', () async {
+      final WriteBuffer buffer = WriteBuffer();
+      buffer.putUint8(132);
+      codec.writeValue(buffer, null);
+      codec.writeValue(buffer, null);
+
+      final RewardItem result = codec.decodeMessage(buffer.done());
+      expect(result.amount, 0);
+      expect(result.type, '');
+    });
+
+    test('encode/decode $AdapterStatus with null description', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      final WriteBuffer buffer = WriteBuffer();
+      buffer.putUint8(136);
+      codec.writeValue(buffer, AdapterInitializationState.ready);
+      codec.writeValue(buffer, null);
+      codec.writeValue(buffer, 1000);
+
+      final AdapterStatus result = codec.decodeMessage(buffer.done());
+      expect(result.state, AdapterInitializationState.ready);
+      expect(result.description, '');
+      expect(result.latency, 1.0);
+    });
+
     test('encode/decode $InlineAdaptiveSize', () async {
       ByteData byteData = codec.encodeMessage(
         AdSize.getCurrentOrientationInlineAdaptiveBannerAdSize(100),


### PR DESCRIPTION
## Description

Added a null check on responseInfo.getMediationAdapterClassName(). If null, domain falls back to "com.google.android.libraries.ads.mobile.sdk", matching the fallback behavior when error.getResponseInfo() is null.

## Related Issues

* Resolves https://github.com/googleads/googleads-mobile-flutter/issues/1460

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
