### PR TITLE
fix: dispatch Next-Gen native ad callbacks on main thread

### DIFF
--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdListener.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdListener.java
@@ -14,6 +14,8 @@
 
 package io.flutter.plugins.googlemobileads;
 
+import android.os.Handler;
+import android.os.Looper;
 import androidx.annotation.NonNull;
 import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd;
 import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdEventCallback;
@@ -130,6 +132,7 @@ class FlutterNativeAdListener implements NativeAdEventCallback {
 /** {@link NativeAdLoaderCallback} for native ads. */
 class FlutterNativeAdLoadedListener implements NativeAdLoaderCallback {
 
+  @NonNull private final Handler mainHandler = new Handler(Looper.getMainLooper());
   private final WeakReference<FlutterNativeAd> nativeAdWeakReference;
 
   FlutterNativeAdLoadedListener(FlutterNativeAd flutterNativeAd) {
@@ -138,15 +141,31 @@ class FlutterNativeAdLoadedListener implements NativeAdLoaderCallback {
 
   @Override
   public void onNativeAdLoaded(@NonNull NativeAd nativeAd) {
-    if (nativeAdWeakReference.get() != null) {
-      nativeAdWeakReference.get().onNativeAdLoaded(nativeAd);
-    }
+    runOnMainThread(
+        () -> {
+          FlutterNativeAd flutterNativeAd = nativeAdWeakReference.get();
+          if (flutterNativeAd != null) {
+            flutterNativeAd.onNativeAdLoaded(nativeAd);
+          }
+        });
   }
 
   @Override
   public void onAdFailedToLoad(LoadAdError loadAdError) {
-    if (nativeAdWeakReference.get() != null) {
-      nativeAdWeakReference.get().onNativeAdFailed(loadAdError);
+    runOnMainThread(
+        () -> {
+          FlutterNativeAd flutterNativeAd = nativeAdWeakReference.get();
+          if (flutterNativeAd != null) {
+            flutterNativeAd.onNativeAdFailed(loadAdError);
+          }
+        });
+  }
+
+  private void runOnMainThread(@NonNull Runnable callback) {
+    if (Looper.myLooper() == Looper.getMainLooper()) {
+      callback.run();
+    } else {
+      mainHandler.post(callback);
     }
   }
 }


### PR DESCRIPTION
## Summary

- deliver Next-Gen native ad load success and failure callbacks on the Android main looper while preserving immediate delivery when already on main

## Root cause

`NativeAdLoaderCallback` can be invoked from an SDK worker thread. The plugin forwarded those callbacks directly into `FlutterNativeAd`, where native ad factories create Android views and mediation adapters register them for interaction.

## Test plan

- `flutter test` (141 tests)
- `dart analyze lib test`
- `./gradlew :google_mobile_ads:compileDebugJavaWithJavac -Pdart-defines=VVNFX05FWFRfR0VOX1NESz10cnVl --rerun-tasks`

Fixes #1473
