### PR TITLE
gma_mediation_meta: build under AGP 9 built-in Kotlin

### DIFF
--- a/packages/mediation/gma_mediation_meta/android/build.gradle
+++ b/packages/mediation/gma_mediation_meta/android/build.gradle
@@ -21,8 +21,13 @@ allprojects {
     }
 }
 
+def builtInKotlinEnabled = (project.findProperty('android.builtInKotlin') ?: 'false').toString().toBoolean()
+
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+// AGP 9 ships built-in Kotlin and rejects this plugin, so only apply it while the consumer opts out.
+if (!builtInKotlinEnabled) {
+    apply plugin: 'kotlin-android'
+}
 
 ext {
     stringVersion = "6.22.0.0"
@@ -40,8 +45,11 @@ android {
         targetCompatibility JavaVersion.VERSION_11
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+    // `kotlinOptions` is contributed by the Kotlin Gradle plugin; built-in Kotlin has no such accessor.
+    if (!builtInKotlinEnabled) {
+        kotlinOptions {
+            jvmTarget = JavaVersion.VERSION_11.toString()
+        }
     }
 
     sourceSets {


### PR DESCRIPTION
`gma_mediation_meta` fails to configure on Android Gradle Plugin 9 when the app has
built-in Kotlin enabled (`android.builtInKotlin=true` in `gradle.properties`, the AGP 9
default that Flutter's own migrator writes):

```
The 'org.jetbrains.kotlin.android' plugin is no longer required for Kotlin support since AGP 9.0
```

Two things in `android/build.gradle` cause it:

1. `apply plugin: 'kotlin-android'` — AGP 9 provides Kotlin compilation itself and hard-errors
   when KGP is applied on top.
2. `android { kotlinOptions { … } }` — that accessor is contributed by the Kotlin Gradle plugin.
   With KGP not applied it does not exist, so the block fails with `MissingMethodException`.

Both are now guarded on the consumer's `android.builtInKotlin` property, read via
`findProperty` so an absent property means `false`:

- **AGP 8 / built-in Kotlin off** — the generated build is byte-identical to today: KGP is
  applied and `jvmTarget` is still pinned to 11. No behaviour change for existing consumers.
- **AGP 9 / built-in Kotlin on** — neither block runs; AGP compiles the module's Kotlin.

This is the same guard shape several Flutter plugins already ship for AGP 9
(`device_info_plus`, `package_info_plus`, `firebase_analytics`, …), so app authors who have
opted in do not need a per-plugin override.

Verified in an app on AGP 9.4.0-rc01 with `android.builtInKotlin=true`: the module configures,
and `GmaMediationMetaPlugin.class` is present in the AAR (checked by class presence — a module
that nothing compiles still reports `BUILD SUCCESSFUL`).

Only `packages/mediation/gma_mediation_meta/android/build.gradle` changes; nothing on the iOS
or Dart side is touched.
