### PR TITLE
Fixes AdPreloader for obfuscated classes

### DIFF
--- a/packages/google_mobile_ads/lib/src/ad_preloader.dart
+++ b/packages/google_mobile_ads/lib/src/ad_preloader.dart
@@ -58,6 +58,17 @@ abstract class _AdPreloader {
   static final Map<String, PreloadableAd Function()> _preloadedAds =
       <String, PreloadableAd Function()>{};
 
+  static String _getClassName<T extends PreloadableAd>() {
+    if (T == InterstitialAd) {
+      return 'InterstitialAd';
+    } else if (T == RewardedAd) {
+      return 'RewardedAd';
+    } else if (T == AppOpenAd) {
+      return 'AppOpenAd';
+    }
+    throw ArgumentError('Unsupported PreloadableAd type: $T');
+  }
+
   static PreloadableAd? _createAd<T extends PreloadableAd>(
     PreloadConfiguration config,
   ) {
@@ -106,7 +117,7 @@ abstract class _AdPreloader {
           'adUnitId': preloadConfiguration.adUnitId,
           'bufferSize': preloadConfiguration.bufferSize,
           'request': preloadConfiguration.request,
-          'className': T.toString(),
+          'className': _getClassName<T>(),
         });
   }
 
@@ -118,7 +129,7 @@ abstract class _AdPreloader {
           'MobileAds#pollAd',
           <String, dynamic>{
             'preloadId': preloadId,
-            'className': T.toString(),
+            'className': _getClassName<T>(),
             'adId': adId,
           },
         );
@@ -142,7 +153,10 @@ abstract class _AdPreloader {
     instanceManager.unregisterPreloadCallback(preloadId);
     await instanceManager.channel.invokeMethod<void>(
       'MobileAds#destroyPreloader',
-      <String, dynamic>{'preloadId': preloadId, 'className': T.toString()},
+      <String, dynamic>{
+        'preloadId': preloadId,
+        'className': _getClassName<T>(),
+      },
     );
   }
 
@@ -154,7 +168,7 @@ abstract class _AdPreloader {
     instanceManager.clearAllPreloadCallbacks();
     await instanceManager.channel.invokeMethod<void>(
       'MobileAds#destroyAllPreloaders',
-      <String, dynamic>{'className': T.toString()},
+      <String, dynamic>{'className': _getClassName<T>()},
     );
   }
 
@@ -164,7 +178,10 @@ abstract class _AdPreloader {
   ) async {
     final bool? available = await instanceManager.channel.invokeMethod<bool>(
       'MobileAds#isPreloadedAdAvailable',
-      <String, dynamic>{'preloadId': preloadId, 'className': T.toString()},
+      <String, dynamic>{
+        'preloadId': preloadId,
+        'className': _getClassName<T>(),
+      },
     );
     return available ?? false;
   }
@@ -175,7 +192,10 @@ abstract class _AdPreloader {
   ) async {
     final int? count = await instanceManager.channel.invokeMethod<int>(
       'MobileAds#getNumAdsAvailable',
-      <String, dynamic>{'preloadId': preloadId, 'className': T.toString()},
+      <String, dynamic>{
+        'preloadId': preloadId,
+        'className': _getClassName<T>(),
+      },
     );
     return count ?? 0;
   }
