### PR TITLE
iOS AppStateNotifier Fix and tests

### DIFF
--- a/packages/google_mobile_ads/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/google_mobile_ads/example/ios/Runner.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		9E61AA2029BBE58400801A83 /* FLTAdRequestTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E61AA1F29BBE58400801A83 /* FLTAdRequestTest.m */; };
+		9E61AA3D29BBE66900801A83 /* FLTAppStateNotifierTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E61AA3E29BBE66900801A83 /* FLTAppStateNotifierTest.m */; };
 		9E61AA2F29BBE66900801A83 /* FLTGoogleMobileAdsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E61AA2129BBE66900801A83 /* FLTGoogleMobileAdsTest.m */; };
 		9E61AA3029BBE66900801A83 /* FLTBannerAdTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E61AA2229BBE66900801A83 /* FLTBannerAdTest.m */; };
 		9E61AA3129BBE66900801A83 /* FLTRewardedInterstitialAdTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E61AA2329BBE66900801A83 /* FLTRewardedInterstitialAdTest.m */; };
@@ -88,6 +89,7 @@
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9E61AA1629BBE51900801A83 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9E61AA1F29BBE58400801A83 /* FLTAdRequestTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLTAdRequestTest.m; sourceTree = "<group>"; };
+		9E61AA3E29BBE66900801A83 /* FLTAppStateNotifierTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLTAppStateNotifierTest.m; sourceTree = "<group>"; };
 		9E61AA2129BBE66900801A83 /* FLTGoogleMobileAdsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLTGoogleMobileAdsTest.m; sourceTree = "<group>"; };
 		9E61AA2229BBE66900801A83 /* FLTBannerAdTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLTBannerAdTest.m; sourceTree = "<group>"; };
 		9E61AA2329BBE66900801A83 /* FLTRewardedInterstitialAdTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLTRewardedInterstitialAdTest.m; sourceTree = "<group>"; };
@@ -244,6 +246,7 @@
 				9E61AA2B29BBE66900801A83 /* FLTRewardedAdTest.m */,
 				9E61AA2329BBE66900801A83 /* FLTRewardedInterstitialAdTest.m */,
 				9E61AA1F29BBE58400801A83 /* FLTAdRequestTest.m */,
+				9E61AA3E29BBE66900801A83 /* FLTAppStateNotifierTest.m */,
 			);
 			path = RunnerTests;
 			sourceTree = "<group>";
@@ -509,6 +512,7 @@
 				9E61AA6129BBE8FD00801A83 /* FLTNativeTemplateFontStyleTest.m in Sources */,
 				9E61AA3629BBE66900801A83 /* FLTNativeAdTest.m in Sources */,
 				9E61AA2029BBE58400801A83 /* FLTAdRequestTest.m in Sources */,
+				9E61AA3D29BBE66900801A83 /* FLTAppStateNotifierTest.m in Sources */,
 				9E61AA3A29BBE66900801A83 /* FLTGAMBannerAdTest.m in Sources */,
 				9E61AA3029BBE66900801A83 /* FLTBannerAdTest.m in Sources */,
 				9E61AA3129BBE66900801A83 /* FLTRewardedInterstitialAdTest.m in Sources */,

