### PR TITLE
Fixes Large Anchored Banner Size

### DIFF
--- a/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdSize.java
+++ b/packages/google_mobile_ads/android/src/adsNextGenSdk/java/io/flutter/plugins/googlemobileads/FlutterAdSize.java
@@ -73,6 +73,7 @@ class FlutterAdSize {
 
   static class AnchoredAdaptiveBannerAdSize extends FlutterAdSize {
     final String orientation;
+    final boolean isLarge;
 
     @NonNull
     private static AdSize getAdSize(
@@ -109,6 +110,7 @@ class FlutterAdSize {
         boolean isLarge) {
       super(getAdSize(context, factory, orientation, width, isLarge));
       this.orientation = orientation;
+      this.isLarge = isLarge;
     }
   }
 

--- a/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
+++ b/packages/google_mobile_ads/android/src/main/java/io/flutter/plugins/googlemobileads/AdMessageCodec.java
@@ -278,8 +278,13 @@ class AdMessageCodec extends StandardMessageCodec {
       case VALUE_ANCHORED_ADAPTIVE_BANNER_AD_SIZE:
         final String orientation = (String) readValueOfType(buffer.get(), buffer);
         final Integer width = (Integer) readValueOfType(buffer.get(), buffer);
+        final Boolean isLarge = booleanValueOf(readValueOfType(buffer.get(), buffer));
         return new FlutterAdSize.AnchoredAdaptiveBannerAdSize(
-            context, adSizeFactory, orientation, width, /* isLarge = */ false);
+            context,
+            adSizeFactory,
+            orientation,
+            width,
+            isLarge != null ? isLarge : false);
       case VALUE_SMART_BANNER_AD_SIZE:
         return new FlutterAdSize.SmartBannerAdSize();
       case VALUE_AD_SIZE:
@@ -463,6 +468,7 @@ class AdMessageCodec extends StandardMessageCodec {
           (FlutterAdSize.AnchoredAdaptiveBannerAdSize) value;
       writeValue(stream, size.orientation);
       writeValue(stream, size.width);
+      writeValue(stream, size.isLarge);
     } else if (value instanceof FlutterAdSize.SmartBannerAdSize) {
       stream.write(VALUE_SMART_BANNER_AD_SIZE);
     } else if (value instanceof FlutterAdSize.FluidAdSize) {

--- a/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdSize.java
+++ b/packages/google_mobile_ads/android/src/playServices/java/io/flutter/plugins/googlemobileads/FlutterAdSize.java
@@ -73,6 +73,7 @@ class FlutterAdSize {
 
   static class AnchoredAdaptiveBannerAdSize extends FlutterAdSize {
     final String orientation;
+    final boolean isLarge;
 
     @NonNull
     private static AdSize getAdSize(
@@ -109,6 +110,7 @@ class FlutterAdSize {
         boolean isLarge) {
       super(getAdSize(context, factory, orientation, width, isLarge));
       this.orientation = orientation;
+      this.isLarge = isLarge;
     }
   }
 

--- a/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
+++ b/packages/google_mobile_ads/android/src/test/java/io/flutter/plugins/googlemobileads/AdMessageCodecTest.java
@@ -175,6 +175,7 @@ public class AdMessageCodecTest {
     final AnchoredAdaptiveBannerAdSize portraitResult =
         (AnchoredAdaptiveBannerAdSize) codec.decodeMessage((ByteBuffer) portraitData.position(0));
     assertEquals(portraitResult.size, mockAdSize);
+    assertEquals(portraitResult.isLarge, false);
 
     final AnchoredAdaptiveBannerAdSize landscapeAnchoredAdaptiveAdSize =
         new AnchoredAdaptiveBannerAdSize(mock(Context.class), mockAdSizeFactory, "landscape", 34, false);
@@ -183,6 +184,7 @@ public class AdMessageCodecTest {
     final AnchoredAdaptiveBannerAdSize landscapeResult =
         (AnchoredAdaptiveBannerAdSize) codec.decodeMessage((ByteBuffer) landscapeData.position(0));
     assertEquals(landscapeResult.size, mockAdSize);
+    assertEquals(landscapeResult.isLarge, false);
 
     final AnchoredAdaptiveBannerAdSize anchoredAdaptiveAdSize =
         new AnchoredAdaptiveBannerAdSize(mock(Context.class), mockAdSizeFactory, null, 45, false);
@@ -191,6 +193,50 @@ public class AdMessageCodecTest {
     final AnchoredAdaptiveBannerAdSize result =
         (AnchoredAdaptiveBannerAdSize) codec.decodeMessage((ByteBuffer) data.position(0));
     assertEquals(result.size, mockAdSize);
+    assertEquals(result.isLarge, false);
+  }
+
+  @Test
+  public void encodeLargeAnchoredAdaptiveBannerAdSize() {
+    AdSize mockAdSize = mock(AdSize.class);
+    doReturn(mockAdSize)
+        .when(mockAdSizeFactory)
+        .getLargePortraitAnchoredAdaptiveBannerAdSize(any(Context.class), anyInt());
+
+    doReturn(mockAdSize)
+        .when(mockAdSizeFactory)
+        .getLargeLandscapeAnchoredAdaptiveBannerAdSize(any(Context.class), anyInt());
+
+    doReturn(mockAdSize)
+        .when(mockAdSizeFactory)
+        .getLargeAnchoredAdaptiveBannerAdSize(any(Context.class), anyInt());
+
+    final AnchoredAdaptiveBannerAdSize portraitAnchoredAdaptiveAdSize =
+        new AnchoredAdaptiveBannerAdSize(mock(Context.class), mockAdSizeFactory, "portrait", 23, true);
+    final ByteBuffer portraitData = codec.encodeMessage(portraitAnchoredAdaptiveAdSize);
+
+    final AnchoredAdaptiveBannerAdSize portraitResult =
+        (AnchoredAdaptiveBannerAdSize) codec.decodeMessage((ByteBuffer) portraitData.position(0));
+    assertEquals(portraitResult.size, mockAdSize);
+    assertEquals(portraitResult.isLarge, true);
+
+    final AnchoredAdaptiveBannerAdSize landscapeAnchoredAdaptiveAdSize =
+        new AnchoredAdaptiveBannerAdSize(mock(Context.class), mockAdSizeFactory, "landscape", 34, true);
+    final ByteBuffer landscapeData = codec.encodeMessage(landscapeAnchoredAdaptiveAdSize);
+
+    final AnchoredAdaptiveBannerAdSize landscapeResult =
+        (AnchoredAdaptiveBannerAdSize) codec.decodeMessage((ByteBuffer) landscapeData.position(0));
+    assertEquals(landscapeResult.size, mockAdSize);
+    assertEquals(landscapeResult.isLarge, true);
+
+    final AnchoredAdaptiveBannerAdSize anchoredAdaptiveAdSize =
+        new AnchoredAdaptiveBannerAdSize(mock(Context.class), mockAdSizeFactory, null, 45, true);
+    final ByteBuffer data = codec.encodeMessage(anchoredAdaptiveAdSize);
+
+    final AnchoredAdaptiveBannerAdSize result =
+        (AnchoredAdaptiveBannerAdSize) codec.decodeMessage((ByteBuffer) data.position(0));
+    assertEquals(result.size, mockAdSize);
+    assertEquals(result.isLarge, true);
   }
 
   @Test

--- a/packages/google_mobile_ads/example/ios/RunnerTests/FLTGoogleMobileAdsReaderWriterTest.m
+++ b/packages/google_mobile_ads/example/ios/RunnerTests/FLTGoogleMobileAdsReaderWriterTest.m
@@ -236,6 +236,67 @@
   FLTAnchoredAdaptiveBannerSize *decodedSize =
       [_messageCodec decode:encodedMessage];
   XCTAssertEqual(decodedSize.size.size.width, testAdSize.size.width);
+  XCTAssertFalse(decodedSize.isLarge);
+}
+
+- (void)testEncodeDecodeAnchoredAdaptiveBannerAdSize_large_portraitOrientation {
+  GADAdSize testAdSize = GADAdSizeFromCGSize(CGSizeMake(23, 34));
+
+  FLTAdSizeFactory *factory = OCMClassMock([FLTAdSizeFactory class]);
+  OCMStub([factory largePortraitAnchoredAdaptiveBannerAdSizeWithWidth:@(23)])
+      .andReturn(testAdSize);
+
+  FLTAnchoredAdaptiveBannerSize *size =
+      [[FLTAnchoredAdaptiveBannerSize alloc] initWithFactory:factory
+                                                 orientation:@"portrait"
+                                                       width:@(23)
+                                                     isLarge:true];
+  NSData *encodedMessage = [_messageCodec encode:size];
+
+  FLTAnchoredAdaptiveBannerSize *decodedSize =
+      [_messageCodec decode:encodedMessage];
+  XCTAssertEqual(decodedSize.size.size.width, testAdSize.size.width);
+  XCTAssertTrue(decodedSize.isLarge);
+}
+
+- (void)testEncodeDecodeAnchoredAdaptiveBannerAdSize_large_landscapeOrientation {
+  GADAdSize testAdSize = GADAdSizeFromCGSize(CGSizeMake(34, 45));
+
+  FLTAdSizeFactory *factory = OCMClassMock([FLTAdSizeFactory class]);
+  OCMStub([factory largeLandscapeAnchoredAdaptiveBannerAdSizeWithWidth:@(34)])
+      .andReturn(testAdSize);
+
+  FLTAnchoredAdaptiveBannerSize *size =
+      [[FLTAnchoredAdaptiveBannerSize alloc] initWithFactory:factory
+                                                 orientation:@"landscape"
+                                                       width:@(34)
+                                                     isLarge:true];
+  NSData *encodedMessage = [_messageCodec encode:size];
+
+  FLTAnchoredAdaptiveBannerSize *decodedSize =
+      [_messageCodec decode:encodedMessage];
+  XCTAssertEqual(decodedSize.size.size.width, testAdSize.size.width);
+  XCTAssertTrue(decodedSize.isLarge);
+}
+
+- (void)testEncodeDecodeAnchoredAdaptiveBannerAdSize_large_currentOrientation {
+  GADAdSize testAdSize = GADAdSizeFromCGSize(CGSizeMake(45, 56));
+
+  FLTAdSizeFactory *factory = OCMClassMock([FLTAdSizeFactory class]);
+  OCMStub([factory largeAnchoredAdaptiveBannerAdSizeWithWidth:@(45)])
+      .andReturn(testAdSize);
+
+  FLTAnchoredAdaptiveBannerSize *size =
+      [[FLTAnchoredAdaptiveBannerSize alloc] initWithFactory:factory
+                                                 orientation:NULL
+                                                       width:@(45)
+                                                     isLarge:true];
+  NSData *encodedMessage = [_messageCodec encode:size];
+
+  FLTAnchoredAdaptiveBannerSize *decodedSize =
+      [_messageCodec decode:encodedMessage];
+  XCTAssertEqual(decodedSize.size.size.width, testAdSize.size.width);
+  XCTAssertTrue(decodedSize.isLarge);
 }
 
 - (void)testEncodeDecodeSmartBannerAdSize {

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTAd_Internal.m
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTAd_Internal.m
@@ -124,6 +124,7 @@
   self = [self initWithAdSize:size];
   if (self) {
     _orientation = orientation;
+    _isLarge = isLarge;
   }
   return self;
 }

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTGoogleMobileAdsReaderWriter_Internal.m
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/FLTGoogleMobileAdsReaderWriter_Internal.m
@@ -247,10 +247,11 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
   case FLTAdmobFieldAnchoredAdaptiveBannerAdSize: {
     NSString *orientation = [self readValueOfType:[self readByte]];
     NSNumber *width = [self readValueOfType:[self readByte]];
+    NSNumber *isLarge = [self readValueOfType:[self readByte]];
     return [[FLTAnchoredAdaptiveBannerSize alloc] initWithFactory:_adSizeFactory
                                                       orientation:orientation
                                                             width:width
-                                                          isLarge:false];
+                                                          isLarge:[isLarge boolValue]];
   }
   case FLTAdmobFieldSmartBannerAdSize:
     return [[FLTSmartBannerSize alloc]
@@ -366,6 +367,7 @@ typedef NS_ENUM(NSInteger, FLTAdMobField) {
         (FLTAnchoredAdaptiveBannerSize *)value;
     [self writeValue:size.orientation];
     [self writeValue:size.width];
+    [self writeValue:@(size.isLarge)];
   } else if ([value isKindOfClass:[FLTSmartBannerSize class]]) {
     [self writeByte:FLTAdmobFieldSmartBannerAdSize];
     FLTSmartBannerSize *size = (FLTSmartBannerSize *)value;

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/include/google_mobile_ads/FLTAd_Internal.h
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/include/google_mobile_ads/FLTAd_Internal.h
@@ -60,7 +60,8 @@
 @end
 
 @interface FLTAnchoredAdaptiveBannerSize : FLTAdSize
-@property(readonly) NSString *_Nonnull orientation;
+@property(readonly) NSString *_Nullable orientation;
+@property(readonly) BOOL isLarge;
 - (instancetype _Nonnull)initWithFactory:(FLTAdSizeFactory *_Nonnull)factory
                              orientation:(NSString *_Nullable)orientation
                                    width:(NSNumber *_Nonnull)width

--- a/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/include/google_mobile_ads/FLTAd_Internal.h
+++ b/packages/google_mobile_ads/ios/google_mobile_ads/Sources/google_mobile_ads/include/google_mobile_ads/FLTAd_Internal.h
@@ -46,6 +46,12 @@
     (NSNumber *_Nonnull)width;
 - (GADAdSize)currentOrientationAnchoredAdaptiveBannerAdSizeWithWidth:
     (NSNumber *_Nonnull)width;
+- (GADAdSize)largePortraitAnchoredAdaptiveBannerAdSizeWithWidth:
+    (NSNumber *_Nonnull)width;
+- (GADAdSize)largeLandscapeAnchoredAdaptiveBannerAdSizeWithWidth:
+    (NSNumber *_Nonnull)width;
+- (GADAdSize)largeAnchoredAdaptiveBannerAdSizeWithWidth:
+    (NSNumber *_Nonnull)width;
 - (GADAdSize)currentOrientationInlineAdaptiveBannerSizeWithWidth:
     (NSNumber *_Nonnull)width;
 - (GADAdSize)portraitOrientationInlineAdaptiveBannerSizeWithWidth:

--- a/packages/google_mobile_ads/lib/src/ad_containers.dart
+++ b/packages/google_mobile_ads/lib/src/ad_containers.dart
@@ -341,10 +341,14 @@ class AnchoredAdaptiveBannerAdSize extends AdSize {
     this.orientation, {
     required int width,
     required int height,
+    this.isLarge = false,
   }) : super(width: width, height: height);
 
   /// Orientation of the device used by the SDK to automatically find the correct height.
   final Orientation? orientation;
+
+  /// Whether this is a large anchored adaptive banner size.
+  final bool isLarge;
 }
 
 /// Ad units that render screen-width banner ads on any screen size across different devices in either [Orientation].
@@ -455,6 +459,7 @@ class AdSize {
       orientation,
       width: width,
       height: height.truncate(),
+      isLarge: false,
     );
   }
 
@@ -480,6 +485,7 @@ class AdSize {
       orientation,
       width: width,
       height: height.truncate(),
+      isLarge: true,
     );
   }
 
@@ -502,6 +508,7 @@ class AdSize {
       null,
       width: width,
       height: height.truncate(),
+      isLarge: false,
     );
   }
 
@@ -523,6 +530,7 @@ class AdSize {
       null,
       width: width,
       height: height.truncate(),
+      isLarge: true,
     );
   }
 

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -685,15 +685,13 @@ class AdInstanceManager {
 
     final int adId = _nextAdId++;
     _loadedAds[adId] = ad;
-    return channel.invokeMethod<void>(
-      'loadAdManagerBannerAd',
-      <dynamic, dynamic>{
-        'adId': adId,
-        'sizes': ad.sizes,
-        'adUnitId': ad.adUnitId,
-        'request': ad.request,
-      },
-    );
+    return channel
+        .invokeMethod<void>('loadAdManagerBannerAd', <dynamic, dynamic>{
+          'adId': adId,
+          'sizes': ad.sizes,
+          'adUnitId': ad.adUnitId,
+          'request': ad.request,
+        });
   }
 
   /// Starts loading the ad if not previously loaded.

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -1108,6 +1108,8 @@ class AdMessageCodec extends StandardMessageCodec {
           buffer,
         );
         final num width = readValueOfType(buffer.getUint8(), buffer);
+        final bool isLarge =
+            readValueOfType(buffer.getUint8(), buffer) ?? false;
         Orientation? orientation;
         if (orientationStr != null) {
           orientation = Orientation.values.firstWhere(
@@ -1118,6 +1120,7 @@ class AdMessageCodec extends StandardMessageCodec {
           orientation,
           width: width.truncate(),
           height: -1, // Unused value
+          isLarge: isLarge,
         );
       case _valueSmartBannerAdSize:
         final String orientationStr = readValueOfType(
@@ -1410,6 +1413,7 @@ class AdMessageCodec extends StandardMessageCodec {
       }
       writeValue(buffer, orientationValue);
       writeValue(buffer, value.width);
+      writeValue(buffer, value.isLarge);
     } else if (value is SmartBannerAdSize) {
       buffer.putUint8(_valueSmartBannerAdSize);
       if (defaultTargetPlatform == TargetPlatform.iOS) {

--- a/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
+++ b/packages/google_mobile_ads/lib/src/ad_instance_manager.dart
@@ -685,13 +685,15 @@ class AdInstanceManager {
 
     final int adId = _nextAdId++;
     _loadedAds[adId] = ad;
-    return channel
-        .invokeMethod<void>('loadAdManagerBannerAd', <dynamic, dynamic>{
-          'adId': adId,
-          'sizes': ad.sizes,
-          'adUnitId': ad.adUnitId,
-          'request': ad.request,
-        });
+    return channel.invokeMethod<void>(
+      'loadAdManagerBannerAd',
+      <dynamic, dynamic>{
+        'adId': adId,
+        'sizes': ad.sizes,
+        'adUnitId': ad.adUnitId,
+        'request': ad.request,
+      },
+    );
   }
 
   /// Starts loading the ad if not previously loaded.

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -1681,12 +1681,14 @@ void main() {
       expect(resultPortrait.orientation, Orientation.portrait);
       expect(resultPortrait.width, 23);
       expect(resultPortrait.height, -1);
+      expect(resultPortrait.isLarge, false);
 
       final ByteData byteDataLandscape = codec.encodeMessage(
         AnchoredAdaptiveBannerAdSize(
           Orientation.landscape,
           width: 34,
           height: 23,
+          isLarge: true,
         ),
       )!;
 
@@ -1696,15 +1698,17 @@ void main() {
       expect(resultLandscape.orientation, Orientation.landscape);
       expect(resultLandscape.width, 34);
       expect(resultLandscape.height, -1);
+      expect(resultLandscape.isLarge, true);
 
       final ByteData byteData = codec.encodeMessage(
-        AnchoredAdaptiveBannerAdSize(null, width: 45, height: 34),
+        AnchoredAdaptiveBannerAdSize(null, width: 45, height: 34, isLarge: true),
       )!;
 
       final AnchoredAdaptiveBannerAdSize result = codec.decodeMessage(byteData);
       expect(result.orientation, null);
       expect(result.width, 45);
       expect(result.height, -1);
+      expect(result.isLarge, true);
     });
 
     test('encode/decode $SmartBannerAdSize', () async {

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -1701,7 +1701,12 @@ void main() {
       expect(resultLandscape.isLarge, true);
 
       final ByteData byteData = codec.encodeMessage(
-        AnchoredAdaptiveBannerAdSize(null, width: 45, height: 34, isLarge: true),
+        AnchoredAdaptiveBannerAdSize(
+          null,
+          width: 45,
+          height: 34,
+          isLarge: true,
+        ),
       )!;
 
       final AnchoredAdaptiveBannerAdSize result = codec.decodeMessage(byteData);

--- a/packages/google_mobile_ads/test/mobile_ads_test.dart
+++ b/packages/google_mobile_ads/test/mobile_ads_test.dart
@@ -83,6 +83,7 @@ void main() {
                     testDeviceIds: <String>['test-device-id'],
                   );
                 case 'AdSize#getAnchoredAdaptiveBannerAdSize':
+                case 'AdSize#getLargeAnchoredAdaptiveBannerAdSize':
                   return null;
                 default:
                   assert(false);
@@ -451,6 +452,53 @@ void main() {
         ),
         isMethodCall(
           'AdSize#getAnchoredAdaptiveBannerAdSize',
+          arguments: {'width': 45},
+        ),
+      ]);
+    });
+
+    test('$AdSize.getLargeAnchoredAdaptiveBannerAdSize', () async {
+      await AdSize.getLargeAnchoredAdaptiveBannerAdSizeWithOrientation(
+        Orientation.portrait,
+        23,
+      );
+
+      expect(log, <Matcher>[
+        isMethodCall(
+          'AdSize#getLargeAnchoredAdaptiveBannerAdSize',
+          arguments: {'orientation': 'portrait', 'width': 23},
+        ),
+      ]);
+
+      await AdSize.getLargeAnchoredAdaptiveBannerAdSizeWithOrientation(
+        Orientation.landscape,
+        34,
+      );
+
+      expect(log, <Matcher>[
+        isMethodCall(
+          'AdSize#getLargeAnchoredAdaptiveBannerAdSize',
+          arguments: {'orientation': 'portrait', 'width': 23},
+        ),
+        isMethodCall(
+          'AdSize#getLargeAnchoredAdaptiveBannerAdSize',
+          arguments: {'orientation': 'landscape', 'width': 34},
+        ),
+      ]);
+
+      await AdSize.getLargeAnchoredAdaptiveBannerAdSize(45);
+
+      expect(log, <Matcher>[
+        isMethodCall(
+          'AdSize#getLargeAnchoredAdaptiveBannerAdSize',
+          arguments: {'orientation': 'portrait', 'width': 23},
+        ),
+        isMethodCall(
+          'AdSize#getLargeAnchoredAdaptiveBannerAdSize',
+          arguments: {'orientation': 'landscape', 'width': 34},
+        ),
+        isMethodCall(
+          'AdSize#getLargeAnchoredAdaptiveBannerAdSize',
           arguments: {'width': 45},
         ),
       ]);


### PR DESCRIPTION
## Description

Fixes an issue where requesting a Large Anchored Adaptive Banner resulted in an incorrect banner height on Android and iOS. The large banner size option is now properly preserved and passed to the underlying platform SDKs so the ad loads and renders with the expected large banner height.

## Related Issues

* Resolves https://github.com/googleads/googleads-mobile-flutter/issues/1480

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
