### PR TITLE
Adds Empty Error View from Release builds on Android

### DIFF
--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsViewFactory.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsViewFactory.java
@@ -49,6 +49,22 @@ final class GoogleMobileAdsViewFactory extends PlatformViewFactory {
     public void dispose() {}
   }
 
+  private static class EmptyPlatformView implements PlatformView {
+    private final View view;
+
+    private EmptyPlatformView(Context context) {
+      view = new View(context);
+    }
+
+    @Override
+    public View getView() {
+      return view;
+    }
+
+    @Override
+    public void dispose() {}
+  }
+
   public GoogleMobileAdsViewFactory(@NonNull AdInstanceManager manager) {
     super(StandardMessageCodec.INSTANCE);
     this.manager = manager;
@@ -83,17 +99,7 @@ final class GoogleMobileAdsViewFactory extends PlatformViewFactory {
       return new ErrorTextView(context, message);
     } else {
       Log.e(GoogleMobileAdsViewFactory.class.getSimpleName(), message);
-      return new PlatformView() {
-        @Override
-        public View getView() {
-          return new View(context);
-        }
-
-        @Override
-        public void dispose() {
-          // Do nothing.
-        }
-      };
+      return new EmptyPlatformView(context);
     }
   }
 }

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsViewFactoryTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/GoogleMobileAdsViewFactoryTest.java
@@ -1,0 +1,95 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.flutter.plugins.googlemobileads;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
+import android.view.View;
+import androidx.test.core.app.ApplicationProvider;
+import io.flutter.plugin.platform.PlatformView;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/** Tests for {@link GoogleMobileAdsViewFactory}. */
+@RunWith(RobolectricTestRunner.class)
+public class GoogleMobileAdsViewFactoryTest {
+
+  private Context context;
+  private AdInstanceManager mockManager;
+  private GoogleMobileAdsViewFactory factory;
+
+  @Before
+  public void setup() {
+    context = ApplicationProvider.getApplicationContext();
+    mockManager = mock(AdInstanceManager.class);
+    factory = new GoogleMobileAdsViewFactory(mockManager);
+  }
+
+  @Test
+  public void create_withNullArgs_returnsConsistentView() {
+    PlatformView platformView = factory.create(context, 1, null);
+    assertNotNull(platformView);
+
+    View view1 = platformView.getView();
+    View view2 = platformView.getView();
+    assertNotNull(view1);
+    assertSame(view1, view2);
+  }
+
+  @Test
+  public void create_withUnknownAdId_returnsConsistentView() {
+    when(mockManager.adForId(999)).thenReturn(null);
+
+    PlatformView platformView = factory.create(context, 1, 999);
+    assertNotNull(platformView);
+
+    View view1 = platformView.getView();
+    View view2 = platformView.getView();
+    assertNotNull(view1);
+    assertSame(view1, view2);
+  }
+
+  @Test
+  public void create_withAdHavingNullPlatformView_returnsConsistentView() {
+    FlutterAd mockAd = mock(FlutterAd.class);
+    when(mockAd.getPlatformView()).thenReturn(null);
+    when(mockManager.adForId(123)).thenReturn(mockAd);
+
+    PlatformView platformView = factory.create(context, 1, 123);
+    assertNotNull(platformView);
+
+    View view1 = platformView.getView();
+    View view2 = platformView.getView();
+    assertNotNull(view1);
+    assertSame(view1, view2);
+  }
+
+  @Test
+  public void create_withValidAd_returnsAdPlatformView() {
+    FlutterAd mockAd = mock(FlutterAd.class);
+    PlatformView mockPlatformView = mock(PlatformView.class);
+    when(mockAd.getPlatformView()).thenReturn(mockPlatformView);
+    when(mockManager.adForId(123)).thenReturn(mockAd);
+
+    PlatformView result = factory.create(context, 1, 123);
+    assertSame(mockPlatformView, result);
+  }
+}


### PR DESCRIPTION
## Description

Fix Android platform view resize error when ErrorView is displayed in release mode for Android builds.

## Related Issues

* Resolves https://github.com/googleads/googleads-mobile-flutter/issues/1481

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