--- a/packages/google_mobile_ads/example/ios/RunnerTests/FLTAppStateNotifierTest.m
+++ b/packages/google_mobile_ads/example/ios/RunnerTests/FLTAppStateNotifierTest.m
@@ -1,0 +1,136 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+#import "google_mobile_ads/FLTAppStateNotifier.h"
+
+@interface FLTAppStateNotifier ()
+- (void)handleWillEnterForeground;
+- (void)handleDidEnterBackground;
+- (void)addAppStateObservers;
+- (void)removeAppStateObservers;
+- (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result;
+@end
+
+@interface FLTAppStateNotifierTest : XCTestCase
+@end
+
+@implementation FLTAppStateNotifierTest {
+  NSObject<FlutterBinaryMessenger> *_mockMessenger;
+  FLTAppStateNotifier *_appStateNotifier;
+}
+
+- (void)setUp {
+  [super setUp];
+  _mockMessenger = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
+  _appStateNotifier = [[FLTAppStateNotifier alloc] initWithBinaryMessenger:_mockMessenger];
+}
+
+- (void)tearDown {
+  [_appStateNotifier removeAppStateObservers];
+  [super tearDown];
+}
+
+- (void)testHandleDidEnterBackground_whenEventsIsNil_doesNotCrash {
+  XCTAssertNoThrow([_appStateNotifier handleDidEnterBackground]);
+}
+
+- (void)testHandleWillEnterForeground_whenEventsIsNil_doesNotCrash {
+  [_appStateNotifier handleDidEnterBackground];
+  XCTAssertNoThrow([_appStateNotifier handleWillEnterForeground]);
+}
+
+- (void)testHandleDidEnterBackground_whenEventsIsPresent_sendsBackgroundEvent {
+  NSMutableArray *receivedEvents = [NSMutableArray array];
+  FlutterEventSink eventSink = ^(id event) {
+    [receivedEvents addObject:event];
+  };
+
+  [_appStateNotifier onListenWithArguments:nil eventSink:eventSink];
+  [_appStateNotifier handleDidEnterBackground];
+
+  XCTAssertEqual(receivedEvents.count, 1);
+  XCTAssertEqualObjects(receivedEvents.firstObject, @"background");
+}
+
+- (void)testHandleWillEnterForeground_whenEventsIsPresent_sendsForegroundEvent {
+  NSMutableArray *receivedEvents = [NSMutableArray array];
+  FlutterEventSink eventSink = ^(id event) {
+    [receivedEvents addObject:event];
+  };
+
+  [_appStateNotifier onListenWithArguments:nil eventSink:eventSink];
+  [_appStateNotifier handleDidEnterBackground];
+  [_appStateNotifier handleWillEnterForeground];
+
+  XCTAssertEqual(receivedEvents.count, 2);
+  XCTAssertEqualObjects(receivedEvents[0], @"background");
+  XCTAssertEqualObjects(receivedEvents[1], @"foreground");
+}
+
+- (void)testOnCancel_clearsEventSink {
+  NSMutableArray *receivedEvents = [NSMutableArray array];
+  FlutterEventSink eventSink = ^(id event) {
+    [receivedEvents addObject:event];
+  };
+
+  [_appStateNotifier onListenWithArguments:nil eventSink:eventSink];
+  [_appStateNotifier onCancelWithArguments:nil];
+
+  // Triggering background after cancel should not crash and not send events to sink
+  XCTAssertNoThrow([_appStateNotifier handleDidEnterBackground]);
+  XCTAssertEqual(receivedEvents.count, 0);
+}
+
+- (void)testMethodCall_startAndStop {
+  __block BOOL startResultCalled = NO;
+  FlutterMethodCall *startCall = [FlutterMethodCall methodCallWithMethodName:@"start" arguments:nil];
+  [_appStateNotifier handleMethodCall:startCall result:^(id result) {
+    startResultCalled = YES;
+    XCTAssertNil(result);
+  }];
+  XCTAssertTrue(startResultCalled);
+
+  __block BOOL stopResultCalled = NO;
+  FlutterMethodCall *stopCall = [FlutterMethodCall methodCallWithMethodName:@"stop" arguments:nil];
+  [_appStateNotifier handleMethodCall:stopCall result:^(id result) {
+    stopResultCalled = YES;
+    XCTAssertNil(result);
+  }];
+  XCTAssertTrue(stopResultCalled);
+}
+
+- (void)testNotificationObservers_receiveApplicationEvents {
+  NSMutableArray *receivedEvents = [NSMutableArray array];
+  FlutterEventSink eventSink = ^(id event) {
+    [receivedEvents addObject:event];
+  };
+
+  [_appStateNotifier onListenWithArguments:nil eventSink:eventSink];
+  [_appStateNotifier addAppStateObservers];
+
+  [NSNotificationCenter.defaultCenter postNotificationName:UIApplicationDidEnterBackgroundNotification
+                                                    object:nil];
+  XCTAssertEqual(receivedEvents.count, 1);
+  XCTAssertEqualObjects(receivedEvents.firstObject, @"background");
+
+  [NSNotificationCenter.defaultCenter postNotificationName:UIApplicationWillEnterForegroundNotification
+                                                    object:nil];
+  XCTAssertEqual(receivedEvents.count, 2);
+  XCTAssertEqualObjects(receivedEvents[1], @"foreground");
+}
+
+@end

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTAppStateNotifier.m
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTAppStateNotifier.m
@@ -116,7 +116,9 @@
     return;
   }
   _applicationInBackground = NO;
-  _events(@"foreground");
+  if (_events) {
+    _events(@"foreground");
+  }
 }
 
 - (void)handleDidEnterBackground {
@@ -124,7 +126,9 @@
     return;
   }
   _applicationInBackground = YES;
-  _events(@"background");
+  if (_events) {
+    _events(@"background");
+  }
 }
 
 - (FlutterError *_Nullable)onCancelWithArguments:(id _Nullable)arguments {


### PR DESCRIPTION
## Description

This PR fixes a fatal crash (EXC_BAD_ACCESS / SIGSEGV) occurring in production when the app transitions between foreground and background states without an active FlutterEventSink listener attached.

## Related Issues

* Resolves https://github.com/googleads/googleads-mobile-flutter/issues/1482

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
