### PR TITLE
Make Android AdInstanceManager ads map thread-safe and optimize adId lookup

### DIFF
--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/AdInstanceManager.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/AdInstanceManager.java
@@ -28,6 +28,7 @@ import io.flutter.plugins.googlemobileads.FlutterAd.FlutterAdError;
 import io.flutter.plugins.googlemobileads.FlutterAd.FlutterResponseInfo;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Maintains reference to ad instances for the {@link
@@ -50,7 +51,7 @@ class AdInstanceManager {
    */
   AdInstanceManager(@NonNull MethodChannel channel) {
     this.channel = channel;
-    this.ads = new HashMap<>();
+    this.ads = new ConcurrentHashMap<>();
   }
 
   void setActivity(@Nullable Activity activity) {
@@ -69,31 +70,30 @@ class AdInstanceManager {
 
   @Nullable
   Integer adIdFor(@NonNull FlutterAd ad) {
-    for (Integer adId : ads.keySet()) {
-      if (ads.get(adId) == ad) {
-        return adId;
+    Integer adId = ad.adId;
+    if (ads.get(adId) == ad) {
+      return adId;
+    }
+    for (Map.Entry<Integer, FlutterAd> entry : ads.entrySet()) {
+      if (entry.getValue() == ad) {
+        return entry.getKey();
       }
     }
     return null;
   }
 
   void trackAd(@NonNull FlutterAd ad, int adId) {
-    if (ads.get(adId) != null) {
+    if (ads.putIfAbsent(adId, ad) != null) {
       throw new IllegalArgumentException(
           String.format("Ad for following adId already exists: %d", adId));
     }
-    ads.put(adId, ad);
   }
 
   void disposeAd(int adId) {
-    if (!ads.containsKey(adId)) {
-      return;
-    }
-    FlutterAd ad = ads.get(adId);
+    FlutterAd ad = ads.remove(adId);
     if (ad != null) {
       ad.dispose();
     }
-    ads.remove(adId);
   }
 
   void disposeAllAds() {

--- a/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/AdInstanceManager.java
+++ b/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/AdInstanceManager.java
@@ -26,6 +26,7 @@ import io.flutter.plugins.googlemobileads.FlutterAd.FlutterAdError;
 import io.flutter.plugins.googlemobileads.FlutterAd.FlutterResponseInfo;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Maintains reference to ad instances for the {@link
@@ -46,7 +47,7 @@ class AdInstanceManager {
    */
   AdInstanceManager(@NonNull MethodChannel channel) {
     this.channel = channel;
-    this.ads = new HashMap<>();
+    this.ads = new ConcurrentHashMap<>();
   }
 
   void setActivity(@Nullable Activity activity) {
@@ -65,31 +66,30 @@ class AdInstanceManager {
 
   @Nullable
   Integer adIdFor(@NonNull FlutterAd ad) {
-    for (Integer adId : ads.keySet()) {
-      if (ads.get(adId) == ad) {
-        return adId;
+    Integer adId = ad.adId;
+    if (ads.get(adId) == ad) {
+      return adId;
+    }
+    for (Map.Entry<Integer, FlutterAd> entry : ads.entrySet()) {
+      if (entry.getValue() == ad) {
+        return entry.getKey();
       }
     }
     return null;
   }
 
   void trackAd(@NonNull FlutterAd ad, int adId) {
-    if (ads.get(adId) != null) {
+    if (ads.putIfAbsent(adId, ad) != null) {
       throw new IllegalArgumentException(
           String.format("Ad for following adId already exists: %d", adId));
     }
-    ads.put(adId, ad);
   }
 
   void disposeAd(int adId) {
-    if (!ads.containsKey(adId)) {
-      return;
-    }
-    FlutterAd ad = ads.get(adId);
+    FlutterAd ad = ads.remove(adId);
     if (ad != null) {
       ad.dispose();
     }
-    ads.remove(adId);
   }
 
   void disposeAllAds() {

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -62,6 +63,13 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Test;
@@ -647,6 +655,129 @@ public class GoogleMobileAdsTest {
     assertEquals(args.get("valueMicros"), 1L);
     assertEquals(args.get("precision"), 1);
     assertEquals(args.get("currencyCode"), "code");
+  }
+
+  private static class TestFlutterAd extends FlutterAd {
+    TestFlutterAd(int adId) {
+      super(adId);
+    }
+
+    @Override
+    void load() {}
+
+    @Override
+    void dispose() {}
+  }
+
+  @Test
+  public void adIdFor_returnsDirectAdIdFastPath() {
+    final TestFlutterAd ad = new TestFlutterAd(42);
+    testManager.trackAd(ad, 42);
+
+    assertEquals(Integer.valueOf(42), testManager.adIdFor(ad));
+    assertEquals(ad, testManager.adForId(42));
+  }
+
+  @Test
+  public void adIdFor_returnsCorrectAdIdWhenKeyDiffersFromAdId() {
+    final TestFlutterAd ad = new TestFlutterAd(10);
+    testManager.trackAd(ad, 99);
+
+    assertEquals(Integer.valueOf(99), testManager.adIdFor(ad));
+    assertEquals(ad, testManager.adForId(99));
+  }
+
+  @Test
+  public void adIdFor_returnsNullForUntrackedOrDisposedAd() {
+    final TestFlutterAd ad = new TestFlutterAd(100);
+    assertNull(testManager.adIdFor(ad));
+
+    testManager.trackAd(ad, 100);
+    assertEquals(Integer.valueOf(100), testManager.adIdFor(ad));
+
+    testManager.disposeAd(100);
+    assertNull(testManager.adIdFor(ad));
+    assertNull(testManager.adForId(100));
+  }
+
+  @Test
+  public void adIdFor_concurrentModification_doesNotThrow() throws Exception {
+    final int numWriterThreads = 2;
+    final int numReaderThreads = 4;
+    final int iterations = 500;
+    final ExecutorService executor =
+        Executors.newFixedThreadPool(numWriterThreads + numReaderThreads);
+    final CountDownLatch startLatch = new CountDownLatch(1);
+    final AtomicBoolean running = new AtomicBoolean(true);
+    final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+    // Pre-populate some ads in the manager
+    final List<TestFlutterAd> staticAds = new ArrayList<>();
+    for (int i = 0; i < 20; i++) {
+      TestFlutterAd ad = new TestFlutterAd(i);
+      staticAds.add(ad);
+      testManager.trackAd(ad, i);
+    }
+
+    final List<Future<?>> futures = new ArrayList<>();
+
+    // Writer threads: dynamically tracking and disposing ads concurrently (mimicking UI thread operations)
+    for (int i = 0; i < numWriterThreads; i++) {
+      final int threadId = i;
+      futures.add(
+          executor.submit(
+              () -> {
+                try {
+                  startLatch.await();
+                  for (int j = 0; j < iterations && running.get(); j++) {
+                    int adId = 1000 + (threadId * iterations) + j;
+                    TestFlutterAd ad = new TestFlutterAd(adId);
+                    testManager.trackAd(ad, adId);
+                    testManager.disposeAd(adId);
+                  }
+                } catch (Throwable t) {
+                  errorRef.compareAndSet(null, t);
+                  running.set(false);
+                }
+              }));
+    }
+
+    // Reader threads: simulating background threads calling adIdFor concurrently while map is mutated
+    for (int i = 0; i < numReaderThreads; i++) {
+      futures.add(
+          executor.submit(
+              () -> {
+                try {
+                  startLatch.await();
+                  for (int j = 0; j < iterations && running.get(); j++) {
+                    for (TestFlutterAd ad : staticAds) {
+                      Integer foundId = testManager.adIdFor(ad);
+                      assertNotNull(foundId);
+                      assertEquals(Integer.valueOf(ad.adId), foundId);
+                    }
+                  }
+                } catch (Throwable t) {
+                  errorRef.compareAndSet(null, t);
+                  running.set(false);
+                }
+              }));
+    }
+
+    startLatch.countDown();
+    executor.shutdown();
+    assertTrue(
+        "Executor should terminate in time",
+        executor.awaitTermination(5, TimeUnit.SECONDS));
+
+    for (Future<?> future : futures) {
+      future.get();
+    }
+
+    if (errorRef.get() != null) {
+      throw new AssertionError(
+          "Concurrent modification exception occurred in background thread",
+          errorRef.get());
+    }
   }
 
   @Test


### PR DESCRIPTION
## Description

Fixes a `java.util.ConcurrentModificationException` crash and concurrency hazard in both Android Legacy's and Android Next-Gen's `AdInstanceManager`.

## Related Issues

* Resolves https://github.com/googleads/googleads-mobile-flutter/issues/1466

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
