### PR TITLE
Register OnPaidEventListener for AdManagerBannerAd on Android

### DIFF
--- a/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdManagerBannerAd.java
+++ b/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdManagerBannerAd.java
@@ -86,6 +86,7 @@ class FlutterAdManagerBannerAd extends FlutterAd implements FlutterAdLoadedListe
     }
     adView.setAdSizes(allSizes);
     adView.setAdListener(new FlutterBannerAdListener(adId, manager, this));
+    adView.setOnPaidEventListener(new FlutterPaidEventListener(manager, this));
     adView.loadAd(request.asAdManagerAdRequest(adUnitId));
   }
 

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerBannerAdTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/FlutterAdManagerBannerAdTest.java
@@ -106,6 +106,7 @@ public class FlutterAdManagerBannerAdTest {
     verify(mockAdView).loadAd(eq(mockAdRequest));
     verify(mockAdView).setAdListener(any(AdListener.class));
     verify(mockAdView).setAppEventListener(any(AppEventListener.class));
+    verify(mockAdView).setOnPaidEventListener(any(FlutterPaidEventListener.class));
     verify(mockAdView).setAdUnitId(eq("testId"));
     verify(mockAdView).setAdSizes(adSize);
     FlutterLoadAdError expectedError = new FlutterLoadAdError(loadError);


### PR DESCRIPTION
Fixes #1462

### Problem

On Android, `AdManagerBannerAd` never fires `onPaidEvent`. `FlutterAdManagerBannerAd.load()` attaches the ad listener and app-event listener but never calls `setOnPaidEventListener` on the `AdManagerAdView`:

```java
adView.setAdSizes(allSizes);
adView.setAdListener(new FlutterBannerAdListener(adId, manager, this));
adView.loadAd(request.asAdManagerAdRequest(adUnitId));   // no setOnPaidEventListener
```

Every other ad type registers it — `FlutterBannerAd`, `FlutterRewardedAd`, `FlutterRewardedInterstitialAd`, `FlutterInterstitialAd`, `FlutterInterstitialAd`, `FlutterNativeAd`, `FlutterAppOpenAd` — and iOS `FLTGAMBannerAd` sets `paidEventHandler`. So `AdManagerBannerAdListener.onPaidEvent` can never be invoked on Android, even though the account earns impression-level ad revenue on those units. The Dart layer (`AdInstanceManager._invokePaidEvent`) already routes `AdWithView` paid events to `ad.listener.onPaidEvent`; the native listener simply is never attached for this type.

### Fix

Register the paid-event listener in `FlutterAdManagerBannerAd.load()`, mirroring `FlutterBannerAd`:

```java
adView.setOnPaidEventListener(new FlutterPaidEventListener(manager, this));
```

### Test

Extends the existing `FlutterAdManagerBannerAdTest` load assertions with `verify(mockAdView).setOnPaidEventListener(any(FlutterPaidEventListener.class))`, matching `FlutterBannerAdTest`.

### Scope

Fixes the `playServices` source set (the Play Services / legacy GMA SDK path). The `adsNextGenSdk` source set uses a different API surface and is left untouched here — maintainers may want to verify the equivalent there. iOS already handles this correctly.