@@ -186,7 +206,10 @@ abstract class _AdPreloader {
     final Map<dynamic, dynamic>? map = await instanceManager.channel
         .invokeMethod<Map<dynamic, dynamic>>(
           'MobileAds#getPreloadConfiguration',
-          <String, dynamic>{'preloadId': preloadId, 'className': T.toString()},
+          <String, dynamic>{
+            'preloadId': preloadId,
+            'className': _getClassName<T>(),
+          },
         );
     if (map == null) {
       return null;
@@ -204,7 +227,7 @@ abstract class _AdPreloader {
     final Map<dynamic, dynamic>? map = await instanceManager.channel
         .invokeMethod<Map<dynamic, dynamic>>(
           'MobileAds#getPreloadConfigurations',
-          <String, dynamic>{'className': T.toString()},
+          <String, dynamic>{'className': _getClassName<T>()},
         );
     if (map == null) {
       return <String, PreloadConfiguration>{};

--- a/packages/google_mobile_ads/test/ad_containers_test.dart
+++ b/packages/google_mobile_ads/test/ad_containers_test.dart
@@ -959,10 +959,10 @@ void main() {
             return null;
           });
 
-      final config = await InterstitialAdPreloader.getConfiguration('id-1');
-      expect(config, isNotNull);
-      expect(config!.adUnitId, 'test-ad-unit-123');
-      expect(config.bufferSize, 5);
+      final config1 = await InterstitialAdPreloader.getConfiguration('id-1');
+      expect(config1, isNotNull);
+      expect(config1!.adUnitId, 'test-ad-unit-123');
+      expect(config1.bufferSize, 5);
       expect(
         log.last,
         isMethodCall(
@@ -974,17 +974,67 @@ void main() {
         ),
       );
 
-      final configs = await RewardedAdPreloader.getConfigurations();
-      expect(configs.length, 2);
-      expect(configs['preload-id-1']!.adUnitId, 'ad-unit-1');
-      expect(configs['preload-id-1']!.bufferSize, 3);
-      expect(configs['preload-id-2']!.adUnitId, 'ad-unit-2');
-      expect(configs['preload-id-2']!.bufferSize, 4);
+      final config2 = await RewardedAdPreloader.getConfiguration('id-2');
+      expect(config2, isNotNull);
+      expect(config2!.adUnitId, 'test-ad-unit-123');
+      expect(config2.bufferSize, 5);
+      expect(
+        log.last,
+        isMethodCall(
+          'MobileAds#getPreloadConfiguration',
+          arguments: <String, dynamic>{
+            'preloadId': 'id-2',
+            'className': 'RewardedAd',
+          },
+        ),
+      );
+
+      final config3 = await AppOpenAdPreloader.getConfiguration('id-3');
+      expect(config3, isNotNull);
+      expect(config3!.adUnitId, 'test-ad-unit-123');
+      expect(config3.bufferSize, 5);
+      expect(
+        log.last,
+        isMethodCall(
+          'MobileAds#getPreloadConfiguration',
+          arguments: <String, dynamic>{
+            'preloadId': 'id-3',
+            'className': 'AppOpenAd',
+          },
+        ),
+      );
+
+      final configs1 = await InterstitialAdPreloader.getConfigurations();
+      expect(configs1.length, 2);
+      expect(
+        log.last,
+        isMethodCall(
+          'MobileAds#getPreloadConfigurations',
+          arguments: <String, dynamic>{'className': 'InterstitialAd'},
+        ),
+      );
+
+      final configs2 = await RewardedAdPreloader.getConfigurations();
+      expect(configs2.length, 2);
+      expect(configs2['preload-id-1']!.adUnitId, 'ad-unit-1');
+      expect(configs2['preload-id-1']!.bufferSize, 3);
+      expect(configs2['preload-id-2']!.adUnitId, 'ad-unit-2');
+      expect(configs2['preload-id-2']!.bufferSize, 4);
       expect(
         log.last,
         isMethodCall(
           'MobileAds#getPreloadConfigurations',
           arguments: <String, dynamic>{'className': 'RewardedAd'},
+        ),
+      );
+
+      final configs3 = await AppOpenAdPreloader.getConfigurations();
+      expect(configs3.length, 2);
+      expect(
+        log.last,
+        isMethodCall(
+          'MobileAds#getPreloadConfigurations',
+          arguments: <String, dynamic>{'className': 'AppOpenAd'},
         ),
       );
 
@@ -1143,6 +1193,48 @@ void main() {
           arguments: <String, dynamic>{'className': 'InterstitialAd'},
         ),
       );
+
+      await RewardedAdPreloader.destroy('preload-2');
+      expect(
+        log.last,
+        isMethodCall(
+          'MobileAds#destroyPreloader',
+          arguments: <String, dynamic>{
+            'preloadId': 'preload-2',
+            'className': 'RewardedAd',
+          },
+        ),
+      );
+
+      await RewardedAdPreloader.destroyAll();
+      expect(
+        log.last,
+        isMethodCall(
+          'MobileAds#destroyAllPreloaders',
+          arguments: <String, dynamic>{'className': 'RewardedAd'},
+        ),
+      );
+
+      await AppOpenAdPreloader.destroy('preload-3');
+      expect(
+        log.last,
+        isMethodCall(
+          'MobileAds#destroyPreloader',
+          arguments: <String, dynamic>{
+            'preloadId': 'preload-3',
+            'className': 'AppOpenAd',
+          },
+        ),
+      );
+
+      await AppOpenAdPreloader.destroyAll();
+      expect(
+        log.last,
+        isMethodCall(
+          'MobileAds#destroyAllPreloaders',
+          arguments: <String, dynamic>{'className': 'AppOpenAd'},
+        ),
+      );
     });
 
     test('isAdAvailable tests', () async {
@@ -1158,10 +1250,10 @@ void main() {
             return null;
           });
 
-      final available = await InterstitialAdPreloader.isAdAvailable(
+      final available1 = await InterstitialAdPreloader.isAdAvailable(
         'preload-1',
       );
-      expect(available, isTrue);
+      expect(available1, isTrue);
       expect(
         log.last,
         isMethodCall(
@@ -1169,6 +1261,32 @@ void main() {
           arguments: <String, dynamic>{
             'preloadId': 'preload-1',
             'className': 'InterstitialAd',
+          },
+        ),
+      );
+
+      final available2 = await RewardedAdPreloader.isAdAvailable('preload-2');
+      expect(available2, isTrue);
+      expect(
+        log.last,
+        isMethodCall(
+          'MobileAds#isPreloadedAdAvailable',
+          arguments: <String, dynamic>{
+            'preloadId': 'preload-2',
+            'className': 'RewardedAd',
+          },
+        ),
+      );
+
+      final available3 = await AppOpenAdPreloader.isAdAvailable('preload-3');
+      expect(available3, isTrue);
+      expect(
+        log.last,
+        isMethodCall(
+          'MobileAds#isPreloadedAdAvailable',
+          arguments: <String, dynamic>{
+            'preloadId': 'preload-3',
+            'className': 'AppOpenAd',
           },
         ),
       );


### PR DESCRIPTION
## Description

Fixes an issue where `AdPreloader` throws an error with a `Unsupported className` message in release builds with code obfuscation enabled.

## Related Issues

* Fixes https://github.com/googleads/googleads-mobile-flutter/issues/1479

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/googleads/googleads-mobile-flutter/issues
[Contributor Guide]: https://github.com/googleads/googleads-mobile-flutter/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
